### PR TITLE
Metric for lambda redirect

### DIFF
--- a/cdn/dovetail-cdn/dovetail-stitch-lambda-filters.yml
+++ b/cdn/dovetail-cdn/dovetail-stitch-lambda-filters.yml
@@ -91,6 +91,15 @@ Resources:
         - MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_partial"
           MetricNamespace: LogMetrics
           MetricValue: $.timer
+  LambdaRedirectMetric:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      FilterPattern: '{ $.location = * }'
+      LogGroupName: !Ref LambdaLogGroup
+      MetricTransformations:
+        - MetricName: !Sub "dt_lambda_${EnvironmentTypeAbbreviation}_redirect"
+          MetricNamespace: LogMetrics
+          MetricValue: "1"
   LambdaInvokeMetric:
     Type: "AWS::Logs::MetricFilter"
     Properties:


### PR DESCRIPTION
2 new logged statements to handle from PRX/dovetail-stitch-lambda#46

```js
{"_logLevel":"warn","msg":"Stale arrangement the-digest","location":"https://dovetail.prxu.org/program_id/guid/anything.mp3","_tags":["log","warn"]}
{"_logLevel":"warn","msg":"Expired arrangement the-digest","location":"https://dovetail.prxu.org/program_id/guid/anything.mp3","_tags":["log","warn"]}
```

This creates a new metric to handle both.  Will have to be deployed manually via StackSet.