### PR TITLE
ECS connection timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .deploy
 node_modules/
 package-lock.json
+__pycache__

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -616,6 +616,8 @@ Resources:
               - Effect: "Allow"
                 Resource: "*"
                 Action:
+                  - ec2:DescribeInstances
+                  - ec2:TerminateInstances
                   - ecs:DescribeContainerInstances
                   - ecs:DescribeServices
                   - ecs:DescribeTaskDefinition

--- a/utility/lambdas/ecs-asg-sizer/lambda_function.py
+++ b/utility/lambdas/ecs-asg-sizer/lambda_function.py
@@ -227,8 +227,8 @@ def scale_asg(asg_name, delta, dry_run):
         'prev': group['DesiredCapacity'],
         'next': group['DesiredCapacity'] + delta,
     }
-    is_ok = (asg_data['next'] > asg_data['min'] and
-             asg_data['next'] < asg_data['max'])
+    is_ok = (asg_data['next'] >= asg_data['min'] and
+             asg_data['next'] <= asg_data['max'])
     if is_ok and asg_data['next'] != asg_data['prev'] and not dry_run:
         asg_client.set_desired_capacity(AutoScalingGroupName=asg_name,
                                         DesiredCapacity=asg_data['next'],


### PR DESCRIPTION
Seeing an issue where EC2 instances connect to the ASG (show up as healthy there), but the ecs-agent never connects.  So the sizer lambda was just spinning forever, waiting for that agent to connect.

This now looks at how long those instances have been up.  If more than 10 minutes passes without it connecting to ECS, it gets terminated.