### PR TITLE
Cloudfront CORS headers

### DIFF
--- a/cdn/feeder-cdn.yml
+++ b/cdn/feeder-cdn.yml
@@ -55,6 +55,9 @@ Resources:
         Origins:
           - DomainName: !Ref OriginBucket
             Id: feeder-s3-bucket
+            OriginCustomHeaders:
+              - HeaderName: Origin
+                HeaderValue: !Ref DistributionDomain
             S3OriginConfig: {}
         PriceClass: PriceClass_200
         ViewerCertificate:


### PR DESCRIPTION
Make sure CORS headers are always cached in cloudfront, by always setting an `Origin` when requesting files from S3.