### PR TITLE
Analytics ingest lambdas

### DIFF
--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -119,7 +119,6 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref AnalyticsPingbacksLambdaFunction
-          Value: !Ref AnalyticsBigqueryLambdaFunction
   AnalyticsRedisErrorAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -1,0 +1,142 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Analytics ingest lambda functions
+Parameters:
+  OpsErrorMessagesSnsTopicArn:
+    Type: String
+  CodeS3Bucket:
+    Type: String
+  CodeS3ObjectVersion:
+    Type: String
+  EnvironmentTypeAbbreviation:
+    Type: String
+Resources:
+  # IAM Roles
+  AnalyticsLambdaExecutionIAMRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+            - Effect: "Allow"
+              Principal:
+                Service:
+                  - "lambda.amazonaws.com"
+              Action:
+                - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+  # Lambda Functions
+  AnalyticsBigqueryLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: !Sub "lambda/PRX-analytics-ingest-lambda.zip"
+        S3ObjectVersion: !Ref CodeS3ObjectVersion
+      Description: Dovetail analytics to BigQuery
+      Environment:
+        Variables:
+          BQ_IMPRESSIONS_TABLE: "impressions"
+          BQ_DOWNLOADS_TABLE: "downloads"
+          BQ_PROJECT_ID: "prx-metrics"
+      Handler: index.handler
+      MemorySize: 256
+      Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
+      Runtime: nodejs6.10
+      Timeout: 30
+  AnalyticsPingbacksLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: !Sub "lambda/PRX-analytics-ingest-lambda.zip"
+        S3ObjectVersion: !Ref CodeS3ObjectVersion
+      Description: Dovetail analytics http pingbacks
+      Environment:
+        Variables:
+          PINGBACKS: "true"
+      Handler: index.handler
+      MemorySize: 256
+      Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
+      Runtime: nodejs6.10
+      Timeout: 30
+  AnalyticsRedisLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: !Sub "lambda/PRX-analytics-ingest-lambda.zip"
+        S3ObjectVersion: !Ref CodeS3ObjectVersion
+      Description: Dovetail analytics redis increments
+      Environment:
+        Variables:
+          REDIS_TTL: "7200"
+      Handler: index.handler
+      MemorySize: 256
+      Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
+      Runtime: nodejs6.10
+      Timeout: 30
+  # Lambda Alarms
+  AnalyticsBigqueryErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "${EnvironmentTypeAbbreviation} analytics bigquery lambda errors"
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription:
+        Too many analytics bigquery lambda errors
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: "1"
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: "300"
+      Statistic: Sum
+      Threshold: "0"
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AnalyticsBigqueryLambdaFunction
+  AnalyticsPingbacksErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "${EnvironmentTypeAbbreviation} analytics pingbacks lambda errors"
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription:
+        Too many analytics pingbacks lambda errors
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: "1"
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: "300"
+      Statistic: Sum
+      Threshold: "0"
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AnalyticsPingbacksLambdaFunction
+          Value: !Ref AnalyticsBigqueryLambdaFunction
+  AnalyticsRedisErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "${EnvironmentTypeAbbreviation} analytics redis lambda errors"
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription:
+        Too many analytics redis lambda errors
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: "1"
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: "300"
+      Statistic: Sum
+      Threshold: "0"
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AnalyticsRedisLambdaFunction

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -79,6 +79,8 @@ Parameters:
     Type: String
   UploadLambdaCodeS3ObjectVersion:
     Type: String
+  AnalyticsIngestLambdaCodeS3ObjectVersion:
+    Type: String
   PRXUploadAccessKey:
     Type: String
   # Parameter Overrides
@@ -782,6 +784,29 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", ["http://s3", !If [IsUsEast1, "", "-"], !If [IsUsEast1, "", !Ref "AWS::Region"], ".amazonaws.com/", "Fn::ImportValue": !Sub "${InfrastructureStorageStackName}-InfrastructureSourceBucket", "/", !Ref InfrastructureGitCommit, "/stacks/metrics.prx.org.yml"]]
+      TimeoutInMinutes: "5"
+  #### analytics-ingest-lambda #################################################
+  AnalyticsIngestLambdaStack:
+    Type: "AWS::CloudFormation::Stack"
+    Properties:
+      NotificationARNs:
+        - Fn::ImportValue:
+            !Sub "${NotificationsStackName}-CloudFormationNotificationSnsTopic"
+      Parameters:
+        OpsErrorMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${NotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+        EnvironmentTypeAbbreviation: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation]
+        CodeS3Bucket:
+          Fn::ImportValue:
+              !Sub "${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket"
+        CodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
+      Tags:
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TemplateURL: !Join ["", ["http://s3", !If [IsUsEast1, "", "-"], !If [IsUsEast1, "", !Ref "AWS::Region"], ".amazonaws.com/", "Fn::ImportValue": !Sub "${InfrastructureStorageStackName}-InfrastructureSourceBucket", "/", !Ref InfrastructureGitCommit, "/stacks/analytics-ingest-lambda.yml"]]
       TimeoutInMinutes: "5"
 Outputs:
   VPCCertificateArn:


### PR DESCRIPTION
Creates the 3 analytics lambdas, for bigquery/pingbacks/redis.

- Not sure the alarms are what we actually want
- Does not include any log metrics (tend to use these more than error counts in our monitoring)
- Does not include any actual secret ENVs
  - Will try adding these manually, and check if CFN blows them away on subsequent deploys
- Does not include any triggers
  - Don't actually want kinesis triggers in CFN, yet