### PR TITLE
adds template for RDS mediajoint instance

### DIFF
--- a/db/rds-mediajoint.yml
+++ b/db/rds-mediajoint.yml
@@ -76,8 +76,7 @@ Parameters:
       The "MySQL_replication_tunnel" EC2 security group that contains the EC2 instance acting as the replication tunnel
       https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#SecurityGroups:sort=groupId
     Default: default
-    Type: String
-    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Type: AWS::EC2::SecurityGroup::Id
     ConstraintDescription: must be a valid security group id.
   RDSSubnetGroup:
     Description: >-
@@ -111,8 +110,14 @@ Resources:
       MasterUserPassword: !Ref DBPassword
       MultiAZ: !Ref MultiAZ
       Tags:
-        - Key: Name
-          Value: Master Database
+        - Key: Project
+          Value: cms.prx.org
+        - Key: Environment
+          Value: Production
+        - Key: 'prx:cloudformation:stack-name'
+          Value: !Ref AWS::StackName
+        - Key: 'prx:cloudformation:stack-id'
+          Value: !Ref AWS::StackId
       DBSubnetGroupName: !Ref RDSSubnetGroup
       VPCSecurityGroups: [!Ref EC2SecurityGroup]
 # replication won't connect via tunnel if false      

--- a/stacks/rds-mediajoint.yml
+++ b/stacks/rds-mediajoint.yml
@@ -1,0 +1,124 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  AWS CloudFormation RDS Template: Template to create RDS MySQL v5.5 instance.
+Parameters:
+  DBName:
+    Default: my_database
+    Description: The database schema name
+    Type: String
+    MinLength: '1'
+    MaxLength: '64'
+    AllowedPattern: '[a-zA-Z][a-zA-Z0-9\-_]*'
+    ConstraintDescription: >-
+      must begin with a letter and contain only alphanumeric characters, dash,
+      or underscore.
+  DBUser:
+    NoEcho: 'true'
+    Description: The database admin account username
+    Type: String
+    MinLength: '1'
+    MaxLength: '16'
+    AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
+    ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+  DBPassword:
+    NoEcho: 'true'
+    Description: The database admin account password
+    Type: String
+    MinLength: '1'
+    MaxLength: '41'
+    AllowedPattern: '[a-zA-Z0-9]+'
+    ConstraintDescription: must contain only alphanumeric characters.
+  DBAllocatedStorage:
+    Default: '20'
+    Description: The size of the database (Gb)
+    Type: Number
+    MinValue: '5'
+    MaxValue: '1024'
+    ConstraintDescription: must be between 5 and 1024Gb.
+  DBInstanceClass:
+    Description: The database instance type
+    Type: String
+    Default: db.t2.small
+    AllowedValues:
+      - db.t1.micro
+      - db.m1.small
+      - db.m1.medium
+      - db.m1.large
+      - db.m1.xlarge
+      - db.m2.xlarge
+      - db.m2.2xlarge
+      - db.m2.4xlarge
+      - db.m3.medium
+      - db.m3.large
+      - db.m3.xlarge
+      - db.m3.2xlarge
+      - db.m4.large
+      - db.m4.xlarge
+      - db.m4.2xlarge
+      - db.m4.4xlarge
+      - db.m4.10xlarge
+      - db.r3.large
+      - db.r3.xlarge
+      - db.r3.2xlarge
+      - db.r3.4xlarge
+      - db.r3.8xlarge
+      - db.m2.xlarge
+      - db.m2.2xlarge
+      - db.m2.4xlarge
+      - db.cr1.8xlarge
+      - db.t2.micro
+      - db.t2.small
+      - db.t2.medium
+      - db.t2.large
+    ConstraintDescription: must select a valid database instance type.
+  EC2SecurityGroup:
+    Description: >-
+      The "MySQL_replication_tunnel" EC2 security group that contains the EC2 instance acting as the replication tunnel
+      https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#SecurityGroups:sort=groupId
+    Default: default
+    Type: String
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    ConstraintDescription: must be a valid security group id.
+  RDSSubnetGroup:
+    Description: >-
+      The "Platform-Production" RDS subnet group name
+      https://console.aws.amazon.com/rds/home?region=us-east-1#db-subnet-groups:
+    Default: default
+    Type: String
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    ConstraintDescription: must be a valid subnet group name.  
+  MultiAZ:
+    Description: Multi-AZ master database
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    ConstraintDescription: must be true or false.
+Resources:
+  MasterDB:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+# 	CloudFormation cannot update a stack when a custom-named resource requires replacing.
+#      DBInstanceIdentifier: !Ref DBInstance
+      DBName: !Ref DBName
+      AllocatedStorage: !Ref DBAllocatedStorage
+      StorageType: gp2
+      DBInstanceClass: !Ref DBInstanceClass
+      Engine: MySQL
+      EngineVersion: 5.5.46
+      MasterUsername: !Ref DBUser
+      MasterUserPassword: !Ref DBPassword
+      MultiAZ: !Ref MultiAZ
+      Tags:
+        - Key: Name
+          Value: Master Database
+      DBSubnetGroupName: !Ref RDSSubnetGroup
+      VPCSecurityGroups: [!Ref EC2SecurityGroup]
+# replication won't connect via tunnel if false      
+      PubliclyAccessible: true
+    DeletionPolicy: Snapshot
+Outputs:
+  EC2Platform:
+    Description: Platform in which this stack is deployed
+    Value: EC2-VPC


### PR DESCRIPTION
intended to be run manually as follows:
`aws cloudformation update-stack --stack-name <stack name> --template-url <template url> --parameters ParameterKey=DBName,ParameterValue=mediajoint_production ParameterKey=DBUser,ParameterValue=<admin but not actually SUPER user> ParameterKey=DBPassword,ParameterValue=<admin user password> ParameterKey=DBAllocatedStorage,ParameterValue=<GB of storage> ParameterKey=DBInstanceClass,ParameterValue=<RDS tier> ParameterKey=EC2SecurityGroup,ParameterValue=<ssh tunnel security group id> ParameterKey=RDSSubnetGroup,ParameterValue=<Platform-Production subnet group name>`