### PR TITLE
DNS record templates

### DIFF
--- a/cd/cd.yaml
+++ b/cd/cd.yaml
@@ -1057,7 +1057,7 @@ Resources:
                 Version: 1
               Configuration:
                 NotificationArn: !Ref CodePipelineApprovalsSnsTopic
-                CustomData: "TODO Get info about the deploy (last commit, etc)"
+                CustomData: !Sub ${AWS::StackName}-root-production
               RunOrder: 3
             - Name: ExecuteChangeSet
               ActionTypeId:

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,2 @@
+These are some CloudFormation templates that currently we're managing manually.
+They are not part of the standard Infrastructure deployment.

--- a/etc/prx.mx-hosted_zone.yml
+++ b/etc/prx.mx-hosted_zone.yml
@@ -18,10 +18,9 @@ Resources:
       Name: !Ref Domain
   Website:
     Type: "AWS::Route53::RecordSetGroup"
-    DependsOn: HostedZone
     Properties:
       Comment: WWW
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - Type: A
           Name: !Ref Domain

--- a/etc/prx.mx-hosted_zone.yml
+++ b/etc/prx.mx-hosted_zone.yml
@@ -11,7 +11,7 @@ Resources:
     Type: "AWS::Route53::HostedZone"
     Properties:
       HostedZoneConfig:
-        Comment: Secondary Radiotopia domain
+        Comment: Remix domain
       HostedZoneTags:
         - Key: Project
           Value: Remix

--- a/etc/prx.mx-hosted_zone.yml
+++ b/etc/prx.mx-hosted_zone.yml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Hosted zone and record sets for prx.mx
+Parameters:
+  Domain:
+    Default: prx.mx.
+    Description: The domain name and hosted zone
+    Type: String
+Resources:
+  HostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: Secondary Radiotopia domain
+      HostedZoneTags:
+        - Key: Project
+          Value: Remix
+      Name: !Ref Domain
+  Website:
+    Type: "AWS::Route53::RecordSetGroup"
+    DependsOn: HostedZone
+    Properties:
+      Comment: WWW
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - Type: A
+          Name: !Ref Domain
+          AliasTarget:
+            DNSName: s3-website-us-east-1.amazonaws.com.
+            # us-east-1 hosted zone ID
+            HostedZoneId: Z3AQBSTGFYJSTF
+        - ResourceRecords:
+            - wafflehammer-staging.herokuapp.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub www.${Domain}
+        - ResourceRecords:
+            - wafflehammer-staging.herokuapp.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub www2.${Domain}

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -370,7 +370,7 @@ Resources:
         - Type: A
           Name: !Sub assets1.${Domain}
           AliasTarget:
-            DNSName: d11pcyef3meeu9.cloudfront.net
+            DNSName: d11pcyef3meeu9.cloudfront.net.
             HostedZoneId: Z2FDTNDATAQYW2
   Unbounce:
     DependsOn: HostedZone

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -1009,102 +1009,102 @@ Resources:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: audition2.${Domain}
+          Name: !Sub audition2.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: audition.qa.${Domain}
+          Name: !Sub audition.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: dlmgr-files.qa.${Domain}
+          Name: !Sub dlmgr-files.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: dlmgr.qa.${Domain}
+          Name: !Sub dlmgr.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: download.qa.${Domain}
+          Name: !Sub download.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: ftp.qa.${Domain}
+          Name: !Sub ftp.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: help2.${Domain}
+          Name: !Sub help2.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: help2.qa.${Domain}
+          Name: !Sub help2.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: help.qa.${Domain}
+          Name: !Sub help.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: loadingdock2.${Domain}
+          Name: !Sub loadingdock2.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: loadingdock.qa.${Domain}
+          Name: !Sub loadingdock.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: mp3audition.qa.${Domain}
+          Name: !Sub mp3audition.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: mp3download2.${Domain}
+          Name: !Sub mp3download2.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: mp3download.qa.${Domain}
+          Name: !Sub mp3download.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: prssstreams2.${Domain}
+          Name: !Sub prssstreams2.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: streams2.${Domain}
+          Name: !Sub streams2.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: streams.qa.${Domain}
+          Name: !Sub streams.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: ws.qa.${Domain}
+          Name: !Sub ws.qa.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: www2.${Domain}
+          Name: !Sub www2.${Domain}
         - ResourceRecords:
             - !Sub ed.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: www.qa.${Domain}
+          Name: !Sub www.qa.${Domain}
   Orson:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
@@ -1116,12 +1116,12 @@ Resources:
             - !Sub orson.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: listen.${Domain}
+          Name: !Sub listen.${Domain}
         - ResourceRecords:
             - !Sub orson.${Domain}
           TTL: "3600"
           Type: CNAME
-          Name: planet.${Domain}
+          Name: !Sub planet.${Domain}
   Legacy:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -440,6 +440,17 @@ Resources:
           AliasTarget:
             DNSName: d11pcyef3meeu9.cloudfront.net.
             HostedZoneId: Z2FDTNDATAQYW2
+  Prss:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Legacy PRSS end point
+      HostedZoneId: !Ref HostedZone
+      RecordSets:
+        - ResourceRecords:
+            - "205.153.38.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub prss.${Domain}
   Localhost:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -311,11 +311,11 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub cdn.saltcast.${Domain}
-  ProductionApps:
+  DotTech:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
-      Comment: Production apps public domains
+      Comment: Public-facing domains for apps managed on .tech
       HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
@@ -343,6 +343,70 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub feeder.${Domain}
+  PrxDotOrg:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: prx.org and www.prx.org
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "199.119.122.237"
+          TTL: "300"
+          Type: A
+          Name: !Ref Domain
+        - ResourceRecords:
+            - "199.119.122.237"
+          TTL: "300"
+          Type: A
+          Name: !Sub www.${Domain}
+  DotOrg:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Legacy prx.org subdomains
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - !Sub id.${Domain}
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub auth.${Domain}
+        - ResourceRecords:
+            - !Sub experiments.${Domain}
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub x.${Domain}
+        - ResourceRecords:
+            - !Sub cms.${Domain}
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub hal.${Domain}
+        - ResourceRecords:
+            - !Sub staging.m.${Domain}
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub m-staging.${Domain}
+        - ResourceRecords:
+            - "107.20.211.130"
+          TTL: "300"
+          Type: A
+          Name: !Sub beta.fixer.${Domain}
+        - ResourceRecords:
+            - "54.211.199.5"
+          TTL: "300"
+          Type: A
+          Name: !Sub experiments.${Domain}
+        - ResourceRecords:
+            - "184.73.205.19"
+          TTL: "300"
+          Type: A
+          Name: !Sub four.${Domain}
+        - ResourceRecords:
+            - "107.20.215.126"
+          TTL: "300"
+          Type: A
+          Name: !Sub fixer.${Domain}
   Contegix:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
@@ -1125,13 +1189,6 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub generation.${Domain}
-  S3:
-    DependsOn: HostedZone
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      Comment: Unbounce
-      HostedZoneName: !Ref Domain
-      RecordSets:
   Unbounce:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
@@ -1180,6 +1237,87 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub on.${Domain}
+  Fixer:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Fixer
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            # TODO Could be an A ALIAS
+            - alpha-fixer-prx-178057969.us-east-1.elb.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub alpha-fixer.${Domain}
+  Cambridge:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Cambridge Office
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "74.94.129.158"
+          TTL: "3600"
+          Type: A
+          Name: !Sub cambridge.${Domain}
+  Chef:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Chef
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "107.21.98.161"
+          TTL: "300"
+          Type: A
+          Name: !Sub chef.${Domain}
+        - ResourceRecords:
+            - "107.21.98.161"
+          TTL: "300"
+          Type: A
+          Name: !Sub munin.${Domain}
+        - ResourceRecords:
+            - "107.21.98.161"
+          TTL: "300"
+          Type: A
+          Name: !Sub beta.munin.${Domain}
+        - ResourceRecords:
+            - "107.21.98.161"
+          TTL: "300"
+          Type: A
+          Name: !Sub jenkins.${Domain}
+  HowSound:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: HowSound
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - howsound.prx.netdna-cdn.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub cdn.howsound.${Domain}
+  TheMoth:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: The Moth
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - pc-a.bitgravity.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub cdn1.themoth.${Domain}
+        - ResourceRecords:
+            - wwwthemoth.prx.netdna-cdn.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub assets.themoth.${Domain}
   AmazonSes:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
@@ -1202,11 +1340,11 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub dqoamfgwjnqyjzoe2rrvwkluoh7ee46v._domainkey.${Domain}
-  StagePages:
+  Statuspage:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
-      Comment: Unbounce
+      Comment: Statuspage
       HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -1,7 +1,22 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: tktk
+Parameters:
+  Domain:
+    Default: prx.org.
+    Description: The domain name and hosted zone
+    Type: String
 Resources:
+  HostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: prx.org
+      # HostedZoneTags:
+      #   - Key: Project
+      #     Value: radiotopia.fm
+      Name: !Ref Domain
   Text:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       # Route53 expects TXT record values to be enclosed in double quotes, so in
@@ -10,7 +25,7 @@ Resources:
       # resource records if necessary.
       # All SPF records need to go into a single resource record.
       Comment: TXT Records
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
             - '"status-page-domain-verification=6n18jv5h9b5d"'
@@ -18,460 +33,473 @@ Resources:
             - '"v=spf1 include:spf.mandrillapp.com include:mail.zendesk.com include:_spf.google.com include:amazonses.com include:stspg-customer.com -all"'
           TTL: "300"
           Type: TXT
-          Name: prx.org.
+          Name: !Ref Domain
         - ResourceRecords:
             - '"E5Armcve3+nXovpZPjTjUOkraFpdG0dcJjxOdScmrMk="'
           TTL: "300"
           Type: TXT
-          Name: _amazonses.prx.org.
+          Name: !Sub _amazonses.${Domain}
         - ResourceRecords:
             - '"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCYbt8bCjEvkdbTiYthVqEtFVySGUqThs+Agsbz7nU2BybHIqo9DCD7xMy9wVfaQOr0uPiKkahvpRVZAFgbYK4o2T7q4tibwb0UoD2LD0X6y+aKN8KWh07vyr17/fq6fiYTeeCIKyz8bufJcEZ1ZatLhlSp5gvUs2CUNWJjwSxh3wIDAQAB"'
           TTL: "300"
           Type: TXT
-          Name: google._domainkey.prx.org.
+          Name: !Sub google._domainkey.${Domain}
   Highwinds:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: CNAME records for Highwinds sites
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
             - cds.b3j2v5n8.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-radiotopia.prx.org.
+          Name: !Sub cdn-radiotopia.${Domain}
         - ResourceRecords:
             - cds.m7x6t6c7.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-bugle.prx.org.
+          Name: !Sub cdn-bugle.${Domain}
         - ResourceRecords:
             - cds.d9n6p3k9.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-99percentinvisible.prx.org.
+          Name: !Sub cdn-99percentinvisible.${Domain}
         - ResourceRecords:
             - cds.v9m6r2v6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-allusionist.prx.org.
+          Name: !Sub cdn-allusionist.${Domain}
         - ResourceRecords:
             - cds.d7n9t9b9.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-blankonblank.prx.org.
+          Name: !Sub cdn-blankonblank.${Domain}
         - ResourceRecords:
             - cds.x9t6f6d6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-esquire.prx.org.
+          Name: !Sub cdn-esquire.${Domain}
         - ResourceRecords:
             - ds.m9w6g3q5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-found.prx.org.
+          Name: !Sub cdn-found.${Domain}
         - ResourceRecords:
             - cds.b8z3t3h4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-fugitivewaves.prx.org.
+          Name: !Sub cdn-fugitivewaves.${Domain}
         - ResourceRecords:
             - cds.n3n3w5u4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-heart.prx.org.
+          Name: !Sub cdn-heart.${Domain}
         - ResourceRecords:
             - cds.m6i2n6w5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-howsound.prx.org.
+          Name: !Sub cdn-howsound.${Domain}
         - ResourceRecords:
             - cds.a7h7m5v4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-loveandradio.prx.org.
+          Name: !Sub cdn-loveandradio.${Domain}
         - ResourceRecords:
             - cds.m6u9z2i5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-mortified.prx.org.
+          Name: !Sub cdn-mortified.${Domain}
         - ResourceRecords:
             - cds.r2x4y8c2.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-radiodiaries.prx.org.
+          Name: !Sub cdn-radiodiaries.${Domain}
         - ResourceRecords:
             - cds.k6r6v2e5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-reveal.prx.org.
+          Name: !Sub cdn-reveal.${Domain}
         - ResourceRecords:
             - cds.x8b5s8y2.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-saltcast.prx.org.
+          Name: !Sub cdn-saltcast.${Domain}
         - ResourceRecords:
             - cds.g4e7f9c7.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-strangers.prx.org.
+          Name: !Sub cdn-strangers.${Domain}
         - ResourceRecords:
             - cds.v2e8q3c4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-toe.prx.org.
+          Name: !Sub cdn-toe.${Domain}
         - ResourceRecords:
             - cds.d2q9e4a4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-transistor.prx.org.
+          Name: !Sub cdn-transistor.${Domain}
         - ResourceRecords:
             - cds.c8s5s9v4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-ffh.prx.org.
+          Name: !Sub cdn-ffh.${Domain}
         - ResourceRecords:
             - cds.y7y4m6q5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-hermoney.prx.org.
+          Name: !Sub cdn-hermoney.${Domain}
         - ResourceRecords:
             - cds.b7i3c5p4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-htba.prx.org.
+          Name: !Sub cdn-htba.${Domain}
         - ResourceRecords:
             - cds.q2i7x7y4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-israel.prx.org.
+          Name: !Sub cdn-israel.${Domain}
         - ResourceRecords:
             - cds.a7u4w6s6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-millennial.prx.org.
+          Name: !Sub cdn-millennial.${Domain}
         - ResourceRecords:
             - cds.x6t5b7p4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-orbital.prx.org.
+          Name: !Sub cdn-orbital.${Domain}
         - ResourceRecords:
             - cds.n6x9x5k6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-outside.prx.org.
+          Name: !Sub cdn-outside.${Domain}
         - ResourceRecords:
             - cds.g4e7f9c7.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.strangers.prx.org.
+          Name: !Sub cdn.strangers.${Domain}
         - ResourceRecords:
             - cds.n3n3w5u4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.heart.prx.org.
+          Name: !Sub cdn.heart.${Domain}
         - ResourceRecords:
             - cds.m6u9z2i5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.mortified.prx.org.
+          Name: !Sub cdn.mortified.${Domain}
         - ResourceRecords:
             - cds.d2q9e4a4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.transistor.prx.org.
+          Name: !Sub cdn.transistor.${Domain}
         - ResourceRecords:
             - cds.v9m6r2v6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.allusionist.prx.org.
+          Name: !Sub cdn.allusionist.${Domain}
         - ResourceRecords:
             - cds.a7h7m5v4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.loveandradio.prx.org.
+          Name: !Sub cdn.loveandradio.${Domain}
         - ResourceRecords:
             - cds.b7i3c5p4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.htba.prx.org.
+          Name: !Sub cdn.htba.${Domain}
         - ResourceRecords:
             - cds.x9t6f6d6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.esquire.prx.org.
+          Name: !Sub cdn.esquire.${Domain}
         - ResourceRecords:
             - cds.q2i7x7y4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.israel.prx.org.
+          Name: !Sub cdn.israel.${Domain}
         - ResourceRecords:
             - cds.x6t5b7p4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.orbital.prx.org.
+          Name: !Sub cdn.orbital.${Domain}
         - ResourceRecords:
             - cds.n6x9x5k6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.outside.prx.org.
+          Name: !Sub cdn.outside.${Domain}
         - ResourceRecords:
             - cds.y7y4m6q5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.hermoney.prx.org.
+          Name: !Sub cdn.hermoney.${Domain}
         - ResourceRecords:
             - cds.m7x6t6c7.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.bugle.prx.org.
+          Name: !Sub cdn.bugle.${Domain}
         - ResourceRecords:
             - cds.a7u4w6s6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.millennial.prx.org.
+          Name: !Sub cdn.millennial.${Domain}
         - ResourceRecords:
             - cds.i7e6a2a4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.cpk.prx.org.
+          Name: !Sub cdn.cpk.${Domain}
         - ResourceRecords:
             - cds.c8s5s9v4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.ffh.prx.org.
+          Name: !Sub cdn.ffh.${Domain}
         - ResourceRecords:
             - cds.v9x4v3q6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.offshore.prx.org.
+          Name: !Sub cdn.offshore.${Domain}
         - ResourceRecords:
             - cds.v9x4v3q6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-offshore.prx.org.
+          Name: !Sub cdn-offshore.${Domain}
         - ResourceRecords:
             - cds.i7e6a2a4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn-cpk.prx.org.
+          Name: !Sub cdn-cpk.${Domain}
         - ResourceRecords:
             - cds.r2x4y8c2.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.radiodiaries.prx.org.
+          Name: !Sub cdn.radiodiaries.${Domain}
         - ResourceRecords:
             - cds.b8z3t3h4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.fugitivewaves.prx.org.
+          Name: !Sub cdn.fugitivewaves.${Domain}
         - ResourceRecords:
             - cds.b3j2v5n8.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.radiotopia.prx.org.
+          Name: !Sub cdn.radiotopia.${Domain}
         - ResourceRecords:
             - cds.k6r6v2e5.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.reveal.prx.org.
+          Name: !Sub cdn.reveal.${Domain}
         - ResourceRecords:
             - cds.d9n6p3k9.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.99percentinvisible.prx.org.
+          Name: !Sub cdn.99percentinvisible.${Domain}
         - ResourceRecords:
             - cds.v2e8q3c4.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.toe.prx.org.
+          Name: !Sub cdn.toe.${Domain}
         - ResourceRecords:
             - cds.t2h2z5k6.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.themoth.prx.org.
+          Name: !Sub cdn.themoth.${Domain}
         - ResourceRecords:
             - cds.x8b5s8y2.hwcdn.net.
           TTL: "300"
           Type: CNAME
-          Name: cdn.saltcast.prx.org.
+          Name: !Sub cdn.saltcast.${Domain}
   ProductionApps:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Production apps public domains
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
             - backsaw.prx.tech.
           TTL: "300"
           Type: CNAME
-          Name: backsaw.prx.org.
+          Name: !Sub backsaw.${Domain}
         - ResourceRecords:
             - crier.prx.tech.
           TTL: "300"
           Type: CNAME
-          Name: crier.prx.org.
+          Name: !Sub crier.${Domain}
         - ResourceRecords:
             - play.prx.tech.
           TTL: "300"
           Type: CNAME
-          Name: play.prx.org.
+          Name: !Sub play.${Domain}
         - ResourceRecords:
             - publish.prx.tech.
           TTL: "300"
           Type: CNAME
-          Name: publish.prx.org.
+          Name: !Sub publish.${Domain}
         - ResourceRecords:
             - feeder.prx.tech.
           TTL: "300"
           Type: CNAME
-          Name: feeder.prx.org.
+          Name: !Sub feeder.${Domain}
   Contegix:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Contegix servers
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
             - prx01.managed.contegix.com.
           TTL: "300"
           Type: CNAME
-          Name: prx01.prx.org.
+          Name: !Sub prx01.${Domain}
         - ResourceRecords:
             - prx04.managed.contegix.com.
           TTL: "300"
           Type: CNAME
-          Name: prx04.prx.org.
+          Name: !Sub prx04.${Domain}
   Legacy:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Various legacy resources
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - Type: A
-          Name: assets1.prx.org.
+          Name: !Sub assets1.${Domain}
           AliasTarget:
             DNSName: d11pcyef3meeu9.cloudfront.net
             HostedZoneId: Z2FDTNDATAQYW2
   Unbounce:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Unbounce
-      HostedZoneName: prx.org.
-      RecordSets:
-        - ResourceRecords:
-            - prx.zendesk.com.
-          TTL: "300"
-          Type: CNAME
-          Name: try.prx.org.
-  Feedburner:
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      Comment: Feedburner
-      HostedZoneName: prx.org.
-      RecordSets:
-        - ResourceRecords:
-            - io25k.feedproxy.ghs.google.com.
-          TTL: "300"
-          Type: CNAME
-          Name: feeds.prx.org.
-  GitHub:
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      Comment: GitHub
-      HostedZoneName: prx.org.
-      RecordSets:
-        - ResourceRecords:
-            - prx.github.io.
-          TTL: "300"
-          Type: CNAME
-          Name: labs.prx.org.
-  Bitly:
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      Comment: Bitly
-      HostedZoneName: prx.org.
-      RecordSets:
-        - ResourceRecords:
-            - cname.bitly.com.
-          TTL: "300"
-          Type: CNAME
-          Name: on.prx.org.
-  AmazonSes:
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      Comment: SES DKIM
-      HostedZoneName: prx.org.
-      RecordSets:
-        - ResourceRecords:
-            - gzyw7nc2rjfy5u6qplqkbbfuv4tdg5mc.dkim.amazonses.com.
-          TTL: "300"
-          Type: CNAME
-          Name: gzyw7nc2rjfy5u6qplqkbbfuv4tdg5mc._domainkey.prx.org.
-        - ResourceRecords:
-            - yqwoyh6wt54oqnyelxkn5hdaxkk52kv6.dkim.amazonses.com.
-          TTL: "300"
-          Type: CNAME
-          Name: yqwoyh6wt54oqnyelxkn5hdaxkk52kv6._domainkey.prx.org.
-        - ResourceRecords:
-            - dqoamfgwjnqyjzoe2rrvwkluoh7ee46v.dkim.amazonses.com.
-          TTL: "300"
-          Type: CNAME
-          Name: dqoamfgwjnqyjzoe2rrvwkluoh7ee46v._domainkey.prx.org.
-  StagePages:
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      Comment: Unbounce
-      HostedZoneName: prx.org.
-      RecordSets:
-        - ResourceRecords:
-            - zlzvfpy9x7fy.stspg-customer.com.
-          TTL: "300"
-          Type: CNAME
-          Name: status.prx.org.
-  ZenDesk:
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      Comment: ZenDesk
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
             - unbouncepages.com.
           TTL: "300"
           Type: CNAME
-          Name: help.prx.org.
+          Name: !Sub try.${Domain}
+  Feedburner:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Feedburner
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - io25k.feedproxy.ghs.google.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub feeds.${Domain}
+  GitHub:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: GitHub
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - prx.github.io.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub labs.${Domain}
+  Bitly:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Bitly
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - cname.bitly.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub on.${Domain}
+  AmazonSes:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: SES DKIM
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - gzyw7nc2rjfy5u6qplqkbbfuv4tdg5mc.dkim.amazonses.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub gzyw7nc2rjfy5u6qplqkbbfuv4tdg5mc._domainkey.${Domain}
+        - ResourceRecords:
+            - yqwoyh6wt54oqnyelxkn5hdaxkk52kv6.dkim.amazonses.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub yqwoyh6wt54oqnyelxkn5hdaxkk52kv6._domainkey.${Domain}
+        - ResourceRecords:
+            - dqoamfgwjnqyjzoe2rrvwkluoh7ee46v.dkim.amazonses.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub dqoamfgwjnqyjzoe2rrvwkluoh7ee46v._domainkey.${Domain}
+  StagePages:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Unbounce
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - zlzvfpy9x7fy.stspg-customer.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub status.${Domain}
+  ZenDesk:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: ZenDesk
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - unbouncepages.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub help.${Domain}
   Squarespace:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Squarespace
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
             - verify.squarespace.com.
           TTL: "300"
           Type: CNAME
-          Name: tydshd7bc7mddya37xk3.prx.org.
+          Name: !Sub tydshd7bc7mddya37xk3.${Domain}
         - ResourceRecords:
             - ext-cust.squarespace.com.
           TTL: "300"
           Type: CNAME
-          Name: catapult.prx.org.
+          Name: !Sub catapult.${Domain}
   GSuite:
+    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: G Suite
-      HostedZoneName: prx.org.
+      HostedZoneName: !Ref Domain
       RecordSets:
         - ResourceRecords:
             - ghs.googlehosted.com.
           TTL: "300"
           Type: CNAME
-          Name: calendar.prx.org.
+          Name: !Sub calendar.${Domain}
         - ResourceRecords:
             - ghs.googlehosted.com.
           TTL: "300"
           Type: CNAME
-          Name: mail.prx.org.
+          Name: !Sub mail.${Domain}
         - ResourceRecords:
             - "1 ASPMX.L.GOOGLE.COM."
             - "5 ALT1.ASPMX.L.GOOGLE.COM."
@@ -480,4 +508,4 @@ Resources:
             - "10 ASPMX3.GOOGLEMAIL.COM."
           TTL: "300"
           Type: MX
-          Name: prx.org.
+          Name: !Ref Domain

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -403,6 +403,11 @@ Resources:
           TTL: "300"
           Type: A
           Name: !Sub fixer.${Domain}
+        - ResourceRecords:
+            - !Sub prx-categorizer.herokuapp.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub categorizer.${Domain}
   Contegix:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -360,6 +360,704 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub prx04.${Domain}
+  Static:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Static assets
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - media.prx.org.s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub media.${Domain}
+        - Type: A
+          Name: !Sub assets1.${Domain}
+          AliasTarget:
+            DNSName: d11pcyef3meeu9.cloudfront.net.
+            HostedZoneId: Z2FDTNDATAQYW2
+  Localhost:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Localhost
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "127.0.0.1"
+          TTL: "3600"
+          Type: A
+          Name: !Sub localhost.${Domain}
+  Prx01:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: PRX01
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub ed.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub studs.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub assignments.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub analytics.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub activemq.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub api.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub audition.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub castle.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub files-local.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub moving.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub mp3download.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub ntop.srg01.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub onassignment.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub streams.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub tcf.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub web.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub webstats.srg01.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub wwwnew.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub www.old.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub www.new.${Domain}
+        - ResourceRecords:
+            - "199.119.122.228"
+          TTL: "300"
+          Type: A
+          Name: !Sub networks.${Domain}
+        - ResourceRecords:
+            - "199.119.122.229"
+          TTL: "300"
+          Type: A
+          Name: !Sub count.${Domain}
+  Prx02:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: PRX02
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub admin.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub about.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub ballotvox.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub blog.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub g2.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub g.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub blogdev.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub fisheye.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub jira.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub wptest.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.solr.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.activemq.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.count.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.networks.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.thecastle.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.castle.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.tcf.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.onassignment.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.assignment.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub assignment.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.fixer.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub svn.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub themoth.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub wiki.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub apps.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.assignments.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub 99percentinvisible.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub toe.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub pmx.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub radiodiaries.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub fugitivewaves.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub radiotopia.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub reveal.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub strangers.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub heart.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub mortified.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub transistor.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub allusionist.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub loveandradio.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub htba.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub stem.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub esquire.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub israel.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub orbital.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub outside.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub hermoney.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub bugle.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub millennial.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub cpk.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub ffh.${Domain}
+        - ResourceRecords:
+            - "199.119.122.230"
+          TTL: "300"
+          Type: A
+          Name: !Sub offshore.${Domain}
+  Prx03:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: PRX03
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "199.119.122.231"
+          TTL: "300"
+          Type: A
+          Name: !Sub wburapp.${Domain}
+        - ResourceRecords:
+            - "199.119.122.231"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.wburapp.${Domain}
+  Prx04:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: PRX04
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "199.119.122.232"
+          TTL: "300"
+          Type: A
+          Name: !Sub search.${Domain}
+        - ResourceRecords:
+            - "199.119.122.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub beta.${Domain}
+        - ResourceRecords:
+            - "199.119.122.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub m.${Domain}
+        - ResourceRecords:
+            - "199.119.122.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub cms.${Domain}
+        - ResourceRecords:
+            - "199.119.122.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub staging.m.${Domain}
+        - ResourceRecords:
+            - "199.119.122.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub login.${Domain}
+        - ResourceRecords:
+            - "199.119.122.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub alpha.${Domain}
+        - ResourceRecords:
+            - "199.119.122.233"
+          TTL: "300"
+          Type: A
+          Name: !Sub id.${Domain}
+  Studs:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Studs
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub collaboration.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub demo.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub dev.collaboration.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub dlmgr-files.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub dlmgr.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub download.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub dropbox.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub edithelp.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub eradio.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub ftp.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub legacy.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub loadingdock.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub mp3audition.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub newhome.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub prpdawards.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub prssstreams.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub v1.${Domain}
+        - ResourceRecords:
+            - !Sub studs.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: !Sub ws.${Domain}
+  Ed:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Ed
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: audition2.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: audition.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: dlmgr-files.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: dlmgr.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: download.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: ftp.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: help2.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: help2.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: help.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: loadingdock2.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: loadingdock.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: mp3audition.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: mp3download2.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: mp3download.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: prssstreams2.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: streams2.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: streams.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: ws.qa.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: www2.${Domain}
+        - ResourceRecords:
+            - !Sub ed.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: www.qa.${Domain}
+  Orson:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Orson
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - !Sub orson.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: listen.${Domain}
+        - ResourceRecords:
+            - !Sub orson.${Domain}
+          TTL: "3600"
+          Type: CNAME
+          Name: planet.${Domain}
   Legacy:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
@@ -367,11 +1065,73 @@ Resources:
       Comment: Various legacy resources
       HostedZoneName: !Ref Domain
       RecordSets:
-        - Type: A
-          Name: !Sub assets1.${Domain}
-          AliasTarget:
-            DNSName: d11pcyef3meeu9.cloudfront.net.
-            HostedZoneId: Z2FDTNDATAQYW2
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub andrew-s3.${Domain}
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub content-dev.${Domain}
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub files.${Domain}
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub files-test.${Domain}
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub files-dev.${Domain}
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub matt-s3.${Domain}
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub nathan-s3.${Domain}
+        - ResourceRecords:
+            - s3.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub robert-s3.${Domain}
+        - ResourceRecords:
+            - s3-website-us-east-1.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub campaignaudio.${Domain}
+        - ResourceRecords:
+            - s3-website-us-east-1.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub economybeat.${Domain}
+        - ResourceRecords:
+            - s3-website-us-east-1.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub economystory.${Domain}
+        - ResourceRecords:
+            - generation.prx.org.s3-website-us-east-1.amazonaws.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub generation.${Domain}
+  S3:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Unbounce
+      HostedZoneName: !Ref Domain
+      RecordSets:
   Unbounce:
     DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -1,0 +1,483 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: tktk
+Resources:
+  Text:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      # Route53 expects TXT record values to be enclosed in double quotes, so in
+      # the YAML they need to be double-quoted.
+      # Each domain name should only have a single text record. Add multiple
+      # resource records if necessary.
+      # All SPF records need to go into a single resource record.
+      Comment: TXT Records
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - '"status-page-domain-verification=6n18jv5h9b5d"'
+            - '"google-site-verification=j5qsGbnU-E37T9lsaAYL1967H0ej6iZAeX_vEWcOA-w"'
+            - '"v=spf1 include:spf.mandrillapp.com include:mail.zendesk.com include:_spf.google.com include:amazonses.com include:stspg-customer.com -all"'
+          TTL: "300"
+          Type: TXT
+          Name: prx.org.
+        - ResourceRecords:
+            - '"E5Armcve3+nXovpZPjTjUOkraFpdG0dcJjxOdScmrMk="'
+          TTL: "300"
+          Type: TXT
+          Name: _amazonses.prx.org.
+        - ResourceRecords:
+            - '"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCYbt8bCjEvkdbTiYthVqEtFVySGUqThs+Agsbz7nU2BybHIqo9DCD7xMy9wVfaQOr0uPiKkahvpRVZAFgbYK4o2T7q4tibwb0UoD2LD0X6y+aKN8KWh07vyr17/fq6fiYTeeCIKyz8bufJcEZ1ZatLhlSp5gvUs2CUNWJjwSxh3wIDAQAB"'
+          TTL: "300"
+          Type: TXT
+          Name: google._domainkey.prx.org.
+  Highwinds:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: CNAME records for Highwinds sites
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - cds.b3j2v5n8.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-radiotopia.prx.org.
+        - ResourceRecords:
+            - cds.m7x6t6c7.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-bugle.prx.org.
+        - ResourceRecords:
+            - cds.d9n6p3k9.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-99percentinvisible.prx.org.
+        - ResourceRecords:
+            - cds.v9m6r2v6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-allusionist.prx.org.
+        - ResourceRecords:
+            - cds.d7n9t9b9.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-blankonblank.prx.org.
+        - ResourceRecords:
+            - cds.x9t6f6d6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-esquire.prx.org.
+        - ResourceRecords:
+            - ds.m9w6g3q5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-found.prx.org.
+        - ResourceRecords:
+            - cds.b8z3t3h4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-fugitivewaves.prx.org.
+        - ResourceRecords:
+            - cds.n3n3w5u4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-heart.prx.org.
+        - ResourceRecords:
+            - cds.m6i2n6w5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-howsound.prx.org.
+        - ResourceRecords:
+            - cds.a7h7m5v4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-loveandradio.prx.org.
+        - ResourceRecords:
+            - cds.m6u9z2i5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-mortified.prx.org.
+        - ResourceRecords:
+            - cds.r2x4y8c2.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-radiodiaries.prx.org.
+        - ResourceRecords:
+            - cds.k6r6v2e5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-reveal.prx.org.
+        - ResourceRecords:
+            - cds.x8b5s8y2.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-saltcast.prx.org.
+        - ResourceRecords:
+            - cds.g4e7f9c7.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-strangers.prx.org.
+        - ResourceRecords:
+            - cds.v2e8q3c4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-toe.prx.org.
+        - ResourceRecords:
+            - cds.d2q9e4a4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-transistor.prx.org.
+        - ResourceRecords:
+            - cds.c8s5s9v4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-ffh.prx.org.
+        - ResourceRecords:
+            - cds.y7y4m6q5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-hermoney.prx.org.
+        - ResourceRecords:
+            - cds.b7i3c5p4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-htba.prx.org.
+        - ResourceRecords:
+            - cds.q2i7x7y4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-israel.prx.org.
+        - ResourceRecords:
+            - cds.a7u4w6s6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-millennial.prx.org.
+        - ResourceRecords:
+            - cds.x6t5b7p4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-orbital.prx.org.
+        - ResourceRecords:
+            - cds.n6x9x5k6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-outside.prx.org.
+        - ResourceRecords:
+            - cds.g4e7f9c7.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.strangers.prx.org.
+        - ResourceRecords:
+            - cds.n3n3w5u4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.heart.prx.org.
+        - ResourceRecords:
+            - cds.m6u9z2i5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.mortified.prx.org.
+        - ResourceRecords:
+            - cds.d2q9e4a4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.transistor.prx.org.
+        - ResourceRecords:
+            - cds.v9m6r2v6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.allusionist.prx.org.
+        - ResourceRecords:
+            - cds.a7h7m5v4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.loveandradio.prx.org.
+        - ResourceRecords:
+            - cds.b7i3c5p4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.htba.prx.org.
+        - ResourceRecords:
+            - cds.x9t6f6d6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.esquire.prx.org.
+        - ResourceRecords:
+            - cds.q2i7x7y4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.israel.prx.org.
+        - ResourceRecords:
+            - cds.x6t5b7p4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.orbital.prx.org.
+        - ResourceRecords:
+            - cds.n6x9x5k6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.outside.prx.org.
+        - ResourceRecords:
+            - cds.y7y4m6q5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.hermoney.prx.org.
+        - ResourceRecords:
+            - cds.m7x6t6c7.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.bugle.prx.org.
+        - ResourceRecords:
+            - cds.a7u4w6s6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.millennial.prx.org.
+        - ResourceRecords:
+            - cds.i7e6a2a4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.cpk.prx.org.
+        - ResourceRecords:
+            - cds.c8s5s9v4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.ffh.prx.org.
+        - ResourceRecords:
+            - cds.v9x4v3q6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.offshore.prx.org.
+        - ResourceRecords:
+            - cds.v9x4v3q6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-offshore.prx.org.
+        - ResourceRecords:
+            - cds.i7e6a2a4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn-cpk.prx.org.
+        - ResourceRecords:
+            - cds.r2x4y8c2.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.radiodiaries.prx.org.
+        - ResourceRecords:
+            - cds.b8z3t3h4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.fugitivewaves.prx.org.
+        - ResourceRecords:
+            - cds.b3j2v5n8.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.radiotopia.prx.org.
+        - ResourceRecords:
+            - cds.k6r6v2e5.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.reveal.prx.org.
+        - ResourceRecords:
+            - cds.d9n6p3k9.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.99percentinvisible.prx.org.
+        - ResourceRecords:
+            - cds.v2e8q3c4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.toe.prx.org.
+        - ResourceRecords:
+            - cds.t2h2z5k6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.themoth.prx.org.
+        - ResourceRecords:
+            - cds.x8b5s8y2.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: cdn.saltcast.prx.org.
+  ProductionApps:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Production apps public domains
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - backsaw.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: backsaw.prx.org.
+        - ResourceRecords:
+            - crier.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: crier.prx.org.
+        - ResourceRecords:
+            - play.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: play.prx.org.
+        - ResourceRecords:
+            - publish.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: publish.prx.org.
+        - ResourceRecords:
+            - feeder.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: feeder.prx.org.
+  Contegix:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Contegix servers
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - prx01.managed.contegix.com.
+          TTL: "300"
+          Type: CNAME
+          Name: prx01.prx.org.
+        - ResourceRecords:
+            - prx04.managed.contegix.com.
+          TTL: "300"
+          Type: CNAME
+          Name: prx04.prx.org.
+  Legacy:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Various legacy resources
+      HostedZoneName: prx.org.
+      RecordSets:
+        - Type: A
+          Name: assets1.prx.org.
+          AliasTarget:
+            DNSName: d11pcyef3meeu9.cloudfront.net
+            HostedZoneId: Z2FDTNDATAQYW2
+  Unbounce:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Unbounce
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - prx.zendesk.com.
+          TTL: "300"
+          Type: CNAME
+          Name: try.prx.org.
+  Feedburner:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Feedburner
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - io25k.feedproxy.ghs.google.com.
+          TTL: "300"
+          Type: CNAME
+          Name: feeds.prx.org.
+  GitHub:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: GitHub
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - prx.github.io.
+          TTL: "300"
+          Type: CNAME
+          Name: labs.prx.org.
+  Bitly:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Bitly
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - cname.bitly.com.
+          TTL: "300"
+          Type: CNAME
+          Name: on.prx.org.
+  AmazonSes:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: SES DKIM
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - gzyw7nc2rjfy5u6qplqkbbfuv4tdg5mc.dkim.amazonses.com.
+          TTL: "300"
+          Type: CNAME
+          Name: gzyw7nc2rjfy5u6qplqkbbfuv4tdg5mc._domainkey.prx.org.
+        - ResourceRecords:
+            - yqwoyh6wt54oqnyelxkn5hdaxkk52kv6.dkim.amazonses.com.
+          TTL: "300"
+          Type: CNAME
+          Name: yqwoyh6wt54oqnyelxkn5hdaxkk52kv6._domainkey.prx.org.
+        - ResourceRecords:
+            - dqoamfgwjnqyjzoe2rrvwkluoh7ee46v.dkim.amazonses.com.
+          TTL: "300"
+          Type: CNAME
+          Name: dqoamfgwjnqyjzoe2rrvwkluoh7ee46v._domainkey.prx.org.
+  StagePages:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Unbounce
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - zlzvfpy9x7fy.stspg-customer.com.
+          TTL: "300"
+          Type: CNAME
+          Name: status.prx.org.
+  ZenDesk:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: ZenDesk
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - unbouncepages.com.
+          TTL: "300"
+          Type: CNAME
+          Name: help.prx.org.
+  Squarespace:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Squarespace
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - verify.squarespace.com.
+          TTL: "300"
+          Type: CNAME
+          Name: tydshd7bc7mddya37xk3.prx.org.
+        - ResourceRecords:
+            - ext-cust.squarespace.com.
+          TTL: "300"
+          Type: CNAME
+          Name: catapult.prx.org.
+  GSuite:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: G Suite
+      HostedZoneName: prx.org.
+      RecordSets:
+        - ResourceRecords:
+            - ghs.googlehosted.com.
+          TTL: "300"
+          Type: CNAME
+          Name: calendar.prx.org.
+        - ResourceRecords:
+            - ghs.googlehosted.com.
+          TTL: "300"
+          Type: CNAME
+          Name: mail.prx.org.
+        - ResourceRecords:
+            - "1 ASPMX.L.GOOGLE.COM."
+            - "5 ALT1.ASPMX.L.GOOGLE.COM."
+            - "5 ALT2.ASPMX.L.GOOGLE.COM."
+            - "10 ASPMX2.GOOGLEMAIL.COM."
+            - "10 ASPMX3.GOOGLEMAIL.COM."
+          TTL: "300"
+          Type: MX
+          Name: prx.org.

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -408,6 +408,11 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub categorizer.${Domain}
+        - ResourceRecords:
+            - !Sub d31nihxqseius7.cloudfront.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub upload.${Domain}
   Contegix:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -17,7 +17,6 @@ Resources:
       #     Value: radiotopia.fm
       Name: !Ref Domain
   Text:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       # Route53 expects TXT record values to be enclosed in double quotes, so in
@@ -26,7 +25,7 @@ Resources:
       # resource records if necessary.
       # All SPF records need to go into a single resource record.
       Comment: TXT Records
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - '"status-page-domain-verification=6n18jv5h9b5d"'
@@ -46,11 +45,10 @@ Resources:
           Type: TXT
           Name: !Sub google._domainkey.${Domain}
   Highwinds:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: CNAME records for Highwinds sites
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - cds.b3j2v5n8.hwcdn.net.
@@ -313,11 +311,10 @@ Resources:
           Type: CNAME
           Name: !Sub cdn.saltcast.${Domain}
   DotTech:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Public-facing domains for apps managed on .tech
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - backsaw.prx.tech.
@@ -345,11 +342,10 @@ Resources:
           Type: CNAME
           Name: !Sub feeder.${Domain}
   PrxDotOrg:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: prx.org and www.prx.org
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "199.119.122.237"
@@ -362,11 +358,10 @@ Resources:
           Type: A
           Name: !Sub www.${Domain}
   DotOrg:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Legacy prx.org subdomains
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - !Sub id.${Domain}
@@ -409,11 +404,10 @@ Resources:
           Type: A
           Name: !Sub fixer.${Domain}
   Contegix:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Contegix servers
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - prx01.managed.contegix.com.
@@ -426,11 +420,10 @@ Resources:
           Type: CNAME
           Name: !Sub prx04.${Domain}
   Static:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Static assets
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - media.prx.org.s3.amazonaws.com.
@@ -443,11 +436,10 @@ Resources:
             DNSName: d11pcyef3meeu9.cloudfront.net.
             HostedZoneId: Z2FDTNDATAQYW2
   Localhost:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Localhost
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "127.0.0.1"
@@ -455,11 +447,10 @@ Resources:
           Type: A
           Name: !Sub localhost.${Domain}
   Prx01:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: PRX01
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "199.119.122.228"
@@ -572,11 +563,10 @@ Resources:
           Type: A
           Name: !Sub count.${Domain}
   Prx02:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: PRX02
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "199.119.122.230"
@@ -839,11 +829,10 @@ Resources:
           Type: A
           Name: !Sub offshore.${Domain}
   Prx03:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: PRX03
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "199.119.122.231"
@@ -856,11 +845,10 @@ Resources:
           Type: A
           Name: !Sub staging.wburapp.${Domain}
   Prx04:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: PRX04
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "199.119.122.232"
@@ -903,11 +891,10 @@ Resources:
           Type: A
           Name: !Sub id.${Domain}
   Studs:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Studs
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - !Sub studs.${Domain}
@@ -1000,11 +987,10 @@ Resources:
           Type: CNAME
           Name: !Sub ws.${Domain}
   Ed:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Ed
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - !Sub ed.${Domain}
@@ -1107,11 +1093,10 @@ Resources:
           Type: CNAME
           Name: !Sub www.qa.${Domain}
   Orson:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Orson
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - !Sub orson.${Domain}
@@ -1124,11 +1109,10 @@ Resources:
           Type: CNAME
           Name: !Sub planet.${Domain}
   Legacy:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Various legacy resources
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - s3.amazonaws.com.
@@ -1191,11 +1175,10 @@ Resources:
           Type: CNAME
           Name: !Sub generation.${Domain}
   Unbounce:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Unbounce
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - unbouncepages.com.
@@ -1203,11 +1186,10 @@ Resources:
           Type: CNAME
           Name: !Sub try.${Domain}
   Feedburner:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Feedburner
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - io25k.feedproxy.ghs.google.com.
@@ -1215,11 +1197,10 @@ Resources:
           Type: CNAME
           Name: !Sub feeds.${Domain}
   GitHub:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: GitHub
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - prx.github.io.
@@ -1227,11 +1208,10 @@ Resources:
           Type: CNAME
           Name: !Sub labs.${Domain}
   Bitly:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Bitly
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - cname.bitly.com.
@@ -1239,11 +1219,10 @@ Resources:
           Type: CNAME
           Name: !Sub on.${Domain}
   Fixer:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Fixer
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             # TODO Could be an A ALIAS
@@ -1252,11 +1231,10 @@ Resources:
           Type: CNAME
           Name: !Sub alpha-fixer.${Domain}
   Cambridge:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Cambridge Office
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "74.94.129.158"
@@ -1264,11 +1242,10 @@ Resources:
           Type: A
           Name: !Sub cambridge.${Domain}
   Chef:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Chef
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "107.21.98.161"
@@ -1291,11 +1268,10 @@ Resources:
           Type: A
           Name: !Sub jenkins.${Domain}
   HowSound:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: HowSound
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - howsound.prx.netdna-cdn.com.
@@ -1303,11 +1279,10 @@ Resources:
           Type: CNAME
           Name: !Sub cdn.howsound.${Domain}
   TheMoth:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: The Moth
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - pc-a.bitgravity.com.
@@ -1320,11 +1295,10 @@ Resources:
           Type: CNAME
           Name: !Sub assets.themoth.${Domain}
   AmazonSes:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: SES DKIM
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - gzyw7nc2rjfy5u6qplqkbbfuv4tdg5mc.dkim.amazonses.com.
@@ -1342,11 +1316,10 @@ Resources:
           Type: CNAME
           Name: !Sub dqoamfgwjnqyjzoe2rrvwkluoh7ee46v._domainkey.${Domain}
   Statuspage:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Statuspage
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - zlzvfpy9x7fy.stspg-customer.com.
@@ -1354,11 +1327,10 @@ Resources:
           Type: CNAME
           Name: !Sub status.${Domain}
   ZenDesk:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: ZenDesk
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - unbouncepages.com.
@@ -1366,11 +1338,10 @@ Resources:
           Type: CNAME
           Name: !Sub help.${Domain}
   Squarespace:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Squarespace
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - verify.squarespace.com.
@@ -1383,11 +1354,10 @@ Resources:
           Type: CNAME
           Name: !Sub catapult.${Domain}
   GSuite:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: G Suite
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - ghs.googlehosted.com.

--- a/etc/prx.org-hosted_zone.yml
+++ b/etc/prx.org-hosted_zone.yml
@@ -1,5 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: tktk
+Description: >
+  Hosted zone and record sets for prx.org
 Parameters:
   Domain:
     Default: prx.org.

--- a/etc/prxu.org-hosted_zone.yml
+++ b/etc/prxu.org-hosted_zone.yml
@@ -35,7 +35,7 @@ Resources:
           Name: !Sub _amazonses.${Domain}
         - ResourceRecords:
             - '"Kr2tQaG5"'
-          TTL: "300"
+          TTL: "1800"
           Type: TXT
           Name: !Sub dzc.${Domain}
   Dovetail:
@@ -113,7 +113,7 @@ Resources:
           Name: !Sub cdn-ad-files.${Domain}
         - ResourceRecords:
             - cds.z6t4p6w9.hwcdn.net.
-          TTL: "300"
+          TTL: "86400"
           Type: CNAME
           Name: !Sub cdn-dovetail-staging.${Domain}
         - ResourceRecords:
@@ -123,7 +123,7 @@ Resources:
           Name: !Sub cdn-dovetail.${Domain}
         - ResourceRecords:
             - cds.m9p3n2z3.hwcdn.net.
-          TTL: "300"
+          TTL: "86400"
           Type: CNAME
           Name: !Sub cdn.dovetail.${Domain}
         - ResourceRecords:

--- a/etc/prxu.org-hosted_zone.yml
+++ b/etc/prxu.org-hosted_zone.yml
@@ -17,7 +17,6 @@ Resources:
       #     Value: radiotopia.fm
       Name: !Ref Domain
   Text:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       # Route53 expects TXT record values to be enclosed in double quotes, so in
@@ -26,7 +25,7 @@ Resources:
       # resource records if necessary.
       # All SPF records need to go into a single resource record.
       Comment: TXT Records
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - '"R69rwoxwHEe6ubbq/suATEEFndpJN2M/uGpqqmP4kHE="'
@@ -39,11 +38,10 @@ Resources:
           Type: TXT
           Name: !Sub dzc.${Domain}
   Dovetail:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Dovetail
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - Type: A
           Name: !Sub dovetail.${Domain}
@@ -76,11 +74,10 @@ Resources:
             DNSName: dualstack.infra-dovet-1y2ncjszlrdmz-1988316390.us-east-1.elb.amazonaws.com.
             HostedZoneId: Z35SXDOTRQ7X7K
   Mx:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: MX Records
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "10 inbound-smtp.us-east-1.amazonaws.com."
@@ -88,11 +85,10 @@ Resources:
           Type: MX
           Name: !Ref Domain
   CloudFront:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: CloudFront
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - dsn15m3yob5tf.cloudfront.net.
@@ -100,11 +96,10 @@ Resources:
           Type: CNAME # TODO Could be A ALIAS
           Name: !Sub userupload.${Domain}
   Highwinds:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Highwinds
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - cds.q5s4q5h8.hwcdn.net.

--- a/etc/prxu.org-hosted_zone.yml
+++ b/etc/prxu.org-hosted_zone.yml
@@ -1,0 +1,138 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Hosted zone and record sets for prxu.org
+Parameters:
+  Domain:
+    Default: prxu.org.
+    Description: The domain name and hosted zone
+    Type: String
+Resources:
+  HostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: User-generated Content
+      # HostedZoneTags:
+      #   - Key: Project
+      #     Value: radiotopia.fm
+      Name: !Ref Domain
+  Text:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      # Route53 expects TXT record values to be enclosed in double quotes, so in
+      # the YAML they need to be double-quoted.
+      # Each domain name should only have a single text record. Add multiple
+      # resource records if necessary.
+      # All SPF records need to go into a single resource record.
+      Comment: TXT Records
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - '"R69rwoxwHEe6ubbq/suATEEFndpJN2M/uGpqqmP4kHE="'
+          TTL: "300"
+          Type: TXT
+          Name: !Sub _amazonses.${Domain}
+        - ResourceRecords:
+            - '"Kr2tQaG5"'
+          TTL: "300"
+          Type: TXT
+          Name: !Sub dzc.${Domain}
+  Dovetail:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Dovetail
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - Type: A
+          Name: !Sub dovetail.${Domain}
+          AliasTarget:
+            DNSName: dualstack.infra-dovet-1jujps3p3xej3-652325001.us-east-1.elb.amazonaws.com.
+            HostedZoneId: Z35SXDOTRQ7X7K
+        - Type: AAAAA
+          Name: !Sub dovetail.${Domain}
+          AliasTarget:
+            DNSName: dualstack.infra-dovet-1jujps3p3xej3-652325001.us-east-1.elb.amazonaws.com.
+            HostedZoneId: Z35SXDOTRQ7X7K
+        - Type: A
+          Name: !Sub tal.dovetail.${Domain}
+          AliasTarget:
+            DNSName: dualstack.infra-dovet-1jujps3p3xej3-652325001.us-east-1.elb.amazonaws.com.
+            HostedZoneId: Z35SXDOTRQ7X7K
+        - Type: AAAAA
+          Name: !Sub tal.dovetail.${Domain}
+          AliasTarget:
+            DNSName: dualstack.infra-dovet-1jujps3p3xej3-652325001.us-east-1.elb.amazonaws.com.
+            HostedZoneId: Z35SXDOTRQ7X7K
+        - Type: A
+          Name: !Sub dovetail.staging.${Domain}
+          AliasTarget:
+            DNSName: dualstack.infra-dovet-1y2ncjszlrdmz-1988316390.us-east-1.elb.amazonaws.com.
+            HostedZoneId: Z35SXDOTRQ7X7K
+        - Type: AAAAA
+          Name: !Sub dovetail.staging.${Domain}
+          AliasTarget:
+            DNSName: dualstack.infra-dovet-1y2ncjszlrdmz-1988316390.us-east-1.elb.amazonaws.com.
+            HostedZoneId: Z35SXDOTRQ7X7K
+  Mx:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: MX Records
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "10 inbound-smtp.us-east-1.amazonaws.com."
+          TTL: "300"
+          Type: MX
+          Name: !Ref Domain
+  CloudFront:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: CloudFront
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - dsn15m3yob5tf.cloudfront.net.
+          TTL: "300"
+          Type: CNAME # TODO Could be A ALIAS
+          Name: !Sub userupload.${Domain}
+  Highwinds:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Highwinds
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - cds.q5s4q5h8.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub cdn-ad-files.${Domain}
+        - ResourceRecords:
+            - cds.z6t4p6w9.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub cdn-dovetail-staging.${Domain}
+        - ResourceRecords:
+            - cds.m9p3n2z3.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub cdn-dovetail.${Domain}
+        - ResourceRecords:
+            - cds.m9p3n2z3.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub cdn.dovetail.${Domain}
+        - ResourceRecords:
+            - cds.m3g3q4x6.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub f-staging.${Domain}
+        - ResourceRecords:
+            - cds.y9f3h4p4.hwcdn.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub f.${Domain}

--- a/etc/radiotopia.com-hosted_zone.yml
+++ b/etc/radiotopia.com-hosted_zone.yml
@@ -17,11 +17,10 @@ Resources:
           Value: radiotopia.fm
       Name: !Ref Domain
   Website:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: WWW
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - Type: A
           Name: !Ref Domain
@@ -36,7 +35,6 @@ Resources:
             # us-east-1 hosted zone ID
             HostedZoneId: Z3AQBSTGFYJSTF
   Text:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       # Route53 expects TXT record values to be enclosed in double quotes, so in
@@ -45,7 +43,7 @@ Resources:
       # resource records if necessary.
       # All SPF records need to go into a single resource record.
       Comment: TXT Records
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - '"google-site-verification=H6g01JYxody2U98gTwUZVFY1kDz1miktW9DIEDh_f1I"'
@@ -53,11 +51,10 @@ Resources:
           Type: TXT
           Name: !Ref Domain
   GSuite:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: G Suite
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "1 ASPMX.L.GOOGLE.COM."

--- a/etc/radiotopia.com-hosted_zone.yml
+++ b/etc/radiotopia.com-hosted_zone.yml
@@ -1,0 +1,70 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Hosted zone and record sets for radiotopia.com
+Parameters:
+  Domain:
+    Default: radiotopia.com.
+    Description: The domain name and hosted zone
+    Type: String
+Resources:
+  HostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: Secondary Radiotopia domain
+      HostedZoneTags:
+        - Key: Project
+          Value: radiotopia.fm
+      Name: !Ref Domain
+  Website:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: WWW
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - Type: A
+          Name: !Ref Domain
+          AliasTarget:
+            DNSName: s3-website-us-east-1.amazonaws.com.
+            # us-east-1 hosted zone ID
+            HostedZoneId: Z3AQBSTGFYJSTF
+        - Type: A
+          Name: !Sub www.${Domain}
+          AliasTarget:
+            DNSName: s3-website-us-east-1.amazonaws.com.
+            # us-east-1 hosted zone ID
+            HostedZoneId: Z3AQBSTGFYJSTF
+  Text:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      # Route53 expects TXT record values to be enclosed in double quotes, so in
+      # the YAML they need to be double-quoted.
+      # Each domain name should only have a single text record. Add multiple
+      # resource records if necessary.
+      # All SPF records need to go into a single resource record.
+      Comment: TXT Records
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - '"google-site-verification=H6g01JYxody2U98gTwUZVFY1kDz1miktW9DIEDh_f1I"'
+          TTL: "300"
+          Type: TXT
+          Name: !Ref Domain
+  GSuite:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: G Suite
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "1 ASPMX.L.GOOGLE.COM."
+            - "5 ALT1.ASPMX.L.GOOGLE.COM."
+            - "5 ALT2.ASPMX.L.GOOGLE.COM."
+            - "10 ASPMX2.GOOGLEMAIL.COM."
+            - "10 ASPMX3.GOOGLEMAIL.COM."
+          TTL: "300"
+          Type: MX
+          Name: !Ref Domain

--- a/etc/radiotopia.fm-hosted_zone.yml
+++ b/etc/radiotopia.fm-hosted_zone.yml
@@ -17,7 +17,6 @@ Resources:
           Value: radiotopia.fm
       Name: !Ref Domain
   Text:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       # Route53 expects TXT record values to be enclosed in double quotes, so in
@@ -26,7 +25,7 @@ Resources:
       # resource records if necessary.
       # All SPF records need to go into a single resource record.
       Comment: TXT Records
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - '"google-site-verification=zFRPkYoCbmLhpl-z3WCBzd0uUXdlP50m39evhsNZHKQ"'
@@ -35,11 +34,10 @@ Resources:
           Type: TXT
           Name: !Ref Domain
   GSuite:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: G Suite
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "1 ASPMX.L.GOOGLE.COM."
@@ -51,11 +49,10 @@ Resources:
           Type: MX
           Name: !Ref Domain
   Squarespace:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Squarespace
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - "198.185.159.144"
@@ -76,11 +73,10 @@ Resources:
           Type: CNAME
           Name: !Sub 8k7w47c5y878fddxzmfk.${Domain}
   MailChimp:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: MailChimp
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - dkim.mcsv.net.
@@ -88,11 +84,10 @@ Resources:
           Type: CNAME
           Name: !Sub k1._domainkey.${Domain}
   Feedburner:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: MailChimp
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
             - io25k.feedproxy.ghs.google.com.
@@ -100,11 +95,10 @@ Resources:
           Type: CNAME
           Name: !Sub feeds.${Domain}
   Media:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Media server
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - Type: A
           Name: !Sub media.${Domain}
@@ -119,11 +113,10 @@ Resources:
             # Global CloudFront hosted zone ID
             HostedZoneId: Z2FDTNDATAQYW2
   RadiotopiaRadio:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Radiotopia Radio and API
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - Type: A
           Name: !Sub radio.${Domain}
@@ -150,11 +143,10 @@ Resources:
             # Global CloudFront hosted zone ID
             HostedZoneId: Z2FDTNDATAQYW2
   Legacy:
-    DependsOn: HostedZone
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       Comment: Radiotopia Radio and API
-      HostedZoneName: !Ref Domain
+      HostedZoneId: !Ref HostedZone
       RecordSets:
         - Type: A
           Name: !Sub v1.${Domain}

--- a/etc/radiotopia.fm-hosted_zone.yml
+++ b/etc/radiotopia.fm-hosted_zone.yml
@@ -1,0 +1,170 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Hosted zone and record sets for radiotopia.fm
+Parameters:
+  Domain:
+    Default: radiotopia.fm.
+    Description: The domain name and hosted zone
+    Type: String
+Resources:
+  HostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: Primary Radiotopia domain
+      HostedZoneTags:
+        - Key: Project
+          Value: radiotopia.fm
+      Name: !Ref Domain
+  Text:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      # Route53 expects TXT record values to be enclosed in double quotes, so in
+      # the YAML they need to be double-quoted.
+      # Each domain name should only have a single text record. Add multiple
+      # resource records if necessary.
+      # All SPF records need to go into a single resource record.
+      Comment: TXT Records
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - '"google-site-verification=zFRPkYoCbmLhpl-z3WCBzd0uUXdlP50m39evhsNZHKQ"'
+            - '"v=spf1 include:mail.zendesk.com include:servers.mcsv.net ?all"'
+          TTL: "300"
+          Type: TXT
+          Name: !Ref Domain
+  GSuite:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: G Suite
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "1 ASPMX.L.GOOGLE.COM."
+            - "5 ALT1.ASPMX.L.GOOGLE.COM."
+            - "5 ALT2.ASPMX.L.GOOGLE.COM."
+            - "10 ASPMX2.GOOGLEMAIL.COM."
+            - "10 ASPMX3.GOOGLEMAIL.COM."
+          TTL: "300"
+          Type: MX
+          Name: !Ref Domain
+  Squarespace:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Squarespace
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - "198.185.159.144"
+            - "198.185.159.145"
+            - "198.49.23.144"
+            - "198.49.23.145"
+          TTL: "300"
+          Type: A
+          Name: !Ref Domain
+        - ResourceRecords:
+            - ext-cust.squarespace.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub www.${Domain}
+        - ResourceRecords:
+            - verify.squarespace.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub 8k7w47c5y878fddxzmfk.${Domain}
+  MailChimp:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: MailChimp
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - dkim.mcsv.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub k1._domainkey.${Domain}
+  Feedburner:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: MailChimp
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - ResourceRecords:
+            - io25k.feedproxy.ghs.google.com.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub feeds.${Domain}
+  Media:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Media server
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - Type: A
+          Name: !Sub media.${Domain}
+          AliasTarget:
+            DNSName: d20aun7mw4so9y.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2
+        - Type: AAAA
+          Name: !Sub media.${Domain}
+          AliasTarget:
+            DNSName: d20aun7mw4so9y.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2
+  RadiotopiaRadio:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Radiotopia Radio and API
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - Type: A
+          Name: !Sub radio.${Domain}
+          AliasTarget:
+            DNSName: di9gzgowz7p3e.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2
+        - Type: AAAA
+          Name: !Sub radio.${Domain}
+          AliasTarget:
+            DNSName: di9gzgowz7p3e.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2
+        - Type: A
+          Name: !Sub tower.${Domain}
+          AliasTarget:
+            DNSName: d2bc6y52zdgbr8.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2
+        - Type: AAAA
+          Name: !Sub tower.${Domain}
+          AliasTarget:
+            DNSName: d2bc6y52zdgbr8.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2
+  Legacy:
+    DependsOn: HostedZone
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Radiotopia Radio and API
+      HostedZoneName: !Ref Domain
+      RecordSets:
+        - Type: A
+          Name: !Sub v1.${Domain}
+          AliasTarget:
+            DNSName: d1eoaqplfeeo8v.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2
+        - Type: AAAA
+          Name: !Sub v1.${Domain}
+          AliasTarget:
+            DNSName: d1eoaqplfeeo8v.cloudfront.net
+            # Global CloudFront hosted zone ID
+            HostedZoneId: Z2FDTNDATAQYW2


### PR DESCRIPTION
Adds templates for Route 53 hosted zones for several domains that already exist in Route 53, as well as prx.org, which currently is hosted on Contegix's name servers.