### PR TITLE
Feat/clean up template urls

### DIFF
--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -426,7 +426,11 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
-      TemplateURL: !Join ["", ["http://s3", !If [IsUsEast1, "", "-"], !If [IsUsEast1, "", !Ref "AWS::Region"], ".amazonaws.com/", "Fn::ImportValue": !Sub "${InfrastructureStorageStackName}-InfrastructureSourceBucket", "/", !Ref InfrastructureGitCommit, "/stacks/fourohfour.prx.org.yml"]]
+      TemplateURL: !Join
+        - ""
+        - - Fn::ImportValue: { "Fn::Sub": "${InfrastructureStorageStackName}-SourceBucketUrl" }
+          - !Ref InfrastructureGitCommit
+          - "/stacks/fourohfour.prx.org.yml"
       TimeoutInMinutes: 5
   PublishStack:
     Type: "AWS::CloudFormation::Stack"

--- a/storage/storage.yml
+++ b/storage/storage.yml
@@ -6,6 +6,8 @@ Description: >
 Parameters:
   BucketNamePrefix:
     Type: String
+Conditions:
+  IsUsEast1: !Equals [!Ref "AWS::Region", us-east-1]
 Resources:
   # S3 Buckets
   InfrastructureSupportBucket:
@@ -87,6 +89,23 @@ Outputs:
     Value: !Ref InfrastructureSourceBucket
     Export:
       Name: !Sub ${AWS::StackName}-InfrastructureSourceBucket
+  InfrastructureSourceBucketUrl:
+    Description: >
+      The complete S3 URL for the Source bucket (e.g.,
+      https://s3.amazonaws.com/acme-us-west-2-source/)
+    Value:
+      Fn::Join:
+        - ""
+        - - "https://s3"
+          - !If
+            - IsUsEast1
+            - ""
+            - !Sub "-${AWS::Region}"
+          - ".amazonaws.com/"
+          - !Ref InfrastructureSourceBucket
+          - "/"
+    Export:
+      Name: !Sub ${AWS::StackName}-SourceBucketUrl
   InfrastructureConfigBucket:
     Value: !Ref InfrastructureConfigBucket
     Export:


### PR DESCRIPTION
This moves a lot of the logic for building the nested stack template URLs into the storage stack, and exports a complete URL that can be imported in the CD templates.

It also switched to https URLs, rather than http, which the docs lead me to believe should be fine.

CloudFormation does **not** treat a template URL changing as a change to any resources, unless the contents of what lives at the URL have in fact changed.