### PR TITLE
Downsize prod cluster

### DIFF
--- a/stacks/castle.prx.org.yml
+++ b/stacks/castle.prx.org.yml
@@ -9,6 +9,7 @@ Mappings:
 Conditions:
   CreateStagingResources: !Equals [!Ref EnvironmentType, Staging]
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+  HasMemoryReservation: !Not [!Equals [!Ref ContainerMemoryReservation, ""]]
 Parameters:
   # VPC ########################################################################
   VPC:
@@ -48,6 +49,9 @@ Parameters:
     Type: String
   ContainerMemory:
     Type: String
+  ContainerMemoryReservation:
+    Type: String
+    Default: ""
   ContainerCpu:
     Type: String
   # Shared ENV #################################################################
@@ -137,6 +141,7 @@ Resources:
               awslogs-group: !Ref CastleLogGroup
               awslogs-region: !Ref AWS::Region
           Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
           Name: !FindInMap [Shared, Container, name]
           PortMappings:
             - HostPort: 0

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -61,13 +61,13 @@ Mappings:
       DovetailMaxCount: 1
       ProxyCount: 1
     Staging:
-      DovetailMinCount: 1
+      DovetailMinCount: 2
       DovetailMaxCount: 4
-      ProxyCount: 2
+      ProxyCount: 1
     Production:
-      DovetailMinCount: 10
+      DovetailMinCount: 8
       DovetailMaxCount: 30
-      ProxyCount: 4
+      ProxyCount: 2
 Resources:
   DovetailSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -231,6 +231,15 @@ Resources:
                 Action:
                   - "ec2:DescribeTags"
                 Resource: "*"
+        - PolicyName: ModifyCreditSpecificationPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:ModifyInstanceCreditSpecification
+                  - ec2:DescribeInstanceCreditSpecifications
+                Resource: "*"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
         - !Ref SecretsInstanceDecryptPolicyArn
@@ -384,11 +393,6 @@ Resources:
                 aws cloudwatch put-metric-data --namespace EC2 --dimensions InstanceId=$AWSINSTANCEID --value $data --unit Bytes --metric-name DockerMetadataSpace --region $AWSREGION
                 aws cloudwatch put-metric-data --namespace EC2 --dimensions AutoScalingGroup=$AWSASG --value $data --unit Bytes --metric-name DockerMetadataSpace --region $AWSREGION
               mode: "000755"
-            # "/etc/newrelic-infra.yml":
-            #   content: !Sub |
-            #     license_key: ${NewRelicLicenseKey}
-            #     custom_attributes:
-            #       environment: ${EnvironmentType}
           commands:
             01_add_instance_to_cluster:
               command: !Sub |
@@ -401,13 +405,16 @@ Resources:
             03_fstrim_reclaim_disk:
               # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/CannotCreateContainerError.html
               command: "(crontab -uroot -l 2> /dev/null; echo '*/5 * * * * docker ps -qa | xargs docker inspect --format=\"{{ .State.Pid }}\" | xargs -IZ /sbin/fstrim /proc/Z/root/') | crontab -u root -"
-            # 04_set_newrelic_data:
-            #   command: "echo \"display_name: $(curl -ss http://169.254.169.254/latest/meta-data/instance-id)\" >> /etc/newrelic-infra.yml"
-            # 05_install_newrelic_infra:
-            #   command: |
-            #     sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
-            #     sudo yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
-            #     sudo yum install newrelic-infra -y
+            04_set_t2_unlimited:
+              command: !Sub |
+                #!/bin/bash
+                AWSREGION=`curl -ss http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region`
+                AWSINSTANCEID=`curl -ss http://169.254.169.254/latest/meta-data/instance-id`
+                AWSINSTANCETYPE=`curl -ss http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .instanceType`
+                if [[ "$AWSINSTANCETYPE" =~ ^t2.* ]]; then
+                  JSON="[{\"InstanceId\": \"${AWSINSTANCEID}\",\"CpuCredits\": \"unlimited\"}]"
+                  aws --region=$AWSREGION ec2 modify-instance-credit-specification --instance-credit-specification "${JSON}"
+                fi
           services:
             sysvinit:
               cfn-hup:

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -60,7 +60,7 @@ Mappings:
     Testing:
       InstanceType: t2.micro
       InstanceStorage: 22
-      AmiName: "amzn-ami-2017.09.k-amazon-ecs-optimized"
+      AmiName: "amzn-ami-2017.09.l-amazon-ecs-optimized"
       MinSize: "1"
       DefaultDesiredCapacity: "1"
       WarningThreshold: "2"
@@ -68,7 +68,7 @@ Mappings:
     Staging:
       InstanceType: t2.small
       InstanceStorage: 22
-      AmiName: "amzn-ami-2017.09.k-amazon-ecs-optimized"
+      AmiName: "amzn-ami-2017.09.l-amazon-ecs-optimized"
       MinSize: "2"
       DefaultDesiredCapacity: "5"
       WarningThreshold: "9"
@@ -76,7 +76,7 @@ Mappings:
     Production:
       InstanceType: t2.medium
       InstanceStorage: 72
-      AmiName: "amzn-ami-2017.09.k-amazon-ecs-optimized"
+      AmiName: "amzn-ami-2017.09.l-amazon-ecs-optimized"
       MinSize: "4"
       DefaultDesiredCapacity: "5"
       WarningThreshold: "35"

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -406,7 +406,7 @@ Resources:
               # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/CannotCreateContainerError.html
               command: "(crontab -uroot -l 2> /dev/null; echo '*/5 * * * * docker ps -qa | xargs docker inspect --format=\"{{ .State.Pid }}\" | xargs -IZ /sbin/fstrim /proc/Z/root/') | crontab -u root -"
             04_set_t2_unlimited:
-              command: !Sub |
+              command: |
                 #!/bin/bash
                 AWSREGION=`curl -ss http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region`
                 AWSINSTANCEID=`curl -ss http://169.254.169.254/latest/meta-data/instance-id`

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -74,7 +74,7 @@ Mappings:
       WarningThreshold: "9"
       MaxSize: "20"
     Production:
-      InstanceType: m4.large
+      InstanceType: t2.medium
       InstanceStorage: 72
       AmiName: "amzn-ami-2017.09.k-amazon-ecs-optimized"
       MinSize: "4"

--- a/stacks/jingle.prx.org.yml
+++ b/stacks/jingle.prx.org.yml
@@ -9,6 +9,7 @@ Mappings:
 Conditions:
   CreateStagingResources: !Equals [!Ref EnvironmentType, Staging]
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+  HasMemoryReservation: !Not [!Equals [!Ref ContainerMemoryReservation, ""]]
 Parameters:
   # VPC ########################################################################
   VPC:
@@ -48,6 +49,9 @@ Parameters:
     Type: String
   ContainerMemory:
     Type: String
+  ContainerMemoryReservation:
+    Type: String
+    Default: ""
   ContainerCpu:
     Type: String
   # Shared ENV #################################################################
@@ -137,6 +141,7 @@ Resources:
               awslogs-group: !Ref JingleLogGroup
               awslogs-region: !Ref AWS::Region
           Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
           Name: !FindInMap [Shared, Container, name]
           PortMappings:
             - HostPort: 0

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -115,7 +115,8 @@ Mappings:
   ECSReservationMap:
     Staging:
       BackendCpu: 128
-      BackendMemory: 650
+      BackendMemory: 1000
+      BackendMemoryReservation: 500
       FrontendCpu: 64
       FrontendMemory: 200
       DovetailCpu: 128
@@ -124,7 +125,8 @@ Mappings:
       DovetailNginxMemory: 400
     Production:
       BackendCpu: 200
-      BackendMemory: 1400
+      BackendMemory: 2000
+      BackendMemoryReservation: 1000
       FrontendCpu: 100
       FrontendMemory: 400
       DovetailCpu: 700
@@ -403,6 +405,7 @@ Resources:
         CastleEcrImageTag: !Ref CastleEcrImageTag
         CastleSecretsVersion: !Ref CastleSecretsVersion
         ContainerMemory: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemory]
+        ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
       Tags:
         - Key: "prx:cloudformation:stack-name"
@@ -445,6 +448,7 @@ Resources:
         JingleEcrImageTag: !Ref JingleEcrImageTag
         JingleSecretsVersion: !Ref JingleSecretsVersion
         ContainerMemory: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemory]
+        ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
       Tags:
         - Key: "prx:cloudformation:stack-name"
@@ -556,6 +560,7 @@ Resources:
         CreateWorker: "true"
         ContainerPort: 3000
         ContainerMemory: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemory]
+        ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
         HealthCheckPath: "/api/v1"
       Tags:
@@ -602,6 +607,7 @@ Resources:
         CreateWorker: "true"
         ContainerPort: 3000
         ContainerMemory: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemory]
+        ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
         HealthCheckPath: "/"
       Tags:
@@ -650,6 +656,7 @@ Resources:
         DesiredWorkersProduction: 1
         ContainerPort: 3000
         ContainerMemory: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemory]
+        ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
         HealthCheckPath: "/api/v1"
       Tags:
@@ -742,6 +749,7 @@ Resources:
         CreateWorker: "true"
         ContainerPort: 3000
         ContainerMemory: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemory]
+        ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
         HealthCheckPath: "/api/v1"
       Tags:
@@ -788,6 +796,7 @@ Resources:
         CreateWorker: "false"
         ContainerPort: 3000
         ContainerMemory: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemory]
+        ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
         HealthCheckPath: "/api/v1/certs"
       Tags:

--- a/stacks/web-alb-application.yml
+++ b/stacks/web-alb-application.yml
@@ -4,6 +4,7 @@ Description: >
 Conditions:
   CreateWorkerResources: !Equals [!Ref CreateWorker, true]
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+  HasMemoryReservation: !Not [!Equals [!Ref ContainerMemoryReservation, ""]]
 Parameters:
   # VPC ########################################################################
   VPC:
@@ -65,6 +66,9 @@ Parameters:
   ContainerMemory:
     Type: String
     Default: 500
+  ContainerMemoryReservation:
+    Type: String
+    Default: ""
   ContainerCpu:
     Type: String
     Default: 128
@@ -274,6 +278,7 @@ Resources:
               awslogs-group: !Ref WebLogGroup
               awslogs-region: !Ref AWS::Region
           Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
           Name: !Sub ${AppName}-web
           PortMappings:
             - HostPort: 0
@@ -340,6 +345,7 @@ Resources:
               awslogs-group: !Ref WorkerLogGroup
               awslogs-region: !Ref AWS::Region
           Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
           Name: !Sub ${AppName}-worker
           Command:
             - worker

--- a/stacks/web-application.yml
+++ b/stacks/web-application.yml
@@ -4,6 +4,7 @@ Description: >
 Conditions:
   CreateWorkerResources: !Equals [!Ref CreateWorker, true]
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+  HasMemoryReservation: !Not [!Equals [!Ref ContainerMemoryReservation, ""]]
 Parameters:
   # VPC ########################################################################
   VPC:
@@ -68,6 +69,9 @@ Parameters:
   ContainerMemory:
     Type: String
     Default: 500
+  ContainerMemoryReservation:
+    Type: String
+    Default: ""
   ContainerCpu:
     Type: String
     Default: 128
@@ -181,6 +185,7 @@ Resources:
               awslogs-group: !Ref WebLogGroup
               awslogs-region: !Ref AWS::Region
           Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
           Name: !Sub ${AppName}-web
           PortMappings:
             - HostPort: 0
@@ -249,6 +254,7 @@ Resources:
               awslogs-group: !Ref WorkerLogGroup
               awslogs-region: !Ref AWS::Region
           Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
           Name: !Sub ${AppName}-worker
           Command:
             - worker


### PR DESCRIPTION
See PRX/dovetail.prx.org#259

Currently we run around 8 `m4.large` instances in prod.  This is less necessary now that DT stitching is _mostly_ done in lambdas.  This moves the cluster back to `t2.medium` and changes some of the memory reservations to accommodate more tasks per instance.

Will want to disable prod deploys while testing this out in staging.  To make sure the t2 unlimited stuff actually works.