### PR TITLE
DynamoDB table template

### DIFF
--- a/db/dynamodb-table.yml
+++ b/db/dynamodb-table.yml
@@ -1,0 +1,98 @@
+# db/dynamodb-table.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Create a simple primary-key-lookup DynamoDB table
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Table Definition
+        Parameters:
+          - TableName
+          - PrimaryKey
+          - PrimaryType
+          - ExpirationField
+      - Label:
+          default: Metadata
+        Parameters:
+          - EnvironmentType
+          - ProjectTag
+    ParameterLabels:
+      TableName:
+        default: Table name
+      PrimaryKey:
+        default: Primary key field
+      PrimaryType:
+        default: Primary key type
+      ExpirationField:
+        default: Field to enable expiration on
+      EnvironmentType:
+        default: Environment type
+      ProjectTag:
+        default: Project Tag
+Parameters:
+  TableName:
+    Type: String
+    Description: The unique DynamoDB table name.
+  PrimaryKey:
+    Type: String
+    Description: The name of the primary key field
+  PrimaryType:
+    Type: String
+    Description: The type of the primary key field
+    AllowedValues:
+      - String
+      - Numeric
+      - Binary
+  ExpirationField:
+    Type: String
+    Description: Optionally enable Time-To-Live on this field
+  EnvironmentType:
+    Type: String
+    Description: Environment this table is used by.
+    AllowedValues:
+      - Testing
+      - Staging
+      - Production
+  ProjectTag:
+    Type: String
+    Description: The value used for the Project tag on resources that support tagging.
+Conditions:
+  HasExpirationField: !Not [!Equals [!Ref ExpirationField, ""]]
+Mappings:
+  DataTypesMap:
+    String:
+      Symbol: S
+    Numeric:
+      Symbol: N
+    Binary:
+      Symbol: B
+Resources:
+  DynamoDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref PrimaryKey
+          AttributeType: !FindInMap [DataTypesMap, !Ref PrimaryType, Symbol]
+      # https://github.com/awslabs/cfn-python-lint/issues/509
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: !Ref PrimaryKey
+          KeyType: HASH
+      TableName: !Ref TableName
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectTag
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TimeToLiveSpecification:
+        AttributeName: !If [HasExpirationField, !Ref "ExpirationField", !Ref "AWS::NoValue"]
+        Enabled: !If [HasExpirationField, true, false]
+Outputs:
+  TableArn:
+    Description: The created DynamoDB table ARN
+    Value: !GetAtt DynamoDBTable.Arn

--- a/db/dynamodb-table.yml
+++ b/db/dynamodb-table.yml
@@ -13,6 +13,11 @@ Metadata:
           - PrimaryType
           - ExpirationField
       - Label:
+          default: Optional Permissions
+        Parameters:
+          - ForeignAccountId
+          - ForeignRoleName
+      - Label:
           default: Metadata
         Parameters:
           - EnvironmentType
@@ -26,6 +31,10 @@ Metadata:
         default: Primary key type
       ExpirationField:
         default: Field to enable expiration on
+      ForeignAccountId:
+        default: Foreign account id
+      ForeignRoleName:
+        default: Role name in foreign account
       EnvironmentType:
         default: Environment type
       ProjectTag:
@@ -47,6 +56,12 @@ Parameters:
   ExpirationField:
     Type: String
     Description: Optionally enable Time-To-Live on this field
+  ForeignAccountId:
+    Type: String
+    Description: Optional account to enable write access to
+  ForeignRoleName:
+    Type: String
+    Description: Optional role name within that account (MUST EXIST)
   EnvironmentType:
     Type: String
     Description: Environment this table is used by.
@@ -59,6 +74,8 @@ Parameters:
     Description: The value used for the Project tag on resources that support tagging.
 Conditions:
   HasExpirationField: !Not [!Equals [!Ref ExpirationField, ""]]
+  HasForeignAccount: !Not [!Equals [!Ref ForeignAccountId, ""]]
+  HasForeignRole: !Not [!Equals [!Ref ForeignRoleName, ""]]
 Mappings:
   DataTypesMap:
     String:
@@ -92,6 +109,40 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: !If [HasExpirationField, !Ref "ExpirationField", !Ref "AWS::NoValue"]
         Enabled: !If [HasExpirationField, true, false]
+  CrossAccountAccessRole:
+    Type: "AWS::IAM::Role"
+    Condition: HasForeignAccount
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "sts:AssumeRole"
+            Principal:
+              !If
+                - HasForeignRole
+                - AWS: !Sub "arn:aws:iam::${ForeignAccountId}:role/${ForeignRoleName}"
+                - AWS: !Ref ForeignAccountId
+      Path: "/"
+      Policies:
+        - PolicyName: DynamoDBWritePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "dynamodb:BatchGetItem"
+                  - "dynamodb:BatchWriteItem"
+                  - "dynamodb:ConditionCheck"
+                  - "dynamodb:DeleteItem"
+                  - "dynamodb:DescribeTable"
+                  - "dynamodb:DescribeTimeToLive"
+                  - "dynamodb:GetItem"
+                  - "dynamodb:PutItem"
+                  - "dynamodb:Query"
+                  - "dynamodb:UpdateItem"
+                Resource:
+                  - !GetAtt DynamoDBTable.Arn
 Outputs:
   TableArn:
     Description: The created DynamoDB table ARN


### PR DESCRIPTION
Creates a dynamodb table.  Optionally:

- Sets an expiration/TTL field
- Creates a role to grant access to an account-id
- Grants access to a specific pre-existing role in that account (maybe will use this later)