### PR TITLE
Add release notes prompt to deploy approvals

### DIFF
--- a/cd/lambdas/pipeline-approval-notification-handler/lambda_function.py
+++ b/cd/lambdas/pipeline-approval-notification-handler/lambda_function.py
@@ -6,6 +6,10 @@
 # deploy. Information regarding the pending changes to the stack are queried
 # from CloudFormation, and sent to Slack along with control to make a decision
 # about the deploy.
+#
+# This creates the Deploy button for production deploys, but does NOT handle
+# what happens when the button is pressed. That is handled by
+# notifications/ike-interactive-messages-callback-handler.
 
 import boto3
 import json
@@ -140,6 +144,17 @@ def approval_action_attachment(notification):
                 'confirm': {
                     'title': 'Production Deploy Approval',
                     'text': 'Are you sure you want to approve this CloudFormation change set for the production stack? Approval will trigger an immediate update to the production stack!',
+                    'ok_text': 'Deploy',
+                    'dismiss_text': 'Cancel'
+                }
+            }, {
+                'type': 'button',
+                'name': 'notes',
+                'text': 'Approve with notes',
+                'value': json.dumps(approved_params),
+                'confirm': {
+                    'title': 'Production Deploy Approval',
+                    'text': 'Are you sure you want to approve this CloudFormation change set for the production stack? Approval will trigger an immediate update to the production stack, even if you choose not to enter release notes!',
                     'ok_text': 'Deploy',
                     'dismiss_text': 'Cancel'
                 }

--- a/notifications/lambdas/ike-interactive-messages-callback-handler/index.js
+++ b/notifications/lambdas/ike-interactive-messages-callback-handler/index.js
@@ -16,7 +16,7 @@ const https = require('https');
 const aws = require('aws-sdk');
 const s3 = new aws.S3({apiVersion: '2006-03-01'});
 const codepipeline = new aws.CodePipeline({apiVersion: '2015-07-09'});
-const sns = new AWS.SNS({ apiVersion: '2010-03-31' });
+const sns = new aws.SNS({ apiVersion: '2010-03-31' });
 
 const APPROVED = 'Approved';
 const REJECTED = 'Rejected';

--- a/notifications/lambdas/ike-interactive-messages-callback-handler/index.js
+++ b/notifications/lambdas/ike-interactive-messages-callback-handler/index.js
@@ -131,7 +131,7 @@ function handleReleaseNotesDialog(payload, callback) {
     sns.publish({
         TopicArn: process.env.SLACK_MESSAGE_RELAY_TOPIC_ARN,
         Message: JSON.stringify({
-            channel: '#tech-releses',
+            channel: '#tech-releases',
             username: 'Release Notes',
             icon_emoji: ':rabbit:',
             text: `<@${payload.user.id}>: ${payload.submission.release_notes}`,

--- a/notifications/notifications.yml
+++ b/notifications/notifications.yml
@@ -66,6 +66,11 @@ Parameters:
     Type: String
   IkeSlackSigningSecret:
     Type: String
+  IkeOauthAccessToken:
+    Type: String
+    Description: >
+      The OAuth access token generated when Ike was installed (e.g.,
+      xoxp-123456789…)
   SnsTopicPolicyPublishAllowanceAccountIds:
     Type: CommaDelimitedList
     Description: >
@@ -819,6 +824,15 @@ Resources:
               - "sts:AssumeRole"
       Path: "/"
       Policies:
+        - PolicyName: SnsPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "sns:Publish"
+                Resource:
+                  - !Ref SlackMessageRelaySnsTopic
         - PolicyName: CodePipelineApprovalPolicy
           PolicyDocument:
             Version: "2012-10-17"
@@ -871,14 +885,16 @@ Resources:
       Environment:
         Variables:
           SLACK_SIGNING_SECRET: !Ref IkeSlackSigningSecret
+          SLACK_ACCESS_TOKEN: !Ref IkeOauthAccessToken
           INFRASTRUCTURE_CONFIG_BUCKET:
             Fn::ImportValue:
               !Sub ${InfrastructureStorageStackName}-InfrastructureConfigBucket
           INFRASTRUCTURE_CONFIG_STAGING_KEY: !Ref InfrastructureConfigStagingKey
+          SLACK_MESSAGE_RELAY_TOPIC_ARN: !Ref SlackMessageRelaySnsTopic
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt IkeHandlerLambdaIamRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Tags:
         - Key: Project
           Value: Infrastructure


### PR DESCRIPTION
Add an additional deployment approval button that will, in addition to approving a production deploy, open a dialog prompting for release notes, which will get posted to #tech-releases

This is not really tested

Closes #275 