### PR TITLE
Add relative file path references to templates

### DIFF
--- a/cd/cd.yml
+++ b/cd/cd.yml
@@ -1,3 +1,4 @@
+# cd/cd.yml
 # This creates a CodePipeline pipeline (and associates resources) for handling
 # deployments and testing of the platform. It watches three sources for changes,
 # which trigger the pipeline: the meta.prx.org repo (used for acceptance

--- a/cd/cd.yml
+++ b/cd/cd.yml
@@ -311,11 +311,11 @@ Resources:
         SecretToken: !Ref GitHubWebhookSecret
       Filters:
         - JsonPath: "$.ref"
-          # Properties from the target action configuration can be included as 
-          # placeholders in this value by surrounding the action configuration 
-          # key with curly braces. For example, if the value supplied here is 
-          # "refs/heads/{Branch}" and the target action has an action 
-          # configuration property called "Branch" with a value of "master", 
+          # Properties from the target action configuration can be included as
+          # placeholders in this value by surrounding the action configuration
+          # key with curly braces. For example, if the value supplied here is
+          # "refs/heads/{Branch}" and the target action has an action
+          # configuration property called "Branch" with a value of "master",
           # the MatchEquals value will be evaluated as "refs/heads/master".
           MatchEquals: "refs/heads/{Branch}"
       RegisterWithThirdParty: true
@@ -330,11 +330,11 @@ Resources:
         SecretToken: !Ref GitHubWebhookSecret
       Filters:
         - JsonPath: "$.ref"
-          # Properties from the target action configuration can be included as 
-          # placeholders in this value by surrounding the action configuration 
-          # key with curly braces. For example, if the value supplied here is 
-          # "refs/heads/{Branch}" and the target action has an action 
-          # configuration property called "Branch" with a value of "master", 
+          # Properties from the target action configuration can be included as
+          # placeholders in this value by surrounding the action configuration
+          # key with curly braces. For example, if the value supplied here is
+          # "refs/heads/{Branch}" and the target action has an action
+          # configuration property called "Branch" with a value of "master",
           # the MatchEquals value will be evaluated as "refs/heads/master".
           MatchEquals: "refs/heads/{Branch}"
       RegisterWithThirdParty: true

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -1,3 +1,4 @@
+# cdn/dovetail-cdn.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a CloudFront distribution to origin-pull from a Dovetail S3 bucket,

--- a/cdn/feed-cdn.yml
+++ b/cdn/feed-cdn.yml
@@ -1,3 +1,4 @@
+# cdn/feed-cdn.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a CloudFront distribution and some associated resources to act as a

--- a/cdn/feeder-cdn.yml
+++ b/cdn/feeder-cdn.yml
@@ -1,3 +1,4 @@
+# cdn/feeder-cdn.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Feeder bucket CDN

--- a/cdn/s3-origin.yml
+++ b/cdn/s3-origin.yml
@@ -1,3 +1,4 @@
+# cdn/s3-origin.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a CloudFront distribution for s3 origins

--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -1,3 +1,4 @@
+# cdn/single-origin.yml
 # When creating a CloudFront distribution for an S3 bucket, it is recommended
 # that the bucket remains private and CloudFront is given access to it via an
 # Origin Access Identity. This template can create that identity, but it cannot

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -1,3 +1,4 @@
+# ci/ci.yml
 # This stack should generally only be launched once globally
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >

--- a/db/elasticache-memcached.yml
+++ b/db/elasticache-memcached.yml
@@ -1,3 +1,4 @@
+# db/elasticache-memcached.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
   AWS CloudFormation Memcached Template: Template to create Elasticache Memcached cluster

--- a/db/mysql-instance.yml
+++ b/db/mysql-instance.yml
@@ -1,3 +1,4 @@
+# db/mysql-instance.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
   AWS CloudFormation RDS Template: Template to create RDS MySQL v5.5 instance.

--- a/db/replication-alarms.yml
+++ b/db/replication-alarms.yml
@@ -1,3 +1,4 @@
+# db/replication-alarms.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates alarms related to ssh tunnel remote server -> rds db replication

--- a/db/vpc.yml
+++ b/db/vpc.yml
@@ -1,3 +1,4 @@
+# db/vpc.yml
 # NOTE Some default resource created along with a VPC (security group, network
 # ACL, etc) can't be tagged, so they don't match the resources that are
 # explicitly created. They work correctly, though, and will be torn down if the

--- a/dns/prx.mx-hosted_zone.yml
+++ b/dns/prx.mx-hosted_zone.yml
@@ -1,3 +1,4 @@
+# dns/prx.mx-hosted_zone.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Hosted zone and record sets for prx.mx

--- a/dns/prx.org-hosted_zone.yml
+++ b/dns/prx.org-hosted_zone.yml
@@ -1,3 +1,4 @@
+# dns/prx.org-hosted_zone.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Hosted zone and record sets for prx.org

--- a/dns/prxu.org-hosted_zone.yml
+++ b/dns/prxu.org-hosted_zone.yml
@@ -1,3 +1,4 @@
+# dns/prxu.org-hosted_zone.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Hosted zone and record sets for prxu.org

--- a/dns/radiotopia.com-hosted_zone.yml
+++ b/dns/radiotopia.com-hosted_zone.yml
@@ -1,3 +1,4 @@
+# dns/radiotopia.com-hosted_zone.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Hosted zone and record sets for radiotopia.com

--- a/dns/radiotopia.fm-hosted_zone.yml
+++ b/dns/radiotopia.fm-hosted_zone.yml
@@ -1,3 +1,4 @@
+# dns/radiotopia.fm-hosted_zone.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Hosted zone and record sets for radiotopia.fm

--- a/etc/adzerk-poller.yml
+++ b/etc/adzerk-poller.yml
@@ -1,3 +1,4 @@
+# etc/adzerk-poller.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a Lambda function that polls the Adzerk API and finds ad flight

--- a/etc/aws-daily-cost-report.yml
+++ b/etc/aws-daily-cost-report.yml
@@ -1,3 +1,4 @@
+# etc/aws-daily-cost-report.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a Lambda function that runs some basic reports against Cost Explorer,

--- a/etc/cross-account-vpc-peering-accepter.yml
+++ b/etc/cross-account-vpc-peering-accepter.yml
@@ -1,4 +1,4 @@
-# cross-account-vpc-peering-accepter.yml
+# etc/cross-account-vpc-peering-accepter.yml
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
   Creates resources to support the accepter side of an already-created VPC

--- a/etc/cross-account-vpc-peering-requester.yml
+++ b/etc/cross-account-vpc-peering-requester.yml
@@ -1,4 +1,4 @@
-# cross-account-vpc-peering-requester.yml
+# etc/cross-account-vpc-peering-requester.yml
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
   Create a VPC Peering connection between two VPCs in different AWS accounts,

--- a/etc/log-group-retention-policy-custom-resource.yml
+++ b/etc/log-group-retention-policy-custom-resource.yml
@@ -1,4 +1,4 @@
-# log-group-retention-policy-custom-resource.yml
+# etc/log-group-retention-policy-custom-resource.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a Lambda function for backing a CloudFormation custom resource that

--- a/etc/root-account-activity-monitor.yml
+++ b/etc/root-account-activity-monitor.yml
@@ -1,3 +1,4 @@
+# etc/root-account-activity-monitor.yml
 # Sample CloudWatch Events event (from CloudTrail)
 # {
 #    "version": "0",

--- a/etc/workable-poller.yml
+++ b/etc/workable-poller.yml
@@ -1,3 +1,4 @@
+# etc/workable-poller.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a Lambda function that polls the Workable API and finds new

--- a/notifications/notifications.yml
+++ b/notifications/notifications.yml
@@ -1,3 +1,4 @@
+# notifications/notifications.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates foundational resources needed to handle infrastructure-related

--- a/secrets/secrets.yml
+++ b/secrets/secrets.yml
@@ -1,3 +1,4 @@
+# secrets/secrets.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates the bucket and lambda needed to support application secrets

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -1,3 +1,4 @@
+# stacks/analytics-ingest-lambda.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Analytics ingest lambda functions
 Conditions:

--- a/stacks/castle.prx.org.yml
+++ b/stacks/castle.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/castle.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: castle.prx.org application running in Docker
 Mappings:

--- a/stacks/certificate.yml
+++ b/stacks/certificate.yml
@@ -1,3 +1,4 @@
+# stacks/certificate.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates a wildcard ACM certificate for the standard VPC created by the root

--- a/stacks/cms-audio-lambda.yml
+++ b/stacks/cms-audio-lambda.yml
@@ -1,3 +1,4 @@
+# stacks/cms-audio-lambda.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Audio processing Lambda function for CMS
 Parameters:

--- a/stacks/cms-image-lambda.yml
+++ b/stacks/cms-image-lambda.yml
@@ -1,3 +1,4 @@
+# stacks/cms-image-lambda.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Image processing Lambda function for CMS
 Parameters:

--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -1,3 +1,4 @@
+# stacks/container-apps/root.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Apps that run in containers (i.e. Docker)

--- a/stacks/container-apps/web-application.yml
+++ b/stacks/container-apps/web-application.yml
@@ -1,3 +1,4 @@
+# stacks/container-apps/web-application.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, using the shared platform ALB

--- a/stacks/dovetail-stitch-lambda.yml
+++ b/stacks/dovetail-stitch-lambda.yml
@@ -1,3 +1,4 @@
+# stacks/dovetail-stitch-lambda.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Dovetail stitch lambda function
 Conditions:

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/dovetail.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: dovetail.prx.org application running in Docker
 Conditions:

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -1,3 +1,4 @@
+# stacks/ecs.yml
 # NOTE EC2 Key Pairs cannot be created by CloudFormation templates, and are
 # region specific, so you need to create them before launching a stack, and
 # pass the name in as a parameter

--- a/stacks/fourohfour.prx.org.yml
+++ b/stacks/fourohfour.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/fourohfour.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: fourohfour.prx.org application running in Docker
 Mappings:

--- a/stacks/legacy-support/root.yml
+++ b/stacks/legacy-support/root.yml
@@ -1,3 +1,4 @@
+# stacks/legacy-support/root.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Legacy Support (resources to support older apps moved to AWS)

--- a/stacks/legacy-support/stripe-proxy.yml
+++ b/stacks/legacy-support/stripe-proxy.yml
@@ -1,3 +1,4 @@
+# stacks/stripe-proxy/root.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker proxy server for stripe with its own ALB

--- a/stacks/load-balancers.yml
+++ b/stacks/load-balancers.yml
@@ -1,3 +1,4 @@
+# stacks/load-balancers.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates application load balancers that can be reused for multiple

--- a/stacks/metrics.prx.org.yml
+++ b/stacks/metrics.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/metrics.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: metrics.prx.org application running in Docker
 Mappings:

--- a/stacks/play.prx.org.yml
+++ b/stacks/play.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/play.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: play.prx.org application running in Docker
 Mappings:

--- a/stacks/proxy.prx.org.yml
+++ b/stacks/proxy.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/proxy.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Top-level proxy server for www.prx.org
 Conditions:

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/publish.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: publish.prx.org application running in Docker
 Mappings:

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -1,3 +1,4 @@
+# stacks/root.yml
 # Generally this template is used to launch stacks from the bootstrapping
 # CodePipeline. Primarily is is simply a wrapper around individial app- and
 # service-specific templates, which get nested into this template and are

--- a/stacks/serverless/dovetail-bytes-lambda.yml
+++ b/stacks/serverless/dovetail-bytes-lambda.yml
@@ -1,4 +1,4 @@
-# stacks/serverless/dovetaul-bytes-lambda.yml
+# stacks/serverless/dovetail-bytes-lambda.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Dovetail bytes lambda function
 Parameters:

--- a/stacks/serverless/dovetail-bytes-lambda.yml
+++ b/stacks/serverless/dovetail-bytes-lambda.yml
@@ -1,3 +1,4 @@
+# stacks/serverless/dovetaul-bytes-lambda.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Dovetail bytes lambda function
 Parameters:

--- a/stacks/serverless/root.yml
+++ b/stacks/serverless/root.yml
@@ -1,3 +1,4 @@
+# stacks/serverless/root.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Serverless (Lambda, API Gateway, etc) apps

--- a/stacks/serverless/tower.radiotopia.fm.yml
+++ b/stacks/serverless/tower.radiotopia.fm.yml
@@ -1,3 +1,4 @@
+# stacks/serverless/tower.radiotopia.fm.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Radiotopia Radio API
 Conditions:

--- a/stacks/serverless/upload.prx.org.yml
+++ b/stacks/serverless/upload.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/serverless/upload.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: File upload Lambda function
 Conditions:

--- a/stacks/static-sites/beta.prx.org.yml
+++ b/stacks/static-sites/beta.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/static-sites/beta.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Beta.prx.org listener site
 Parameters:

--- a/stacks/static-sites/radio.radiotopia.fm.yml
+++ b/stacks/static-sites/radio.radiotopia.fm.yml
@@ -1,3 +1,4 @@
+# stacks/static-sites/radio.radiotopia.fm.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Radiotopia Radio static site
 Parameters:

--- a/stacks/static-sites/root.yml
+++ b/stacks/static-sites/root.yml
@@ -1,3 +1,4 @@
+# stacks/static-sites/root.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Sites that are deployed through S3 as static websites

--- a/stacks/upload.prx.org.yml
+++ b/stacks/upload.prx.org.yml
@@ -1,3 +1,4 @@
+# stacks/upload.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: File upload Lambda function
 Conditions:

--- a/stacks/vpc.yml
+++ b/stacks/vpc.yml
@@ -1,3 +1,4 @@
+# stacks/vpc.yml
 # NOTE Some default resource created along with a VPC (security group, network
 # ACL, etc) can't be tagged, so they don't match the resources that are
 # explicitly created. They work correctly, though, and will be torn down if the

--- a/stacks/web-alb-application.yml
+++ b/stacks/web-alb-application.yml
@@ -1,3 +1,4 @@
+# stacks/web-alb-application.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, with its own ALB

--- a/storage/storage.yml
+++ b/storage/storage.yml
@@ -1,3 +1,4 @@
+# storage/storage.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Creates the standard S3 buckets that are necessary for launching the rest of


### PR DESCRIPTION
This adds a first-line comment to all templates to indicate their own file path relative to the root of the Infrastructure repo.

***NOTE*** Lots of these have not actually been deployed to CloudFormation, since the console rejects stack updates when only comments have changed.