### PR TITLE
Add a CNAME from for api.prx.org to exchange tech hosted on aws

### DIFF
--- a/dns/prx.org-hosted_zone.yml
+++ b/dns/prx.org-hosted_zone.yml
@@ -372,11 +372,6 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub exchange.${Domain}
-        - ResourceRecords:
-            - exchange.prx.tech.
-          TTL: "300"
-          Type: CNAME
-          Name: !Sub api.${Domain}
         - Type: A
           Name: !Ref Domain
           AliasTarget:
@@ -607,6 +602,11 @@ Resources:
           TTL: "300"
           Type: A
           Name: !Sub activemq.${Domain}
+        - ResourceRecords:
+            - exchange.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub api.${Domain}
         - ResourceRecords:
             - "199.119.122.228"
           TTL: "300"

--- a/dns/prx.org-hosted_zone.yml
+++ b/dns/prx.org-hosted_zone.yml
@@ -372,6 +372,11 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub exchange.${Domain}
+        - ResourceRecords:
+            - exchange.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub api.${Domain}
         - Type: A
           Name: !Ref Domain
           AliasTarget:
@@ -602,11 +607,6 @@ Resources:
           TTL: "300"
           Type: A
           Name: !Sub activemq.${Domain}
-        - ResourceRecords:
-            - "199.119.122.228"
-          TTL: "300"
-          Type: A
-          Name: !Sub api.${Domain}
         - ResourceRecords:
             - "199.119.122.228"
           TTL: "300"

--- a/dns/prx.org-hosted_zone.yml
+++ b/dns/prx.org-hosted_zone.yml
@@ -372,6 +372,11 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub exchange.${Domain}
+        - ResourceRecords:
+            - exchange.prx.tech.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub api.${Domain}
         - Type: A
           Name: !Ref Domain
           AliasTarget:
@@ -602,11 +607,6 @@ Resources:
           TTL: "300"
           Type: A
           Name: !Sub activemq.${Domain}
-        - ResourceRecords:
-            - exchange.prx.tech.
-          TTL: "300"
-          Type: CNAME
-          Name: !Sub api.${Domain}
         - ResourceRecords:
             - "199.119.122.228"
           TTL: "300"


### PR DESCRIPTION
`api.prx.org` has always gone to the exchange app, since it was hosted on contegix at the apex domain.
Need to specify this explicitly now to go to AWS via the `exchange.prx.tech` address.