### PR TITLE
Secrets lambda ignores files other than secrets

### DIFF
--- a/secrets/README.md
+++ b/secrets/README.md
@@ -2,7 +2,8 @@
 
 Works with the `aws-secrets` project (https://github.com/PRX/aws-secrets) to
 provide the bucket to store secrets, and creates a lambda to watch for changes
-to secrets files in that S3 bucket.
+to `/[app]/[env]/secrets` files in that S3 bucket. It will ignore changes to
+other files stored by `aws-secrets` in the bucket.
 
 When the lambda detects a change, it determines which environment and apps are
 affected, and gets the latest secrets file version IDs. It downloads and updates

--- a/secrets/lambdas/secrets-s3-update/lambda_function.py
+++ b/secrets/lambdas/secrets-s3-update/lambda_function.py
@@ -33,16 +33,17 @@ def temp_file_path():
 def get_record_info(record):
     bucket = record['s3']['bucket']['name']
     key = record['s3']['object']['key']
-    app, env, secrets = key.split('/')
-    # print(app, env, secrets)
+    app, env, file = key.split('/')
+    # print(app, env, file)
     version = s3.head_object(Bucket=bucket, Key=key)['VersionId']
-    return {'app' : app, 'env' : env, 'version' : version}
+    return {'app' : app, 'env' : env, 'file' : file, 'version' : version}
 
 def get_secrets_changes(event):
     changes = {}
     for record in event['Records']:
         info = get_record_info(record)
-        changes.setdefault(info['env'], []).append(info)
+        if info['file'] == 'secrets':
+            changes.setdefault(info['env'], []).append(info)
     return changes
 
 def get_config(env):


### PR DESCRIPTION
Enhancing `aws-secrets` to securely store files other than just `/app/env/secrets` (e.g. private key files). https://github.com/PRX/aws-secrets/pull/6

However, if they are stored in the same `/app/env/*` path, they are picked up as changes to the secrets.

This change causes the secrets update lambda to ignore changes to files that are not names `/secrets`