### PR TITLE
Analytics lambdas updates

### DIFF
--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -82,7 +82,7 @@ Resources:
           BQ_DOWNLOADS_TABLE: "downloads"
           BQ_PROJECT_ID: "prx-metrics"
       Handler: index.handler
-      MemorySize: 256
+      MemorySize: 384
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
       Runtime: nodejs8.10
       Tags:
@@ -107,7 +107,7 @@ Resources:
         Variables:
           PINGBACKS: "true"
       Handler: index.handler
-      MemorySize: 256
+      MemorySize: 384
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
       Runtime: nodejs8.10
       Tags:
@@ -203,7 +203,7 @@ Resources:
     Condition: CreateProductionResources
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub "[AnalyticsLambda][BigQuery][Invocations] ${EnvironmentType} < 1500"
+      AlarmName: !Sub "[AnalyticsLambda][BigQuery][Invocations] ${EnvironmentType} too low"
       AlarmActions:
         - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
       InsufficientDataActions:
@@ -218,7 +218,7 @@ Resources:
       Namespace: AWS/Lambda
       Period: 300
       Statistic: Sum
-      Threshold: 1500
+      Threshold: 500
       TreatMissingData: breaching
       Dimensions:
         - Name: FunctionName

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -107,7 +107,7 @@ Resources:
         Variables:
           PINGBACKS: "true"
       Handler: index.handler
-      MemorySize: 512
+      MemorySize: 1024
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
       Runtime: nodejs8.10
       Tags:
@@ -203,7 +203,7 @@ Resources:
     Condition: CreateProductionResources
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub "[AnalyticsLambda][BigQuery][Invocations] ${EnvironmentType} too low"
+      AlarmName: !Sub "[AnalyticsLambda][BigQuery][Invocations] ${EnvironmentType} < 1500"
       AlarmActions:
         - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
       InsufficientDataActions:
@@ -218,7 +218,7 @@ Resources:
       Namespace: AWS/Lambda
       Period: 300
       Statistic: Sum
-      Threshold: 500
+      Threshold: 1500
       TreatMissingData: breaching
       Dimensions:
         - Name: FunctionName

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -107,7 +107,7 @@ Resources:
         Variables:
           PINGBACKS: "true"
       Handler: index.handler
-      MemorySize: 384
+      MemorySize: 512
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
       Runtime: nodejs8.10
       Tags:


### PR DESCRIPTION
Changed our kinesis stream to have fewer shards (3).  And the new "combined" downloads+impressions kinesis records also increase the amount of work-per-record the lambdas have to do.

- [x] Add some more memory to BigQuery and Pingbacks lambdas, as they were getting close to the limit.  (If you hit the memory limit, the execution is halted and the batch of kinesis records retried).
- [x] Decrease alarm threshold.  We now average < 900 lambda executions every 5 minutes.