### PR TITLE
More params

### DIFF
--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -12,11 +12,12 @@ curl -sO https://raw.githubusercontent.com/PRX/Infrastructure/master/codebuild/b
 ### Inputs
 
 - Codebuild ENVs:
-  - `SNS_CALLBACK` - an SNS topic for callbacks.
+  - `PRX_SNS_CALLBACK` - an SNS topic for callbacks.
   - `PRX_REPO` - the repo this is for.  Not actually used in this script, but passed back to SNS.
-  - `PRX_COMMIT` - the SHA of the commit this is for.  Not used, but passed back to SNS.
-  - `PRX_ECR_TAG` - optional param telling codebuild to push to this ECR tag after successfully testing.
-   - `PRX_ECR_REGION` - required if you set `PRX_ECR_TAG`
+  - `PRX_COMMIT` - the 7-char SHA of the commit this is for. Not used, but passed back to SNS.
+  - `PRX_GITHUB_PR` - optional github pull request number.
+  - `PRX_ECR_TAG` - optional param telling codebuild to push to this ECR tag after successfully testing. Will only be used if there is a Dockerfile present.
+  - `PRX_ECR_REGION` - required if you set `PRX_ECR_TAG`
 - Repo setup:
   - Must have a `.prxci` file in the root.  This is just a plain text file, with 1 command to run per line.  Does any setup for the tests, and runs them.
   - For docker projects, the Dockerfile must have `LABEL org.prx.app="yes"` in it.  This tells codebuild which image to push to ECR (in case your docker-compose is building multiple).
@@ -28,6 +29,7 @@ curl -sO https://raw.githubusercontent.com/PRX/Infrastructure/master/codebuild/b
   - `reason` - string message if success = false.
   - `prxRepo` - the repo you passed in.
   - `prxCommit` - the commit you passed in.
+  - `prxGithubPr` - the pull request number you passed in.
   - `prxEcrTag` - the ecr tag you passed in.
   - `prxEcrRegion` - the ecr region you passed in.
   - `buildArn` - the ARN of this codebuild run.

--- a/codebuild/bootstrap.sh
+++ b/codebuild/bootstrap.sh
@@ -12,14 +12,14 @@ if [ -z "$PRX_SNS_CALLBACK" ]; then
   exit 1
 fi
 sns_message() {
-  MSG="'{\"success\":$1,\"reason\":\"$2\""
+  MSG="{\"success\":$1,\"reason\":\"$2\""
   [ -z "$PRX_REPO" ] || MSG="$MSG,\"prxRepo\":\"$PRX_REPO\""
   [ -z "$PRX_COMMIT" ] || MSG="$MSG,\"prxCommit\":\"$PRX_COMMIT\""
   [ -z "$PRX_GITHUB_PR" ] || MSG="$MSG,\"prxGithubPr\":\"$PRX_GITHUB_PR\""
   [ -z "$PRX_ECR_TAG" ] || MSG="$MSG,\"prxEcrTag\":\"$PRX_ECR_TAG\""
   [ -z "$PRX_ECR_REGION" ] || MSG="$MSG,\"prxEcrRegion\":\"$PRX_ECR_REGION\""
   [ -z "$CODEBUILD_BUILD_ARN" ] || MSG="$MSG,\"buildArn\":\"$CODEBUILD_BUILD_ARN\""
-  MSG="$MSG}'"
+  MSG="$MSG}"
   OUT=$(aws sns publish --topic-arn "$PRX_SNS_CALLBACK" --message "$MSG")
   CODE=$?
   if [ $CODE -eq 0 ]; then

--- a/codebuild/bootstrap.sh
+++ b/codebuild/bootstrap.sh
@@ -7,19 +7,20 @@ TEST_FILE=".prxci"
 #
 
 # sns callback helpers
-if [ -z "$SNS_CALLBACK" ]; then
-  echo "You must define an \$SNS_CALLBACK"
+if [ -z "$PRX_SNS_CALLBACK" ]; then
+  echo "You must define a \$PRX_SNS_CALLBACK"
   exit 1
 fi
 sns_message() {
   MSG="'{\"success\":$1,\"reason\":\"$2\""
   [ -z "$PRX_REPO" ] || MSG="$MSG,\"prxRepo\":\"$PRX_REPO\""
   [ -z "$PRX_COMMIT" ] || MSG="$MSG,\"prxCommit\":\"$PRX_COMMIT\""
+  [ -z "$PRX_GITHUB_PR" ] || MSG="$MSG,\"prxGithubPr\":\"$PRX_GITHUB_PR\""
   [ -z "$PRX_ECR_TAG" ] || MSG="$MSG,\"prxEcrTag\":\"$PRX_ECR_TAG\""
   [ -z "$PRX_ECR_REGION" ] || MSG="$MSG,\"prxEcrRegion\":\"$PRX_ECR_REGION\""
   [ -z "$CODEBUILD_BUILD_ARN" ] || MSG="$MSG,\"buildArn\":\"$CODEBUILD_BUILD_ARN\""
   MSG="$MSG}'"
-  OUT=$(aws sns publish --topic-arn "$SNS_CALLBACK" --message "$MSG")
+  OUT=$(aws sns publish --topic-arn "$PRX_SNS_CALLBACK" --message "$MSG")
   CODE=$?
   if [ $CODE -eq 0 ]; then
     echo "Sent SNS message: $MSG"
@@ -74,7 +75,7 @@ if [ -n "$(grep docker-compose $TEST_FILE)" ] && [ -z "$(command -v docker-compo
   chmod +x /usr/local/bin/docker-compose
   echo "  successfully installed $(docker-compose -v)"
 fi
-if [ -n "$PRX_ECR_TAG" ]; then
+if [ -n "$PRX_ECR_TAG" ] && [ -f "Dockerfile" ]; then
   echo "Logging into ECR..."
   $(aws ecr get-login --region $PRX_ECR_REGION)
 fi
@@ -97,7 +98,7 @@ set -e
 #
 # optionally push to ECR
 #
-if [ -n "$PRX_ECR_TAG" ]; then
+if [ -n "$PRX_ECR_TAG" ] && [ -f "Dockerfile" ]; then
   IMAGE_ID=$(docker images --filter "label=org.prx.app" --format "{{.ID}}" | head -n 1)
   if [ -z "$IMAGE_ID" ]; then
     sns_error "Dockerfile needs an org.prx.app label"


### PR DESCRIPTION
- Add `PRX_GITHUB_PR` env
- Add `prxGithubPr` to SNS json
- Ignore `PRX_ECR_TAG` if no Dockerfile is present
- Rename `SNS_CALLBACK` -> `PRX_SNS_CALLBACK`, to be more consistent.  (All custom inputs namespaced to PRX_).