### PR TITLE
ASG sizing lambda

### DIFF
--- a/notifications/lambdas/slack-message-relay/index.js
+++ b/notifications/lambdas/slack-message-relay/index.js
@@ -17,7 +17,11 @@ exports.handler = (event, context, callback) => {
         const sns = event.Records[0].Sns;
 
         const attrs = sns.MessageAttributes;
-        const webhookUrl = attrs.WebhookURL.Value;
+
+        let webhookUrl = process.env['DEFAULT_WEBHOOK_URL'];
+        if (attrs.WebhookURL) {
+          webhookUrl = attrs.WebhookURL.Value;
+        }
 
         // Setup request options
         const options = url.parse(webhookUrl);

--- a/notifications/lambdas/slack-message-relay/index.js
+++ b/notifications/lambdas/slack-message-relay/index.js
@@ -18,7 +18,7 @@ exports.handler = (event, context, callback) => {
 
         const attrs = sns.MessageAttributes;
 
-        let webhookUrl = process.env['DEFAULT_WEBHOOK_URL'];
+        let webhookUrl = process.env.DEFAULT_WEBHOOK_URL;
         if (attrs.WebhookURL) {
           webhookUrl = attrs.WebhookURL.Value;
         }

--- a/notifications/notifications.yml
+++ b/notifications/notifications.yml
@@ -166,6 +166,9 @@ Resources:
       Description: >
         Receives preformed Slack message payloads and sends them to the provided
         Incoming Webhook URL
+      Environment:
+        Variables:
+          DEFAULT_WEBHOOK_URL: !Ref CloudFormationSlackWebhookUrl
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt LambdaBasicExecutionIamRole.Arn

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -588,11 +588,11 @@ Resources:
         - Key: Project
           Value: Infrastructure
       Timeout: 300
-  ECSScaleRole:
+  ASGSizerRole:
     Type: "AWS::IAM::Role"
     Properties:
       Policies:
-        - PolicyName: "scale-lambda-inline"
+        - PolicyName: "ASGSizerLambdaPolicy"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -603,23 +603,19 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - ecs:DescribeContainerInstances
+                  - ecs:DescribeServices
+                  - ecs:DescribeTaskDefinition
                   - ecs:ListContainerInstances
+                  - ecs:ListServices
               - Effect: "Allow"
                 Resource: "*" # TODO: how to get an ASG ARN?
                 Action:
                   - autoscaling:DescribeAutoScalingGroups
                   - autoscaling:SetDesiredCapacity
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "lambda.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
       Path: "/"
-  ECSScaleFunction:
+  ASGSizerFunction:
     Type: "AWS::Lambda::Function"
     Properties:
       Code:
@@ -627,14 +623,14 @@ Resources:
           Fn::ImportValue:
             !Sub ${InfrastructureStorageStackName}-InfrastructureSupportBucket
         S3Key: utility/ecs-asg-sizer.zip
-      Description:
+      Description: Make an ASG the perfect size for an ECS cluster
       Environment:
         Variables:
           ASG_NAME: !Ref ECSClusterASG
           ECS_CLUSTER: !Ref ECSCluster
       Handler: lambda_function.lambda_handler
       MemorySize: 128
-      Role: !GetAtt ECSScaleRole.Arn
+      Role: !GetAtt ASGSizerRole.Arn
       Runtime: python3.6
       Tags:
         - Key: Project

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -49,12 +49,6 @@ Parameters:
     Type: String
   SecretsInstanceAccessPolicyArn:
     Type: String
-  ThresholdCpu:
-    Type: String
-  ThresholdMemory:
-    Type: String
-  ThresholdCount:
-    Type: String
 Mappings:
   EnvironmentTypeMap:
     Testing:
@@ -638,9 +632,6 @@ Resources:
         Variables:
           ASG_NAME: !Ref ECSClusterASG
           ECS_CLUSTER: !Ref ECSCluster
-          THRESHOLD_CPU: !Ref ThresholdCpu
-          THRESHOLD_MEMORY: !Ref ThresholdMemory
-          THRESHOLD_COUNT: !Ref ThresholdCount
       Handler: lambda_function.lambda_handler
       MemorySize: 128
       Role: !GetAtt ECSScaleRole.Arn

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -45,6 +45,8 @@ Parameters:
     Type: String
   OpsErrorMessagesSnsTopicArn:
     Type: String
+  SlackMessageRelaySnsTopicArn:
+    Type: String
   SecretsInstanceDecryptPolicyArn:
     Type: String
   SecretsInstanceAccessPolicyArn:
@@ -612,6 +614,15 @@ Resources:
                 Action:
                   - autoscaling:DescribeAutoScalingGroups
                   - autoscaling:SetDesiredCapacity
+        - PolicyName: SnsPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "sns:Publish"
+                Resource:
+                  - !Ref SlackMessageRelaySnsTopicArn
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
       Path: "/"
@@ -628,6 +639,7 @@ Resources:
         Variables:
           ASG_NAME: !Ref ECSClusterASG
           ECS_CLUSTER: !Ref ECSCluster
+          SLACK_SNS_TOPIC: !Ref SlackMessageRelaySnsTopicArn
       Handler: lambda_function.lambda_handler
       MemorySize: 128
       Role: !GetAtt ASGSizerRole.Arn

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -49,6 +49,12 @@ Parameters:
     Type: String
   SecretsInstanceAccessPolicyArn:
     Type: String
+  ThresholdCpu:
+    Type: String
+  ThresholdMemory:
+    Type: String
+  ThresholdCount:
+    Type: String
 Mappings:
   EnvironmentTypeMap:
     Testing:
@@ -588,6 +594,61 @@ Resources:
         - Key: Project
           Value: Infrastructure
       Timeout: 300
+  ECSScaleRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Policies:
+        - PolicyName: "scale-lambda-inline"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Resource: "*"
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - ecs:DescribeContainerInstances
+                  - ecs:ListContainerInstances
+              - Effect: "Allow"
+                Resource: "*" # TODO: how to get an ASG ARN?
+                Action:
+                  - autoscaling:DescribeAutoScalingGroups
+                  - autoscaling:SetDesiredCapacity
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+  ECSScaleFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket:
+          Fn::ImportValue:
+            !Sub ${InfrastructureStorageStackName}-InfrastructureSupportBucket
+        S3Key: utility/ecs-asg-sizer.zip
+      Description:
+      Environment:
+        Variables:
+          ASG_NAME: !Ref ECSClusterASG
+          ECS_CLUSTER: !Ref ECSCluster
+          THRESHOLD_CPU: !Ref ThresholdCpu
+          THRESHOLD_MEMORY: !Ref ThresholdMemory
+          THRESHOLD_COUNT: !Ref ThresholdCount
+      Handler: lambda_function.lambda_handler
+      MemorySize: 128
+      Role: !GetAtt ECSScaleRole.Arn
+      Runtime: python3.6
+      Tags:
+        - Key: Project
+          Value: Infrastructure
+      Timeout: 30
 Outputs:
   ECSCluster:
     Description: >

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -601,9 +601,6 @@ Resources:
               - Effect: "Allow"
                 Resource: "*"
                 Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
                   - ecs:DescribeContainerInstances
                   - ecs:DescribeServices
                   - ecs:DescribeTaskDefinition

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -189,6 +189,9 @@ Resources:
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue:
             !Sub "${NotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+        SlackMessageRelaySnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${NotificationsStackName}-SlackMessageRelaySnsTopicArn"
         SecretsInstanceDecryptPolicyArn:
           Fn::ImportValue:
             !Sub "${SecretsStackName}-SecretsInstanceDecryptPolicyArn"

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -98,6 +98,15 @@ Mappings:
       abbreviation: stag
     Production:
       abbreviation: prod
+  ASGScalingMap:
+    Staging:
+      ThresholdCpu: 128
+      ThresholdMemory: 400
+      ThresholdCount: 2
+    Production:
+      ThresholdCpu: 700
+      ThresholdMemory: 1400
+      ThresholdCount: 2
   ECSReservationMap:
     Staging:
       BackendCpu: 128
@@ -195,6 +204,9 @@ Resources:
         SecretsInstanceAccessPolicyArn:
           Fn::ImportValue:
             !Sub "${SecretsStackName}-SecretsInstanceAccessPolicyArn"
+        ThresholdCpu: !FindInMap [ASGScalingMap, !Ref EnvironmentType, ThresholdCpu]
+        ThresholdMemory: !FindInMap [ASGScalingMap, !Ref EnvironmentType, ThresholdMemory]
+        ThresholdCount: !FindInMap [ASGScalingMap, !Ref EnvironmentType, ThresholdCount]
       TemplateURL: !Join ["", ["http://s3", !If [IsUsEast1, "", "-"], !If [IsUsEast1, "", !Ref "AWS::Region"], ".amazonaws.com/", "Fn::ImportValue": !Sub "${InfrastructureStorageStackName}-InfrastructureSourceBucket", "/", !Ref InfrastructureGitCommit, "/stacks/ecs.yml"]]
       TimeoutInMinutes: "5"
   LoadBalancersStack:

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -98,15 +98,6 @@ Mappings:
       abbreviation: stag
     Production:
       abbreviation: prod
-  ASGScalingMap:
-    Staging:
-      ThresholdCpu: 128
-      ThresholdMemory: 400
-      ThresholdCount: 2
-    Production:
-      ThresholdCpu: 700
-      ThresholdMemory: 1400
-      ThresholdCount: 2
   ECSReservationMap:
     Staging:
       BackendCpu: 128
@@ -204,9 +195,6 @@ Resources:
         SecretsInstanceAccessPolicyArn:
           Fn::ImportValue:
             !Sub "${SecretsStackName}-SecretsInstanceAccessPolicyArn"
-        ThresholdCpu: !FindInMap [ASGScalingMap, !Ref EnvironmentType, ThresholdCpu]
-        ThresholdMemory: !FindInMap [ASGScalingMap, !Ref EnvironmentType, ThresholdMemory]
-        ThresholdCount: !FindInMap [ASGScalingMap, !Ref EnvironmentType, ThresholdCount]
       TemplateURL: !Join ["", ["http://s3", !If [IsUsEast1, "", "-"], !If [IsUsEast1, "", !Ref "AWS::Region"], ".amazonaws.com/", "Fn::ImportValue": !Sub "${InfrastructureStorageStackName}-InfrastructureSourceBucket", "/", !Ref InfrastructureGitCommit, "/stacks/ecs.yml"]]
       TimeoutInMinutes: "5"
   LoadBalancersStack:

--- a/utility/lambdas/ecs-asg-sizer/lambda_function.py
+++ b/utility/lambdas/ecs-asg-sizer/lambda_function.py
@@ -1,118 +1,137 @@
-import boto3
-import json
+# Invoked by: TBD
+# Returns: Error or status message
+#
+#  Make an ASG the perfect size for an ECS cluster
+
 import os
+import boto3
 
 session = boto3.session.Session()
-asgClient = session.client(service_name='autoscaling')
-ecsClient = session.client(service_name='ecs')
+asg_client = session.client(service_name='autoscaling')
+ecs_client = session.client(service_name='ecs')
 
-#
-# Make an ASG the perfect size for an ECS cluster
-#
+
 def lambda_handler(event, context):
-    asgName = get_env('ASG_NAME')
-    clusterName = get_env('ECS_CLUSTER')
-    thresholdCpu = int(get_env('THRESHOLD_CPU'))
-    thresholdMemory = int(get_env('THRESHOLD_MEMORY'))
-    thresholdCount = int(get_env('THRESHOLD_COUNT'))
-    dryRun = True if 'DRY_RUN' in os.environ else False
+    ASG_NAME = get_env('ASG_NAME')
+    ECS_CLUSTER = get_env('ECS_CLUSTER')
+    MAX_CPU = int(get_env('THRESHOLD_CPU'))
+    MAX_MEM = int(get_env('THRESHOLD_MEMORY'))
+    MAX_COUNT = int(get_env('THRESHOLD_COUNT'))
+    DRY_RUN = True if 'DRY_RUN' in os.environ else False
 
-    usages = get_usages(clusterName)
-    log_debug('Targeting threshold {0}x {1} cpu / {2} mem'.format(thresholdCount, thresholdCpu, thresholdMemory))
+    usages = get_usages(ECS_CLUSTER)
+    log_debug(f'Targeting {MAX_COUNT}x [{MAX_CPU} cpu / {MAX_MEM} mem]')
     for usage in usages:
-        log_debug('    {0} - {1} / {2}'.format(usage['id'], usage['remainingCpu'], usage['remainingMemory']))
+        log_debug(f"    {usage['id']} - {usage['cpu']} / {usage['mem']}")
     if len(usages) == 0:
-        log_error('No instances running in cluster {0}'.format())
+        log_error(f'No instances running in cluster {ECS_CLUSTER}')
 
     # return early if already scaling
-    reason = is_scaling(asgName, len(usages))
-    if reason: log_debug('Already scaling: {0}'.format(reason)); return
+    reason = is_scaling(ASG_NAME, len(usages))
+    if reason:
+        log_debug(f'Already scaling: {reason}')
+        return
 
     # how many THRESHOLD-sized tasks can fit in this cluster
-    slotsAvailable = 0
+    num_slots = 0
     for usage in usages:
-        cpu = usage['remainingCpu']
-        mem = usage['remainingMemory']
-        while cpu >= thresholdCpu and mem >= thresholdMemory:
-            slotsAvailable += 1
-            cpu -= thresholdCpu
-            mem -= thresholdMemory
+        cpu = usage['cpu']
+        mem = usage['mem']
+        while cpu >= MAX_CPU and mem >= MAX_MEM:
+            num_slots += 1
+            cpu -= MAX_CPU
+            mem -= MAX_MEM
 
     # calculate how many THRESHOLD-sized tasks could fit on 1 instance
-    totalCpu = usages[0]['totalCpu']
-    totalMemory = usages[0]['totalMemory']
-    slotsPerInstance = 0
-    while totalCpu > 0 and totalMemory > 0:
-        slotsPerInstance += 1
-        totalCpu -= thresholdCpu
-        totalMemory -= thresholdMemory
+    total_cpu = usages[0]['tcpu']
+    total_memory = usages[0]['tmem']
+    slots_per_instance = 0
+    while total_cpu > 0 and total_memory > 0:
+        slots_per_instance += 1
+        total_cpu -= MAX_CPU
+        total_memory -= MAX_MEM
 
     # scale!
-    msg = '{0} slots available ({1}/instance)'.format(slotsAvailable, slotsPerInstance)
-    if slotsAvailable < thresholdCount:
+    msg = f'{num_slots} slots available ({slots_per_instance}/instance)'
+    if num_slots < MAX_COUNT:
         log_info('Scale UP: ' + msg)
-        scale_asg(asgName, 1, dryRun)
-    elif (slotsAvailable - thresholdCount - slotsPerInstance) > 0:
+        scale_asg(ASG_NAME, 1, DRY_RUN)
+    elif (num_slots - MAX_COUNT - slots_per_instance) > 0:
         log_info('Scale DOWN: ' + msg)
-        scale_asg(asgName, -1, dryRun)
+        scale_asg(ASG_NAME, -1, DRY_RUN)
     else:
         log_debug('No Change: ' + msg)
 
-# logging functions
-def log_debug(msg): print('[DEBUG] ' + msg)
-def log_info(msg): print('[INFO] ' + msg)
-def log_warn(msg): print('[WARN] ' + msg)
-def log_error(msg): print('[ERROR] ' + msg); raise Exception(msg)
 
-# get env or raise
+def log_debug(msg): print('[DEBUG] ' + msg)
+
+
+def log_info(msg): print('[INFO] ' + msg)
+
+
+def log_warn(msg): print('[WARN] ' + msg)
+
+
+def log_error(msg):
+    print('[ERROR] ' + msg)
+    raise Exception(msg)
+
+
 def get_env(name):
     if name in os.environ:
         return os.environ[name]
     else:
-        log_error('Missing env {0}'.format(name))
+        log_error(f'Missing env {name}')
 
-# check asg for in-progress changes
-def is_scaling(asgName, ecsClusterCount):
-    groups = asgClient.describe_auto_scaling_groups(AutoScalingGroupNames=[asgName])
+
+def is_scaling(asg_name, ecs_cluster_count):
+    groups = asg_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[asg_name])
     if len(groups['AutoScalingGroups']) != 1:
-        log_error('Invalid asg name {0}'.format(asgName))
+        log_error(f'Invalid asg name {asg_name}')
     group = groups['AutoScalingGroups'][0]
     for instance in group['Instances']:
         state = instance['LifecycleState']
         if state != 'InService' and state != 'Terminated':
-            return 'lifecycle state {0}'.format(state)
+            return f'lifecycle state {state}'
     if len(group['Instances']) != group['DesiredCapacity']:
         return 'waiting for ASG instance count'
-    if len(group['Instances']) != ecsClusterCount:
+    if len(group['Instances']) != ecs_cluster_count:
         return 'waiting for ECS agent connection'
 
-# get an array of usages from ECS
+
 def get_usages(clusterName):
-    instanceList = ecsClient.list_container_instances(cluster=clusterName)
-    instanceArns = instanceList['containerInstanceArns']
-    details = ecsClient.describe_container_instances(cluster=clusterName, containerInstances=instanceArns)
+    instance_list = ecs_client.list_container_instances(cluster=clusterName)
+    instance_arns = instance_list['containerInstanceArns']
+    details = ecs_client.describe_container_instances(
+        cluster=clusterName, containerInstances=instance_arns)
     return list(map(get_usage, details['containerInstances']))
 
-# format ECS instance usage info
+
 def get_usage(details):
+    rem = details['remainingResources']
+    reg = details['registeredResources']
     return {
         'id': details['ec2InstanceId'],
-        'remainingCpu': next(res['integerValue'] for res in details['remainingResources'] if res['name'] == 'CPU'),
-        'remainingMemory': next(res['integerValue'] for res in details['remainingResources'] if res['name'] == 'MEMORY'),
-        'totalCpu': next(res['integerValue'] for res in details['registeredResources'] if res['name'] == 'CPU'),
-        'totalMemory': next(res['integerValue'] for res in details['registeredResources'] if res['name'] == 'MEMORY'),
+        'cpu': next(r['integerValue'] for r in rem if r['name'] == 'CPU'),
+        'mem': next(r['integerValue'] for r in rem if r['name'] == 'MEMORY'),
+        'tcpu': next(r['integerValue'] for r in reg if r['name'] == 'CPU'),
+        'tmem': next(r['integerValue'] for r in reg if r['name'] == 'MEMORY'),
     }
 
-# update the ASG desired count
-def scale_asg(asgName, delta, dryRun):
-    group = asgClient.describe_auto_scaling_groups(AutoScalingGroupNames=[asgName])['AutoScalingGroups'][0]
+
+def scale_asg(asg_name, delta, dry_run):
+    group = asg_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[asg_name])['AutoScalingGroups'][0]
     desired = group['DesiredCapacity'] + delta
     if desired > group['MaxSize']:
         log_warn('Already at max-size')
     elif desired < group['MinSize']:
         log_warn('Already at min-size')
-    elif dryRun:
-        log_debug('DRY RUN desired capacity to {0}'.format(desired))
+    elif dry_run:
+        log_debug(f'DRY RUN desired capacity to {desired}')
     else:
-        asgClient.set_desired_capacity(AutoScalingGroupName=asgName, DesiredCapacity=desired, HonorCooldown=False)
-        log_debug('Updated desired capacity to {0}'.format(desired))
+        asg_client.set_desired_capacity(AutoScalingGroupName=asg_name,
+                                        DesiredCapacity=desired,
+                                        HonorCooldown=False)
+        log_debug(f'Updated desired capacity to {desired}')

--- a/utility/lambdas/ecs-asg-sizer/lambda_function.py
+++ b/utility/lambdas/ecs-asg-sizer/lambda_function.py
@@ -1,0 +1,115 @@
+import boto3
+import json
+import os
+
+session = boto3.session.Session()
+asgClient = session.client(service_name='autoscaling')
+ecsClient = session.client(service_name='ecs')
+
+#
+# Make an ASG the perfect size for an ECS cluster
+#
+def lambda_handler(event, context):
+    asgName = get_env('ASG_NAME')
+    clusterName = get_env('ECS_CLUSTER')
+    thresholdCpu = int(get_env('THRESHOLD_CPU'))
+    thresholdMemory = int(get_env('THRESHOLD_MEMORY'))
+    thresholdCount = int(get_env('THRESHOLD_COUNT'))
+
+    usages = get_usages(clusterName)
+    log_debug('Targeting threshold {0}x {1} cpu / {2} mem'.format(thresholdCount, thresholdCpu, thresholdMemory))
+    for usage in usages:
+        log_debug('    {0} - {1} / {2}'.format(usage['id'], usage['remainingCpu'], usage['remainingMemory']))
+    if len(usages) == 0:
+        log_error('No instances running in cluster {0}'.format())
+
+    # return early if already scaling
+    reason = is_scaling(asgName, len(usages))
+    if reason: log_debug('Already scaling: {0}'.format(reason)); return
+
+    # how many THRESHOLD-sized tasks can fit in this cluster
+    slotsAvailable = 0
+    for usage in usages:
+        cpu = usage['remainingCpu']
+        mem = usage['remainingMemory']
+        while cpu >= thresholdCpu and mem >= thresholdMemory:
+            slotsAvailable += 1
+            cpu -= thresholdCpu
+            mem -= thresholdMemory
+
+    # calculate how many THRESHOLD-sized tasks could fit on 1 instance
+    totalCpu = usages[0]['totalCpu']
+    totalMemory = usages[0]['totalMemory']
+    slotsPerInstance = 0
+    while totalCpu > 0 and totalMemory > 0:
+        slotsPerInstance += 1
+        totalCpu -= thresholdCpu
+        totalMemory -= thresholdMemory
+
+    # scale!
+    msg = '{0} slots available ({1}/instance)'.format(slotsAvailable, slotsPerInstance)
+    if slotsAvailable < thresholdCount:
+        log_info('Scale UP: ' + msg)
+        scale_asg(asgName, 1)
+    elif (slotsAvailable - thresholdCount - slotsPerInstance) > 0:
+        log_info('Scale DOWN: ' + msg)
+        scale_asg(asgName, -1)
+    else:
+        log_debug('No Change: ' + msg)
+
+# logging functions
+def log_debug(msg): print '[DEBUG] ' + msg
+def log_info(msg): print '[INFO] ' + msg
+def log_warn(msg): print '[WARN] ' + msg
+def log_error(msg): print '[ERROR] ' + msg; raise Exception(msg)
+
+# get env or raise
+def get_env(name):
+    if name in os.environ:
+        return os.environ[name]
+    else:
+        log_error('Missing env {0}'.format(name))
+
+# check asg for in-progress changes
+def is_scaling(asgName, ecsClusterCount):
+    groups = asgClient.describe_auto_scaling_groups(AutoScalingGroupNames=[asgName])
+    if len(groups['AutoScalingGroups']) != 1:
+        log_error('Invalid asg name {0}'.format(asgName))
+    group = groups['AutoScalingGroups'][0]
+    for instance in group['Instances']:
+        state = instance['LifecycleState']
+        if state != 'InService' and state != 'Terminated':
+            return 'lifecycle state {0}'.format(state)
+    if len(group['Instances']) != group['DesiredCapacity']:
+        return 'waiting for ASG instance count'
+    if len(group['Instances']) != ecsClusterCount:
+        return 'waiting for ECS agent connection'
+
+# get an array of usages from ECS
+def get_usages(clusterName):
+    instanceList = ecsClient.list_container_instances(cluster=clusterName)
+    instanceArns = instanceList['containerInstanceArns']
+    details = ecsClient.describe_container_instances(cluster=clusterName, containerInstances=instanceArns)
+    return map(get_usage, details['containerInstances'])
+
+# format ECS instance usage info
+def get_usage(details):
+    return {
+        'id': details['ec2InstanceId'],
+        'remainingCpu': next(res['integerValue'] for res in details['remainingResources'] if res['name'] == 'CPU'),
+        'remainingMemory': next(res['integerValue'] for res in details['remainingResources'] if res['name'] == 'MEMORY'),
+        'totalCpu': next(res['integerValue'] for res in details['registeredResources'] if res['name'] == 'CPU'),
+        'totalMemory': next(res['integerValue'] for res in details['registeredResources'] if res['name'] == 'MEMORY'),
+    }
+
+# update the ASG desired count
+def scale_asg(asgName, delta):
+    group = asgClient.describe_auto_scaling_groups(AutoScalingGroupNames=[asgName])['AutoScalingGroups'][0]
+    desired = group['DesiredCapacity'] + delta
+    if desired > group['MaxSize']:
+        log_warn('Already at max-size')
+    elif desired < group['MinSize']:
+        log_warn('Already at min-size')
+    else:
+        asgClient.set_desired_capacity(AutoScalingGroupName=asgName, DesiredCapacity=desired, HonorCooldown=False)
+        log_debug('Updated desired capacity to {0}'.format(desired))


### PR DESCRIPTION
See #10.  Attempts to scale an auto-scaling-group to most effectively fit an ECS cluster.

The 3 "threshold" ENVs (cpu/memory/count) configure a theoretical task that you always want to leave room for on the cluster.  It should have reservations at least as big as the largest task running on your cluster.

For instance, if you set those to 700/1400/2, this lambda would make sure there was always room for 2 more tasks on the cluster, with 700 cpu and 1400 memory.  If not, it scales up by 1.

Scaling down is a bit more complex.  You can't know which instance/tasks the ASG will kill when scaling down, so just assume it's completely full of these big "threshold" tasks.  So if 1 instance can hold 4 threshold tasks ... and I need space for 2 more tasks so we don't immediately scale back up ... there must be at least 6 slots available in the cluster in order for us to scale down.