### PR TITLE
Clean up template errors

### DIFF
--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -131,12 +131,12 @@ Resources:
           Value: Global
         - Name: DistributionId
           Value: !Ref CloudFrontDistribution
-      EvaluationPeriods: "2"
+      EvaluationPeriods: 2
       MetricName: 4xxErrorRate
       Namespace: AWS/CloudFront
-      Period: "300"
+      Period: 300
       Statistic: Average
-      Threshold: "30"
+      Threshold: 30
       TreatMissingData: notBreaching
       Unit: Percent
   CloudFrontDistribution500Alarm:
@@ -161,12 +161,12 @@ Resources:
           Value: Global
         - Name: DistributionId
           Value: !Ref CloudFrontDistribution
-      EvaluationPeriods: "5"
+      EvaluationPeriods: 5
       MetricName: 5xxErrorRate
       Namespace: AWS/CloudFront
-      Period: "60"
+      Period: 60
       Statistic: Average
-      Threshold: "0.01"
+      Threshold: 0.01
       TreatMissingData: notBreaching
       Unit: Percent
 Outputs:

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -161,12 +161,12 @@ Resources:
       AlarmDescription:
         Too many analytics bigquery lambda errors
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "2"
+      EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: "300"
+      Period: 300
       Statistic: Sum
-      Threshold: "1"
+      Threshold: 1
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName
@@ -186,12 +186,12 @@ Resources:
       AlarmDescription:
         Too few invocations
       ComparisonOperator: LessThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: "300"
+      Period: 300
       Statistic: Sum
-      Threshold: "1500"
+      Threshold: 1500
       TreatMissingData: breaching
       Dimensions:
         - Name: FunctionName
@@ -210,12 +210,12 @@ Resources:
       AlarmDescription:
         Too many analytics pingbacks lambda errors
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: "300"
+      Period: 300
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName
@@ -234,12 +234,12 @@ Resources:
       AlarmDescription:
         Too many analytics redis lambda errors
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: "300"
+      Period: 300
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName

--- a/stacks/castle.prx.org.yml
+++ b/stacks/castle.prx.org.yml
@@ -77,7 +77,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: "30"
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]
@@ -192,12 +192,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the castle target group exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer

--- a/stacks/dovetail-stitch-lambda-alarms.yml
+++ b/stacks/dovetail-stitch-lambda-alarms.yml
@@ -100,7 +100,7 @@ Resources:
       MetricTransformations:
         - MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_timeout"
           MetricNamespace: LogMetrics
-          MetricValue: 1
+          MetricValue: "1"
   LambdaWarnMetric:
     Type: "AWS::Logs::MetricFilter"
     Properties:
@@ -109,7 +109,7 @@ Resources:
       MetricTransformations:
         - MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_warn"
           MetricNamespace: LogMetrics
-          MetricValue: 1
+          MetricValue: "1"
   LambdaErrorMetric:
     Type: "AWS::Logs::MetricFilter"
     Properties:
@@ -118,7 +118,7 @@ Resources:
       MetricTransformations:
         - MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_error"
           MetricNamespace: LogMetrics
-          MetricValue: 1
+          MetricValue: "1"
   LambdaErrorAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Condition: CreateLambdaAlarms
@@ -149,12 +149,12 @@ Resources:
       AlarmDescription:
         Errors on the dovetail stitch lambda exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName
@@ -189,12 +189,12 @@ Resources:
       AlarmDescription:
         Throttles on the dovetail stitch lambda exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Throttles
       Namespace: AWS/Lambda
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName
@@ -229,12 +229,12 @@ Resources:
       AlarmDescription:
         Logged errors on dovetail stitch lambda exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_error"
       Namespace: LogMetrics
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
   LambdaTimeoutAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -266,12 +266,12 @@ Resources:
       AlarmDescription:
         Logged errors on dovetail stitch lambda exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_timeout"
       Namespace: LogMetrics
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
 Outputs:
   LambdaLogGroupName:

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -170,12 +170,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the dovetail application
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -195,12 +195,12 @@ Resources:
       AlarmDescription: >
         5XX load balancer errors originating from the dovetail load balancer
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "2"
+      EvaluationPeriods: 2
       MetricName: HTTPCode_ELB_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "5"
+      Threshold: 5
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -221,12 +221,12 @@ Resources:
         Target response time value for Dovetail load balancer targets at 99th
         percentile higher than expected
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       ExtendedStatistic: p99
       MetricName: TargetResponseTime
       Namespace: AWS/ApplicationELB
-      Period: "300"
-      Threshold: "4"
+      Period: 300
+      Threshold: 4
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -247,12 +247,12 @@ Resources:
         Target response time value for Dovetail load balancer targets at 95th
         percentile higher than expected
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       ExtendedStatistic: p95
       MetricName: TargetResponseTime
       Namespace: AWS/ApplicationELB
-      Period: "60"
-      Threshold: "6"
+      Period: 60
+      Threshold: 6
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -272,7 +272,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 20
+          Value: "20"
       Tags:
         - Key: Project
           Value: Dovetail
@@ -376,7 +376,7 @@ Resources:
       Description: Allows for DesiredCount persistence on ECS services
       Environment:
         Variables:
-          DEFAULT_DESIRED_COUNT: 2
+          DEFAULT_DESIRED_COUNT: "2"
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt DovetailServiceDesiredCountRolloverIamRole.Arn
@@ -445,12 +445,12 @@ Resources:
       AlarmDescription: >
         Too many dovetails running
       ComparisonOperator: LessThanOrEqualToThreshold
-      EvaluationPeriods: "2"
+      EvaluationPeriods: 2
       MetricName: CPUUtilization
       Namespace: AWS/ECS
-      Period: "60"
+      Period: 60
       Statistic: Average
-      Threshold: "30"
+      Threshold: 30
       TreatMissingData: notBreaching
       Dimensions:
         - Name: ServiceName
@@ -483,12 +483,12 @@ Resources:
       AlarmDescription: >
         Not enough dovetails running
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: CPUUtilization
       Namespace: AWS/ECS
-      Period: "60"
+      Period: 60
       Statistic: Average
-      Threshold: "50"
+      Threshold: 50
       TreatMissingData: notBreaching
       Dimensions:
         - Name: ServiceName
@@ -534,7 +534,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: "30"
       Tags:
         - Key: Project
           Value: Dovetail

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -328,7 +328,7 @@ Resources:
       GroupDescription: Enable outbound traffic on cluster instances
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
-          IpProtocol: -1
+          IpProtocol: "-1"
       Tags:
         - Key: Project
           Value: platform.prx.org
@@ -534,12 +534,12 @@ Resources:
       AlarmDescription: >
         ECS Cluster ASG outbound network traffic is unusually high
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "2"
+      EvaluationPeriods: 2
       MetricName: NetworkOut
       Namespace: AWS/EC2
-      Period: "300"
+      Period: 300
       Statistic: Sum
-      Threshold: "25000000000"
+      Threshold: 25000000000
       TreatMissingData: missing
       Dimensions:
         - Name: AutoScalingGroupName
@@ -559,12 +559,12 @@ Resources:
       AlarmDescription: >
         ECS Cluster ASG inbound network traffic is unusually high
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "2"
+      EvaluationPeriods: 2
       MetricName: NetworkIn
       Namespace: AWS/EC2
-      Period: "300"
+      Period: 300
       Statistic: Sum
-      Threshold: "25000000000"
+      Threshold: 25000000000
       TreatMissingData: missing
       Dimensions:
         - Name: AutoScalingGroupName
@@ -652,7 +652,7 @@ Resources:
     Properties:
       AutoScalingGroupName: !Ref ECSClusterASG
       DefaultResult: "ABANDON"
-      HeartbeatTimeout: "900"
+      HeartbeatTimeout: 900
       LifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING"
       NotificationTargetARN: !Ref ECSDrainSNSTopic
       RoleARN: !GetAtt ECSDrainSNSRole.Arn

--- a/stacks/jingle.prx.org.yml
+++ b/stacks/jingle.prx.org.yml
@@ -77,7 +77,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: "30"
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]
@@ -192,12 +192,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the jingle target group exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer

--- a/stacks/legacy-support/root.yml
+++ b/stacks/legacy-support/root.yml
@@ -78,4 +78,4 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "stripe-proxy.yml"]]
-      TimeoutInMinutes: "10"
+      TimeoutInMinutes: 10

--- a/stacks/legacy-support/stripe-proxy.yml
+++ b/stacks/legacy-support/stripe-proxy.yml
@@ -67,7 +67,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: "30"
       Tags:
         - Key: Project
           Value: stripe-proxy
@@ -121,12 +121,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the stripe-proxy target group exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer

--- a/stacks/load-balancers.yml
+++ b/stacks/load-balancers.yml
@@ -133,12 +133,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the Platform ALB exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_ELB_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "3"
+      Threshold: 3
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -159,12 +159,12 @@ Resources:
         Target response time value for platform load balancer targets at 95th
         percentile higher than expected
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       ExtendedStatistic: p95
       MetricName: TargetResponseTime
       Namespace: AWS/ApplicationELB
-      Period: "60"
-      Threshold: "0.5"
+      Period: 60
+      Threshold: 0.5
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -178,7 +178,6 @@ Outputs:
     Value: !GetAtt PlatformALB.DNSName
   PlatformALBDualstackDNSName:
     Description: The dualstack DNS name for the application load balancer
-    Value: !GetAtt PlatformALB.DNSName
     Value: !Sub dualstack.${PlatformALB.DNSName}
   PlatformALBFullName:
     Description: The full name for the application load balancer

--- a/stacks/metrics.prx.org.yml
+++ b/stacks/metrics.prx.org.yml
@@ -73,7 +73,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 15
+          Value: "15"
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]
@@ -187,12 +187,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the metrics target group exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer

--- a/stacks/play.prx.org.yml
+++ b/stacks/play.prx.org.yml
@@ -86,7 +86,7 @@ Resources:
           Value: !Ref AWS::StackId
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 15
+          Value: "15"
       VpcId: !Ref VPC
   # ALB Listener Rules
   PlayALBHTTPSHostWildcardListenerRule:
@@ -276,12 +276,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the play target group exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer

--- a/stacks/proxy.prx.org.yml
+++ b/stacks/proxy.prx.org.yml
@@ -231,12 +231,12 @@ Resources:
       Dimensions:
         - Name: ApiName
           Value: !Sub "${AWS::StackName} API"
-      EvaluationPeriods: "3"
+      EvaluationPeriods: 3
       MetricName: 5xxError
       Namespace: AWS/ApiGateway
-      Period: "300"
+      Period: 300
       Statistic: Sum
-      Threshold: "1"
+      Threshold: 1
       TreatMissingData: notBreaching
 Outputs:
   ApiDomainName:

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -73,7 +73,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 15
+          Value: "15"
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]
@@ -187,12 +187,12 @@ Resources:
       AlarmDescription: >
         5XX server errors originating from the publish target group exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer

--- a/stacks/serverless/root.yml
+++ b/stacks/serverless/root.yml
@@ -47,7 +47,7 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "upload.prx.org.yml"]]
-      TimeoutInMinutes: "5"
+      TimeoutInMinutes: 5
   RadiotopiaTowerStack:
     Type: "AWS::CloudFormation::Stack"
     Properties:
@@ -65,4 +65,4 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "tower.radiotopia.fm.yml"]]
-      TimeoutInMinutes: "5"
+      TimeoutInMinutes: 5

--- a/stacks/static-sites/root.yml
+++ b/stacks/static-sites/root.yml
@@ -94,7 +94,7 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "radio.radiotopia.fm.yml"]]
-      TimeoutInMinutes: "5"
+      TimeoutInMinutes: 5
   BetaPrxOrgStack:
     Type: "AWS::CloudFormation::Stack"
     Properties:
@@ -116,4 +116,4 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "beta.prx.org.yml"]]
-      TimeoutInMinutes: "5"
+      TimeoutInMinutes: 5

--- a/stacks/upload.prx.org.yml
+++ b/stacks/upload.prx.org.yml
@@ -202,12 +202,12 @@ Resources:
       AlarmDescription:
         The error rate on the upload lambda has exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName
@@ -227,12 +227,12 @@ Resources:
       AlarmDescription:
         Throttles on the upload lambda has exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Throttles
       Namespace: AWS/Lambda
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName
@@ -252,12 +252,12 @@ Resources:
       AlarmDescription:
         At least one invocation duration exceeded 225ms
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: Duration
       Namespace: AWS/Lambda
-      Period: "60"
+      Period: 60
       Statistic: Maximum
-      Threshold: "225"
+      Threshold: 225
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName

--- a/stacks/web-alb-application.yml
+++ b/stacks/web-alb-application.yml
@@ -159,7 +159,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: "30"
       Tags:
         - Key: Project
           Value: !Ref AppName
@@ -188,12 +188,12 @@ Resources:
       AlarmDescription: !Sub |
         5XX server errors originating from the ${AppName} application
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -213,12 +213,12 @@ Resources:
       AlarmDescription: !Sub |
         5XX load balancer errors originating from the ${AppName} load balancer
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_ELB_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "2"
+      Threshold: 2
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
@@ -239,12 +239,12 @@ Resources:
         Target response time value for ${AppName} load balancer targets at 95th
         percentile higher than expected
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       ExtendedStatistic: p95
       MetricName: TargetResponseTime
       Namespace: AWS/ApplicationELB
-      Period: "300"
-      Threshold: "0.2"
+      Period: 300
+      Threshold: 0.2
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer

--- a/stacks/web-application.yml
+++ b/stacks/web-application.yml
@@ -90,7 +90,7 @@ Resources:
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: "30"
       Tags:
         - Key: Project
           Value: !Ref AppName
@@ -144,12 +144,12 @@ Resources:
       AlarmDescription: !Sub |
         5XX server errors originating from the ${AppName} target group exceeded 0
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: "1"
+      EvaluationPeriods: 1
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
-      Period: "60"
+      Period: 60
       Statistic: Sum
-      Threshold: "0"
+      Threshold: 0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer


### PR DESCRIPTION
This resolves a majority of the CloudFormation template linting errors. Base on my testing Cfn does not consider these type changes to be stack changes (ie it seems to be doing the coercion before determining if definitions have changed), so pretty much none of these should actually be resource updates. The only ones that I'm worried about in here are the `TimeoutInMinutes` on nested stacks. Again, I don't think it will do anything, but if for some reason it does register those as changes the docs says updating that value "isn't supported", so idk what that would do, hopefully not replace. Will just need to keep an eye on things in staging once this gets merged.