### PR TITLE
Add a mostly-random nonce to Root stack for utility purposes

### DIFF
--- a/cd/cd.yaml
+++ b/cd/cd.yaml
@@ -958,7 +958,8 @@ Resources:
                     "InfrastructureStorageStackName": "${InfrastructureStorageStackName}",
                     "NotificationsStackName": "${NotificationsStackName}",
                     "SecretsStackName": "${SecretsStackName}",
-                    "InfrastructureGitCommit": { "Fn::GetParam" : ["RepoStateArtifact", "state.json", "commit"]}
+                    "InfrastructureGitCommit": { "Fn::GetParam" : ["RepoStateArtifact", "state.json", "commit"]},
+                    "PipelineExecutionNonce": { "Fn::GetArtifactAtt" : ["InfrastructureRepoSourceArtifact", "ObjectKey"]}
                   }
                 TemplateConfiguration: TemplateConfigStagingZipArtifact::staging.json
                 TemplatePath: InfrastructureRepoSourceArtifact::stacks/root.yml
@@ -1036,7 +1037,8 @@ Resources:
                     "InfrastructureStorageStackName": "${InfrastructureStorageStackName}",
                     "NotificationsStackName": "${NotificationsStackName}",
                     "SecretsStackName": "${SecretsStackName}",
-                    "InfrastructureGitCommit": { "Fn::GetParam" : ["RepoStateArtifact", "state.json", "commit"]}
+                    "InfrastructureGitCommit": { "Fn::GetParam" : ["RepoStateArtifact", "state.json", "commit"]},
+                    "PipelineExecutionNonce": { "Fn::GetArtifactAtt" : ["InfrastructureRepoSourceArtifact", "ObjectKey"]}
                   }
                 RoleArn: !GetAtt CloudFormationIAMRole.Arn
                 StackName: !Sub ${AWS::StackName}-root-production

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -73,6 +73,8 @@ Parameters:
     Type: String
   InfrastructureGitCommit:
     Type: String
+  PipelineExecutionNonce:
+    Type: String
 Mappings:
   EnvironmentTypeMap:
     Testing:


### PR DESCRIPTION
For custom resources it can be useful to have a value that changes each
time the pipeline runs. This uses the S3 object key for an artifact
that is always created, and therefore should be unique to each pipeline
execution