### PR TITLE
Noisy origin-pull 403s

### DIFF
--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -57,13 +57,13 @@ Resources:
         Aliases:
           - !Ref DistributionDomain
         CustomErrorResponses:
-          # unrecognized uri, and s3 object not found
-          - ErrorCachingMinTTL: 300
-            ErrorCode: 403
-            ResponseCode: 404
-            ResponsePagePath: /404.html
-          # recognized uri, arrangement not in redis
+          # dovetail uploaded, but file wasn't there!
           - ErrorCachingMinTTL: 0
+            ErrorCode: 403
+            ResponseCode: 500
+            ResponsePagePath: /500.html
+          # unrecognized uri or arrangement not in redis
+          - ErrorCachingMinTTL: 300
             ErrorCode: 404
           # lambda caught an error
           - ErrorCachingMinTTL: 0

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -1,6 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  Creates a CloudFront distribution to origin-pull from a Dovetail ALB.
+  Creates a CloudFront distribution to origin-pull from a Dovetail S3 bucket,
+  with an origin-request Lambda to do the actual file stitching.
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/cdn/feeder-cdn.yml
+++ b/cdn/feeder-cdn.yml
@@ -62,7 +62,7 @@ Resources:
           SslSupportMethod: sni-only
       Tags:
         - Key: Project
-          Value: Dovetail
+          Value: feeder
         - Key: "prx:cloudformation:stack-name"
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"

--- a/cdn/feeder-cdn.yml
+++ b/cdn/feeder-cdn.yml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Feeder bucket CDN (or really any plain S3-bucket CDN)
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Distribution Parameters
+        Parameters:
+          - OriginBucket
+          - DistributionDomain
+          - DistributionDomain2
+          - CertificateArn
+    ParameterLabels:
+      OriginBucket:
+        default: Origin S3 Bucket
+      DistributionDomain:
+        default: Domain Name
+      DistributionDomain2:
+        default: Alternate Domain Name
+      CertificateArn:
+        default: ACM Certificate Arn
+Parameters:
+  OriginBucket:
+    Type: String
+    Description: eg. staging-prx-feed.s3.amazonaws.com, prx-feed.s3.amazonaws.com
+  DistributionDomain:
+    Type: String
+    Description: eg. f-staging.prxu.org, f.prxu.org
+  DistributionDomain2:
+    Type: String
+    Description: eg. f2-staging.prxu.org, f2.prxu.org
+  CertificateArn:
+    Type: String
+    Description: eg. arn:aws:acm:<region>:<account>:certificate/<guid>
+Resources:
+  CloudFrontDistribution:
+    Type: "AWS::CloudFront::Distribution"
+    Properties:
+      DistributionConfig:
+        Aliases:
+          - !Ref DistributionDomain
+          - !Ref DistributionDomain2
+        CustomErrorResponses:
+          - ErrorCachingMinTTL: 0
+            ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: /404.html
+        DefaultCacheBehavior:
+          AllowedMethods: [HEAD, GET]
+          CachedMethods: [HEAD, GET]
+          Compress: false
+          DefaultTTL: 86400
+          ForwardedValues:
+            QueryString: false
+          TargetOriginId: feeder-s3-bucket
+          ViewerProtocolPolicy : allow-all
+        DefaultRootObject: index.html
+        Enabled: true
+        HttpVersion: http2
+        IPV6Enabled: true
+        Origins:
+          - DomainName: !Ref OriginBucket
+            Id: feeder-s3-bucket
+            S3OriginConfig: {}
+        PriceClass: PriceClass_200
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          SslSupportMethod: sni-only
+      Tags:
+        - Key: Project
+          Value: Dovetail
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId

--- a/cdn/feeder-cdn.yml
+++ b/cdn/feeder-cdn.yml
@@ -9,15 +9,12 @@ Metadata:
         Parameters:
           - OriginBucket
           - DistributionDomain
-          - DistributionDomain2
           - CertificateArn
     ParameterLabels:
       OriginBucket:
         default: Origin S3 Bucket
       DistributionDomain:
         default: Domain Name
-      DistributionDomain2:
-        default: Alternate Domain Name
       CertificateArn:
         default: ACM Certificate Arn
 Parameters:
@@ -27,9 +24,6 @@ Parameters:
   DistributionDomain:
     Type: String
     Description: eg. f-staging.prxu.org, f.prxu.org
-  DistributionDomain2:
-    Type: String
-    Description: eg. f2-staging.prxu.org, f2.prxu.org
   CertificateArn:
     Type: String
     Description: eg. arn:aws:acm:<region>:<account>:certificate/<guid>
@@ -40,7 +34,6 @@ Resources:
       DistributionConfig:
         Aliases:
           - !Ref DistributionDomain
-          - !Ref DistributionDomain2
         CustomErrorResponses:
           - ErrorCachingMinTTL: 0
             ErrorCode: 403


### PR DESCRIPTION
Per PRX/dovetail-stitch-lambda#9 ... going to start returning 404s early.  And a 403 really means that the stitch-lambda uploaded a file, but the origin-pull couldn't access it (S3 eventual read consistency).

Also added the feeder `f.prxu.org` and `f-staging.prxu.org` CDNs into this PR.  Haven't switched the DNS from Highwinds yet, but they're in place when we're ready.