### PR TITLE
Codebuild secrets

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -154,6 +154,9 @@ Resources:
                   - "ecr:PutImage"
                 Resource:
                   - !Sub "arn:aws:ecr:us-east-1:${AWS::AccountId}:repository/*"
+      ManagedPolicyArns:
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/key-prx-infrastructure-${AWS::Region}-secrets-instance-access-policy"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/key-prx-infrastructure-${AWS::Region}-secrets-instance-decrypt-policy"
   CodeBuildProject:
     Type: "AWS::CodeBuild::Project"
     Properties:

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -15,6 +15,7 @@ Metadata:
         Parameters:
           - InfrastructureStorageStackName
           - InfrastructureNotificationsStackName
+          - InfrastructureSecretsStackName
       - Label:
           default: Template Configuration
         Parameters:
@@ -33,6 +34,8 @@ Metadata:
         default: Storage stack name
       InfrastructureNotificationsStackName:
         default: Notifications stack name
+      InfrastructureSecretsStackName:
+        default: Secrets stack name
       InfrastructureConfigStagingKey:
         default: Staging S3 object key
       GitHubToken:
@@ -49,6 +52,10 @@ Parameters:
   InfrastructureNotificationsStackName:
     Default: infrastructure-notifications
     Description: The name of a previously launched notifications stack
+    Type: String
+  InfrastructureSecretsStackName:
+    Default: infrastructure-secrets
+    Description: The name of a previously launched infrastructure secrets stack
     Type: String
   InfrastructureConfigStagingKey:
     Default: template-config-staging.zip
@@ -155,8 +162,10 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:ecr:us-east-1:${AWS::AccountId}:repository/*"
       ManagedPolicyArns:
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/key-prx-infrastructure-${AWS::Region}-secrets-instance-access-policy"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/key-prx-infrastructure-${AWS::Region}-secrets-instance-decrypt-policy"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureSecretsStackName}-SecretsInstanceAccessPolicyArn"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureSecretsStackName}-SecretsInstanceDecryptPolicyArn"
   CodeBuildProject:
     Type: "AWS::CodeBuild::Project"
     Properties:


### PR DESCRIPTION
Give codebuild access to aws-secrets.  (Assumes names of managed policies will stay the same).