### PR TITLE
Add alarm for proxy 500s

### DIFF
--- a/stacks/proxy.prx.org.yml
+++ b/stacks/proxy.prx.org.yml
@@ -214,6 +214,30 @@ Resources:
       DomainName: !Ref ProductionRestApiDomainName
       RestApiId: !Ref ProxyRestApi
       Stage: prod
+  ApiGateway5XXAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[proxy.prx.org][${EnvironmentType}] 5XXErrors"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription: >
+        Too many 500 errors from the corporate site proxy
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} API"
+      EvaluationPeriods: "3"
+      MetricName: 5xxError
+      Namespace: AWS/ApiGateway
+      Period: "300"
+      Statistic: Sum
+      Threshold: "1"
+      TreatMissingData: notBreaching
 Outputs:
   ApiDomainName:
     Description: The custom API domain name


### PR DESCRIPTION
See PRX/proxy.prx.org#13.

Note: the ApiGateway does normally return ~10 500s a day, which are actually coming from proxying to squarespace:

```
[INFO] Proxy 500 POST corporate.prx.tech/api/1/wp-rum/record
```

I guess this is expected behavior then?  Certainly don't want to get into the habit of retrying things for squarespace.  This alarm should _not_ trigger on those, since they're fairly spread out through the day.

Also looked at the ApiGateway `Latency` metric, but it didn't seem very useful.  Would not have caught any issues we've seen thus far.