### PR TITLE
Stitch lambda updates

### DIFF
--- a/cdn/dovetail-cdn/dovetail-stitch-lambda-filters.yml
+++ b/cdn/dovetail-cdn/dovetail-stitch-lambda-filters.yml
@@ -131,26 +131,14 @@ Resources:
       ActionsEnabled: true
       AlarmName: !Sub "[DovetailStitchLambda][Errors] ${EnvironmentType} > 0"
       AlarmActions:
-        - Fn::If:
-          - IsProduction
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
       InsufficientDataActions:
-        - Fn::If:
-          - IsProduction
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
       OKActions:
-        - Fn::If:
-          - IsProduction
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
       AlarmDescription:
         Errors on the dovetail stitch lambda exceeded 0
       ComparisonOperator: GreaterThanThreshold
@@ -160,6 +148,34 @@ Resources:
       Period: 60
       Statistic: Sum
       Threshold: 0
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "${LambdaRegion}.${LambdaName}"
+  LambdaManyErrorsAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Condition: !And [CreateLambdaAlarms, IsProduction]
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[DovetailStitchLambda][ManyErrors] ${EnvironmentType}"
+      AlarmActions:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      InsufficientDataActions:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      OKActions:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      AlarmDescription:
+        Way too many errors on the dovetail stitch lambda
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 2
       TreatMissingData: notBreaching
       Dimensions:
         - Name: FunctionName
@@ -248,28 +264,16 @@ Resources:
       ActionsEnabled: true
       AlarmName: !Sub "[DovetailStitchLambda][Timeouts] ${EnvironmentType} > 0"
       AlarmActions:
-        - Fn::If:
-          - IsProduction
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
       InsufficientDataActions:
-        - Fn::If:
-          - IsProduction
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
       OKActions:
-        - Fn::If:
-          - IsProduction
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-          - Fn::ImportValue:
-              !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
       AlarmDescription:
-        Logged errors on dovetail stitch lambda exceeded 0
+        Timeouts on dovetail stitch lambda exceeded 0
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_timeout"
@@ -277,6 +281,31 @@ Resources:
       Period: 60
       Statistic: Sum
       Threshold: 0
+      TreatMissingData: notBreaching
+  LambdaManyTimeoutsAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Condition: !And [CreateLambdaAlarms, IsProduction]
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[DovetailStitchLambda][ManyTimeouts] ${EnvironmentType}"
+      AlarmActions:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      InsufficientDataActions:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      OKActions:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      AlarmDescription:
+        Way too many timeouts on the dovetail stitch lambda
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_timeout"
+      Namespace: LogMetrics
+      Period: 60
+      Statistic: Sum
+      Threshold: 2
       TreatMissingData: notBreaching
 Outputs:
   LambdaLogGroupName:

--- a/cdn/dovetail-cdn/dovetail-stitch-lambda-filters.yml
+++ b/cdn/dovetail-cdn/dovetail-stitch-lambda-filters.yml
@@ -36,6 +36,9 @@ Metadata:
 Conditions:
   CreateLambdaAlarms: !Equals [!Ref LambdaRegion, !Ref "AWS::Region"]
   IsProduction: !Equals [!Ref EnvironmentType, Production]
+  IsProductionAlarms: !And
+    - !Equals [!Ref LambdaRegion, !Ref "AWS::Region"]
+    - !Equals [!Ref EnvironmentType, Production]
 Parameters:
   InfrastructureNotificationsStackName:
     Default: infrastructure-notifications
@@ -154,7 +157,7 @@ Resources:
           Value: !Sub "${LambdaRegion}.${LambdaName}"
   LambdaManyErrorsAlarm:
     Type: "AWS::CloudWatch::Alarm"
-    Condition: !And [CreateLambdaAlarms, IsProduction]
+    Condition: IsProductionAlarms
     Properties:
       ActionsEnabled: true
       AlarmName: !Sub "[DovetailStitchLambda][ManyErrors] ${EnvironmentType}"
@@ -284,7 +287,7 @@ Resources:
       TreatMissingData: notBreaching
   LambdaManyTimeoutsAlarm:
     Type: "AWS::CloudWatch::Alarm"
-    Condition: !And [CreateLambdaAlarms, IsProduction]
+    Condition: IsProductionAlarms
     Properties:
       ActionsEnabled: true
       AlarmName: !Sub "[DovetailStitchLambda][ManyTimeouts] ${EnvironmentType}"

--- a/stacks/dovetail-stitch-lambda.yml
+++ b/stacks/dovetail-stitch-lambda.yml
@@ -19,12 +19,15 @@ Mappings:
   EnvironmentTypeMap:
     Testing:
       Bucket: ""
+      Folder: ""
       Handler: ""
     Staging:
       Bucket: "prx-dovetail"
+      Folder: "stitch-staging"
       Handler: "index-staging.handler"
     Production:
       Bucket: "prx-dovetail"
+      Folder: "stitch-production"
       Handler: "index-production.handler"
 Resources:
   # IAM Roles
@@ -77,8 +80,9 @@ Resources:
                 Action:
                   - "s3:GetObject"
                   - "s3:PutObject"
+                  - "s3:PutObjectTagging"
                 Resource:
-                  - !Join ["", ["arn:aws:s3:::", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, Bucket], "/*"]]
+                  - !Join ["", ["arn:aws:s3:::", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, Bucket], "/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, Folder], "/*"]]
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"


### PR DESCRIPTION
- [x] Add the s3-tagging permission for the dovetail-stitch-lambda, which will be required for PRX/dovetail-stitch-lambda#28
- [x] Restrict stitch-lambda S3 writes to a subfolder (just in case)
- [x] Quiet alarms, by moving all the prod `> 0` to ops-warn, and adding new `> 2` prod alarms to ops-error