### PR TITLE
Dovetail app stack

### DIFF
--- a/stacks/certificate.yml
+++ b/stacks/certificate.yml
@@ -21,6 +21,8 @@ Resources:
           DomainName: !Sub "*.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech"
       SubjectAlternativeNames:
         - "*.prx.org"
+        - "*.prxu.org"
+        - "*.dovetail.prxu.org"
         - "*.prx.tech"
         - "*.staging.prx.tech"
         - !Sub "*.cdn.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech"

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -169,8 +169,6 @@ Resources:
         MinimumHealthyPercent: 50
       PlacementConstraints:
         Type: "distinctInstance"
-      # TODO: waaaaaaaay more in prod
-      DesiredCount: 2
       LoadBalancers:
         - ContainerName: !FindInMap [Shared, Container, name]
           ContainerPort: 8080

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -1,0 +1,219 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: dovetail.prx.org application running in Docker
+Mappings:
+  Shared:
+    Project:
+      name: dovetail.prx.org
+    Container:
+      name: dovetail-express
+Conditions:
+  CreateStagingResources: !Equals [!Ref EnvironmentType, Staging]
+  CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+Parameters:
+  # VPC ########################################################################
+  VPC:
+    Type: "AWS::EC2::VPC::Id"
+  VPCSubnet1:
+    Type: "AWS::EC2::Subnet::Id"
+  VPCSubnet2:
+    Type: "AWS::EC2::Subnet::Id"
+  VPCCertificateArn:
+    Type: String
+  # ECS Cluster ################################################################
+  ECSCluster:
+    Type: String
+  ECSServiceAutoscaleIAMRoleArn:
+    Type: String
+  ECSServiceIAMRole:
+    Type: String
+  # Misc #######################################################################
+  OpsDebugMessagesSnsTopicArn:
+    Type: String
+  OpsErrorMessagesSnsTopicArn:
+    Type: String
+  EnvironmentType:
+    Type: String
+  EnvironmentTypeAbbreviation:
+    Type: String
+  EcrRegion:
+    Type: String
+  SecretsBase:
+    Type: String
+  # Dovetail ###################################################################
+  DovetailEcrImageTag:
+    Type: String
+  DovetailSecretsVersion:
+    Type: String
+Resources:
+  DovetailSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      VpcId: !Ref VPC
+      GroupDescription: Allow web and SSH traffic to the ALB
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+      Tags:
+        - Key: Project
+          Value: Dovetail
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: Name
+          Value: !Sub Dovetail-${EnvironmentType}-LB-web_ssh
+  DovetailALB:
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Properties:
+      Scheme: internet-facing
+      SecurityGroups:
+        - !Ref DovetailSecurityGroup
+      Subnets:
+        - !Ref VPCSubnet1
+        - !Ref VPCSubnet2
+      Tags:
+        - Key: Project
+          Value: Dovetail
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: Name
+          Value: !Sub Dovetail-${EnvironmentType}
+  DovetailALBHTTPListener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      LoadBalancerArn: !Ref DovetailALB
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref DovetailALBTargetGroup
+  DovetailALBHTTPSListener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref VPCCertificateArn
+      LoadBalancerArn: !Ref DovetailALB
+      Port: 443
+      Protocol: HTTPS
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref DovetailALBTargetGroup
+  DovetailALBTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      HealthCheckPath: /ping
+      Name: !Sub dovetail-${EnvironmentTypeAbbreviation}-${VPC}
+      Port: 80
+      Protocol: HTTP
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 20
+      Tags:
+        - Key: Project
+          Value: Dovetail
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: Name
+          Value: !Sub Dovetail-${EnvironmentType}
+      VpcId: !Ref VPC
+  DovetailLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      RetentionInDays: 14
+  DovetailTaskDefinition:
+    Type: "AWS::ECS::TaskDefinition"
+    Properties:
+      ContainerDefinitions:
+        - Cpu: 256
+          Environment:
+            - Name: APP_NAME
+              Value: "dovetail"
+            - Name: APP_ENV
+              Value: !Ref EnvironmentTypeAbbreviation
+            - Name: AWS_SECRETS_BASE
+              Value: !Ref SecretsBase
+            - Name: AWS_SECRETS_VERSION
+              Value: !Ref DovetailSecretsVersion
+            - Name: AWS_DEFAULT_REGION
+              Value: !Ref AWS::Region
+          Essential: true
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/dovetail.prx.org:${DovetailEcrImageTag}
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref DovetailLogGroup
+              awslogs-region: !Ref AWS::Region
+          Memory: 600
+          Name: !FindInMap [Shared, Container, name]
+          PortMappings:
+            - HostPort: 0
+              ContainerPort: 8080
+  DovetailService:
+    Type: "AWS::ECS::Service"
+    Properties:
+      Cluster: !Ref ECSCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+      # TODO: waaaaaaaay more in prod
+      DesiredCount: 2
+      LoadBalancers:
+        - ContainerName: !FindInMap [Shared, Container, name]
+          ContainerPort: 8080
+          TargetGroupArn: !Ref DovetailALBTargetGroup
+      Role: !Ref ECSServiceIAMRole
+      TaskDefinition: !Ref DovetailTaskDefinition
+  DovetailWebRecordSetGroup:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Record sets for dualstack web traffic to a dovetail instance
+      HostedZoneName: prx.tech.
+      RecordSets:
+        - Type: A
+          Name: !Sub dovetail.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech.
+          AliasTarget:
+            Value:
+            DNSName: !Sub dualstack.${DovetailALB.DNSName}
+            HostedZoneId: !GetAtt DovetailALB.CanonicalHostedZoneID
+  DovetailALBTargetGroup500Alarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Condition: CreateProductionResources
+    Properties:
+      ActionsEnabled: true
+      AlarmName: Dovetail ALB Target Group HTTP 5XXs
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      InsufficientDataActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      OKActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription: >
+        5XX server errors originating from the dovetail target group exceeded 0
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: "1"
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Period: "60"
+      Statistic: Sum
+      Threshold: "0"
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt DovetailALB.LoadBalancerFullName
+Outputs:
+  HostedZoneDNSName:
+    Description: Convenience domain name for the ALB in a hosted zone
+    Value: !Sub |
+      dovetail.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech.

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -167,6 +167,8 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
+      PlacementConstraints:
+        Type: "distinctInstance"
       # TODO: waaaaaaaay more in prod
       DesiredCount: 2
       LoadBalancers:

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -38,6 +38,10 @@ Parameters:
     Type: String
   CrierSecretsVersion:
     Type: String
+  DovetailEcrImageTag:
+    Type: String
+  DovetailSecretsVersion:
+    Type: String
   FeederEcrImageTag:
     Type: String
   FeederSecretsVersion:
@@ -439,6 +443,39 @@ Resources:
         HealthCheckPath: "/api/v1"
       TemplateURL: !Join ["", ["http://s3", !If [IsUsEast1, "", "-"], !If [IsUsEast1, "", !Ref "AWS::Region"], ".amazonaws.com/", "Fn::ImportValue": !Sub "${InfrastructureStorageStackName}-InfrastructureSourceBucket", "/", !Ref InfrastructureGitCommit, "/stacks/web-application.yml"]]
       TimeoutInMinutes: "5"
+################################################################################
+#### DOVETAIL ##################################################################
+################################################################################
+DovetailStack:
+  DependsOn: ECSClusterStack
+  Properties:
+    NotificationARNs:
+      - Fn::ImportValue:
+          !Sub "${NotificationsStackName}-OpsDebugMessagesSnsTopicArn"
+    Parameters:
+      VPC: !GetAtt VPCStack.Outputs.VPC
+      VPCSubnet1: !GetAtt VPCStack.Outputs.Subnet1
+      VPCSubnet2: !GetAtt VPCStack.Outputs.Subnet2
+      VPCCertificateArn: !GetAtt CertificateStack.Outputs.WildcardCertificateArn
+      ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
+      ECSServiceAutoscaleIAMRoleArn: !GetAtt ECSClusterStack.Outputs.ECSServiceAutoscaleIAMRoleArn
+      ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
+      OpsDebugMessagesSnsTopicArn:
+        Fn::ImportValue:
+          !Sub "${NotificationsStackName}-OpsDebugMessagesSnsTopicArn"
+      OpsErrorMessagesSnsTopicArn:
+        Fn::ImportValue:
+          !Sub "${NotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      EnvironmentType: !Ref EnvironmentType
+      EnvironmentTypeAbbreviation: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation]
+      EcrRegion: !Ref EcrRegion
+      SecretsBase:
+          Fn::ImportValue:
+            !Sub "${SecretsStackName}-SecretsBaseRegion"
+      DovetailEcrImageTag: !Ref DovetailEcrImageTag
+      DovetailSecretsVersion: !Ref DovetailSecretsVersion
+    TemplateURL: !Join ["", ["http://s3", !If [IsUsEast1, "", "-"], !If [IsUsEast1, "", !Ref "AWS::Region"], ".amazonaws.com/", "Fn::ImportValue": !Sub "${InfrastructureStorageStackName}-InfrastructureSourceBucket", "/", !Ref InfrastructureGitCommit, "/stacks/dovetail.prx.org.yml"]]
+    TimeoutInMinutes: "5"
 Outputs:
   VPCCertificateArn:
     Description: The ARN for the wildcard certificate for the VPC
@@ -468,6 +505,9 @@ Outputs:
   FeederHostedZoneDNSName:
     Description: Domain name for feeder app
     Value: !GetAtt FeederStack.Outputs.HostedZoneDNSName
+  DovetailHostedZoneDNSName:
+    Description: Domain name for dovetail app
+    Value: !GetAtt DovetailStack.Outputs.HostedZoneDNSName
   # CmsHostedZoneDNSName:
   #   Description: Domain name for CMS app
   #   Value: !GetAtt CmsStack.Outputs.HostedZoneDNSName


### PR DESCRIPTION
Get dovetail running in ECS, with an independent load balancer from the rest of Platform.

Does **not** include the NGINX reverse proxy cache.  Will work on that after DT is running here.

Will also require most of #62 before we move prod over.  But this _should_ be able to run before that happens.