### PR TITLE
Fix docker available space metric

### DIFF
--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -383,7 +383,7 @@ Resources:
                   else echo "Unknown unit $1"; exit 1; fi
                 }
                 function getMetric {
-                  if [ "$1" == "Data" ] || [ "$1" == "Metadata" ] ; then echo $(docker info | grep "$1 Space Available" | awk '{print tolower($5), $4}');
+                  if [ "$1" == "Data" ] || [ "$1" == "Metadata" ] ; then echo $(docker info | grep "$1 Space Available" | sed 's/\([0-9]\+\)\([a-zA-Z]\+\)/\1 \2/' | awk '{print tolower($5), $4}');
                   else echo "Metric must be either 'Data' or 'Metadata'"; exit 1; fi
                 }
                 data=$(convertUnits `getMetric Data`)


### PR DESCRIPTION
At some point, the output of docker info changed, breaking the cron that reports cloudwatch metrics:

```
# old
Data Space Available: 71.09 GB
Metadata Space Available: 77.54 MB
# new
Data Space Available: 71.09GB
Metadata Space Available: 77.54MB
```

This sed re-inserts the space, if it's missing.