### PR TITLE
Faster health checks

### DIFF
--- a/stacks/castle.prx.org.yml
+++ b/stacks/castle.prx.org.yml
@@ -70,8 +70,10 @@ Resources:
   CastleALBTargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
-      HealthCheckIntervalSeconds: 60
-      UnhealthyThresholdCount: 10
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
       HealthCheckPath: /api/v1
       Name: !Sub castle-${EnvironmentTypeAbbreviation}-${VPC}
       Port: 80

--- a/stacks/container-apps/web-application.yml
+++ b/stacks/container-apps/web-application.yml
@@ -93,8 +93,10 @@ Resources:
   ALBTargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
-      HealthCheckIntervalSeconds: 60
-      UnhealthyThresholdCount: 10
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
       HealthCheckPath: !Ref HealthCheckPath
       Name: !Sub ${AppName}-${EnvironmentTypeAbbreviation}
       Port: 80

--- a/stacks/metrics.prx.org.yml
+++ b/stacks/metrics.prx.org.yml
@@ -66,8 +66,10 @@ Resources:
   MetricsALBTargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
-      HealthCheckIntervalSeconds: 60
-      UnhealthyThresholdCount: 10
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
       HealthCheckPath: /
       Name: !Sub metrics-${EnvironmentTypeAbbreviation}-${VPC}
       Port: 80

--- a/stacks/play.prx.org.yml
+++ b/stacks/play.prx.org.yml
@@ -68,8 +68,10 @@ Resources:
   PlayALBTargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
-      HealthCheckIntervalSeconds: 60
-      UnhealthyThresholdCount: 10
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
       HealthCheckPath: /
       Name: !Sub play-${EnvironmentTypeAbbreviation}-${VPC}
       Port: 80

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -66,8 +66,10 @@ Resources:
   PublishALBTargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
-      HealthCheckIntervalSeconds: 60
-      UnhealthyThresholdCount: 10
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
       HealthCheckPath: /
       Name: !Sub publish-${EnvironmentTypeAbbreviation}-${VPC}
       Port: 80

--- a/stacks/web-alb-application.yml
+++ b/stacks/web-alb-application.yml
@@ -152,8 +152,10 @@ Resources:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     DependsOn: ALB
     Properties:
-      HealthCheckIntervalSeconds: 60
-      HealthCheckTimeoutSeconds: 10
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
       HealthCheckPath: !Ref HealthCheckPath
       Name: !Sub ${AppName}-${EnvironmentTypeAbbreviation}-${VPC}
       Port: 80


### PR DESCRIPTION
For #287.

Change all target groups to have health check:

- frequency of 15 seconds
- timeout checks after 5 seconds
- healthy after 3 successes
- unhealthy after 3 failures