### PR TITLE
GitHub webhooks for CD

### DIFF
--- a/cd/cd.yml
+++ b/cd/cd.yml
@@ -309,14 +309,14 @@ Resources:
       AuthenticationConfiguration:
         SecretToken: !Ref GitHubWebhookSecret
       Filters:
-        - jsonPath: "$.ref"
+        - JsonPath: "$.ref"
           # Properties from the target action configuration can be included as 
           # placeholders in this value by surrounding the action configuration 
           # key with curly braces. For example, if the value supplied here is 
           # "refs/heads/{Branch}" and the target action has an action 
           # configuration property called "Branch" with a value of "master", 
           # the MatchEquals value will be evaluated as "refs/heads/master".
-          matchEquals: "refs/heads/{Branch}"
+          MatchEquals: "refs/heads/{Branch}"
       RegisterWithThirdParty: true
       TargetAction: InfrastructureRepo
       TargetPipeline: !Ref Pipeline
@@ -328,14 +328,14 @@ Resources:
       AuthenticationConfiguration:
         SecretToken: !Ref GitHubWebhookSecret
       Filters:
-        - jsonPath: "$.ref"
+        - JsonPath: "$.ref"
           # Properties from the target action configuration can be included as 
           # placeholders in this value by surrounding the action configuration 
           # key with curly braces. For example, if the value supplied here is 
           # "refs/heads/{Branch}" and the target action has an action 
           # configuration property called "Branch" with a value of "master", 
           # the MatchEquals value will be evaluated as "refs/heads/master".
-          matchEquals: "refs/heads/{Branch}"
+          MatchEquals: "refs/heads/{Branch}"
       RegisterWithThirdParty: true
       TargetAction: MetaRepo
       TargetPipeline: !Ref Pipeline


### PR DESCRIPTION
They have added CodePipeline webhook triggers support to CloudFormation, so this creates a webhook for each repo we use to trigger the CD pipeline (Infrastructure, and meta.prx.org).

Creating webhooks in AWS (optionally) creates the webhooks in GitHub. Both webhooks share a single signing secret.