### PR TITLE
analytics-dynamodb-lambda

### DIFF
--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -18,6 +18,14 @@ Parameters:
     Type: String
   EnvironmentTypeAbbreviation:
     Type: String
+  MetricsKinesisStream:
+    Type: AWS::SSM::Parameter::Value<String>
+  DynamodbKinesisStream:
+    Type: AWS::SSM::Parameter::Value<String>
+  DynamodbTableName:
+    Type: AWS::SSM::Parameter::Value<String>
+  DynamodbAccessRole:
+    Type: AWS::SSM::Parameter::Value<String>
 Mappings:
   VPCSettingsMap:
     test:
@@ -63,6 +71,24 @@ Resources:
                   - "ssm:GetParametersByPath"
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/prx/${EnvironmentTypeAbbreviation}/analytics-*"
+        - PolicyName: KinesisWritePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "kinesis:DescribeStream"
+                  - "kinesis:PutRecord"
+                  - "kinesis:PutRecords"
+                Resource:
+                  - !Ref MetricsKinesisStream
+        - PolicyName: DynamodbAssumeRolePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "sts:AssumeRole"
+                Resource: !Ref DynamodbAccessRole
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
@@ -161,6 +187,10 @@ Resources:
         Variables:
           PARAMSTORE_PREFIX: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-dynamodb"
           DYNAMODB: "true"
+          DDB_TABLE: !Ref DynamodbTableName
+          DDB_ROLE: !Ref DynamodbAccessRole
+          DDB_TTL: "604800"
+          KINESIS_STREAM: !Ref MetricsKinesisStream
       Handler: index.handler
       MemorySize: 256
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
@@ -175,6 +205,16 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       Timeout: 30
+  # Lambda Triggers
+  # TODO: bigquery/pingbacks/redis triggers manually managed, and tricky to move
+  AnalyticsDynamodbKinesisTrigger:
+    Type: "AWS::Lambda::EventSourceMapping"
+    Properties:
+      BatchSize: 100
+      Enabled: true
+      EventSourceArn: !Ref DynamodbKinesisStream
+      FunctionName: !Ref AnalyticsDynamodbLambdaFunction
+      StartingPosition: "LATEST"
   # Lambda Alarms
   AnalyticsBigqueryErrorAlarm:
     Type: "AWS::CloudWatch::Alarm"

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -149,6 +149,32 @@ Resources:
       VpcConfig:
         SecurityGroupIds: !Split [",", !FindInMap [VPCSettingsMap, !Ref EnvironmentTypeAbbreviation, vpcsecurity]]
         SubnetIds: !Split [",", !FindInMap [VPCSettingsMap, !Ref EnvironmentTypeAbbreviation, vpcsubnets]]
+  AnalyticsDynamodbLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: lambda/PRX-analytics-ingest-lambda.zip
+        S3ObjectVersion: !Ref CodeS3ObjectVersion
+      Description: Dovetail analytics to dynamodb
+      Environment:
+        Variables:
+          PARAMSTORE_PREFIX: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-dynamodb"
+          DYNAMODB: "true"
+      Handler: index.handler
+      MemorySize: 256
+      Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
+      Runtime: nodejs8.10
+      Tags:
+        - Key: Project
+          Value: Dovetail
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      Timeout: 30
   # Lambda Alarms
   AnalyticsBigqueryErrorAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -319,3 +345,51 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref AnalyticsRedisLambdaFunction
+  AnalyticsDynamodbErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[AnalyticsLambda][DynamoDB][Errors] ${EnvironmentType} > 0"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription:
+        Too many analytics dynamodb lambda errors
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AnalyticsDynamodbLambdaFunction
+  AnalyticsDynamodbIteratorAgeAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[AnalyticsLambda][DynamoDB][IteratorAge] ${EnvironmentType} > 1 Hour"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription:
+        Processing is very behind
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: IteratorAge
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Maximum
+      Threshold: 3600000
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AnalyticsDynamodbLambdaFunction

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -185,7 +185,6 @@ Resources:
       Description: Dovetail analytics to dynamodb
       Environment:
         Variables:
-          PARAMSTORE_PREFIX: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-dynamodb"
           DYNAMODB: "true"
           DDB_TABLE: !Ref DynamodbTableName
           DDB_ROLE: !Ref DynamodbAccessRole

--- a/stacks/analytics-ingest-lambda.yml
+++ b/stacks/analytics-ingest-lambda.yml
@@ -18,14 +18,6 @@ Parameters:
     Type: String
   EnvironmentTypeAbbreviation:
     Type: String
-  MetricsKinesisStream:
-    Type: AWS::SSM::Parameter::Value<String>
-  DynamodbKinesisStream:
-    Type: AWS::SSM::Parameter::Value<String>
-  DynamodbTableName:
-    Type: AWS::SSM::Parameter::Value<String>
-  DynamodbAccessRole:
-    Type: AWS::SSM::Parameter::Value<String>
 Mappings:
   VPCSettingsMap:
     test:
@@ -71,24 +63,6 @@ Resources:
                   - "ssm:GetParametersByPath"
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/prx/${EnvironmentTypeAbbreviation}/analytics-*"
-        - PolicyName: KinesisWritePolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "kinesis:DescribeStream"
-                  - "kinesis:PutRecord"
-                  - "kinesis:PutRecords"
-                Resource:
-                  - !Ref MetricsKinesisStream
-        - PolicyName: DynamodbAssumeRolePolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action: "sts:AssumeRole"
-                Resource: !Ref DynamodbAccessRole
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
@@ -175,45 +149,6 @@ Resources:
       VpcConfig:
         SecurityGroupIds: !Split [",", !FindInMap [VPCSettingsMap, !Ref EnvironmentTypeAbbreviation, vpcsecurity]]
         SubnetIds: !Split [",", !FindInMap [VPCSettingsMap, !Ref EnvironmentTypeAbbreviation, vpcsubnets]]
-  AnalyticsDynamodbLambdaFunction:
-    Type: "AWS::Lambda::Function"
-    Properties:
-      Code:
-        S3Bucket: !Ref CodeS3Bucket
-        S3Key: lambda/PRX-analytics-ingest-lambda.zip
-        S3ObjectVersion: !Ref CodeS3ObjectVersion
-      Description: Dovetail analytics to dynamodb
-      Environment:
-        Variables:
-          DYNAMODB: "true"
-          DDB_TABLE: !Ref DynamodbTableName
-          DDB_ROLE: !Ref DynamodbAccessRole
-          DDB_TTL: "604800"
-          KINESIS_STREAM: !Ref MetricsKinesisStream
-      Handler: index.handler
-      MemorySize: 256
-      Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
-      Runtime: nodejs8.10
-      Tags:
-        - Key: Project
-          Value: Dovetail
-        - Key: Environment
-          Value: !Ref EnvironmentType
-        - Key: "prx:cloudformation:stack-name"
-          Value: !Ref AWS::StackName
-        - Key: "prx:cloudformation:stack-id"
-          Value: !Ref AWS::StackId
-      Timeout: 30
-  # Lambda Triggers
-  # TODO: bigquery/pingbacks/redis triggers manually managed, and tricky to move
-  AnalyticsDynamodbKinesisTrigger:
-    Type: "AWS::Lambda::EventSourceMapping"
-    Properties:
-      BatchSize: 100
-      Enabled: true
-      EventSourceArn: !Ref DynamodbKinesisStream
-      FunctionName: !Ref AnalyticsDynamodbLambdaFunction
-      StartingPosition: "LATEST"
   # Lambda Alarms
   AnalyticsBigqueryErrorAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -384,51 +319,3 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref AnalyticsRedisLambdaFunction
-  AnalyticsDynamodbErrorAlarm:
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      ActionsEnabled: true
-      AlarmName: !Sub "[AnalyticsLambda][DynamoDB][Errors] ${EnvironmentType} > 0"
-      AlarmActions:
-        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      InsufficientDataActions:
-        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      OKActions:
-        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      AlarmDescription:
-        Too many analytics dynamodb lambda errors
-      ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Period: 300
-      Statistic: Sum
-      Threshold: 0
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref AnalyticsDynamodbLambdaFunction
-  AnalyticsDynamodbIteratorAgeAlarm:
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      ActionsEnabled: true
-      AlarmName: !Sub "[AnalyticsLambda][DynamoDB][IteratorAge] ${EnvironmentType} > 1 Hour"
-      AlarmActions:
-        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      InsufficientDataActions:
-        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      OKActions:
-        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      AlarmDescription:
-        Processing is very behind
-      ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
-      MetricName: IteratorAge
-      Namespace: AWS/Lambda
-      Period: 60
-      Statistic: Maximum
-      Threshold: 3600000
-      TreatMissingData: notBreaching
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref AnalyticsDynamodbLambdaFunction

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -828,6 +828,10 @@ Resources:
           Fn::ImportValue:
             !Sub "${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket"
         CodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
+        MetricsKinesisStream: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/METRICS_KINESIS_STREAM"]]
+        DynamodbKinesisStream: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"]]
+        DynamodbTableName: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_TABLE_NAME"]]
+        DynamodbAccessRole: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_ACCESS_ROLE"]]
       Tags:
         - Key: "prx:cloudformation:stack-name"
           Value: !Ref AWS::StackName

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -228,6 +228,7 @@ Resources:
         DovetailCountsLambdaCodeS3ObjectVersion: !Ref DovetailCountsLambdaCodeS3ObjectVersion
         CmsAudioLambdaCodeS3ObjectVersion: !Ref CmsAudioLambdaCodeS3ObjectVersion
         CmsImageLambdaCodeS3ObjectVersion: !Ref CmsImageLambdaCodeS3ObjectVersion
+        AnalyticsIngestLambdaCodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
       Tags:
         - Key: "prx:cloudformation:stack-name"
           Value: !Ref AWS::StackName
@@ -828,10 +829,6 @@ Resources:
           Fn::ImportValue:
             !Sub "${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket"
         CodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
-        MetricsKinesisStream: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/METRICS_KINESIS_STREAM"]]
-        DynamodbKinesisStream: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"]]
-        DynamodbTableName: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_TABLE_NAME"]]
-        DynamodbAccessRole: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_ACCESS_ROLE"]]
       Tags:
         - Key: "prx:cloudformation:stack-name"
           Value: !Ref AWS::StackName

--- a/stacks/serverless/analytics-ingest-alarms.yml
+++ b/stacks/serverless/analytics-ingest-alarms.yml
@@ -1,0 +1,89 @@
+# stacks/serverless/analytics-ingest-alarms.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: The many, many alarms on analytics-ingest-lambda functions
+Conditions:
+  CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+Parameters:
+  OpsWarnMessagesSnsTopicArn:
+    Type: String
+  OpsErrorMessagesSnsTopicArn:
+    Type: String
+  OpsFatalMessagesSnsTopicArn:
+    Type: String
+  EnvironmentType:
+    Type: String
+  DynamodbFunctionArn:
+    Type: String
+Resources:
+  AnalyticsDynamodbErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[AnalyticsLambda][DynamoDB][Errors] ${EnvironmentType} > 1"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription:
+        Too many analytics dynamodb lambda errors
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref DynamodbFunctionArn
+  AnalyticsDynamodbIteratorAgeWarnAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[AnalyticsLambda][DynamoDB][IteratorAge] ${EnvironmentType} > 15 minutes"
+      AlarmActions:
+        - !Ref OpsWarnMessagesSnsTopicArn
+      InsufficientDataActions:
+        - !Ref OpsWarnMessagesSnsTopicArn
+      OKActions:
+        - !Ref OpsWarnMessagesSnsTopicArn
+      AlarmDescription:
+        Processing is slightly behind
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: IteratorAge
+      Namespace: AWS/Lambda
+      Period: 15
+      Statistic: Maximum
+      Threshold: 900000
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref DynamodbFunctionArn
+  AnalyticsDynamodbIteratorAgeFatalAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[AnalyticsLambda][DynamoDB][IteratorAge] ${EnvironmentType} > 1 Hour"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription:
+        Processing is very behind
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: IteratorAge
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Maximum
+      Threshold: 3600000
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref DynamodbFunctionArn

--- a/stacks/serverless/analytics-ingest-lambdas.yml
+++ b/stacks/serverless/analytics-ingest-lambdas.yml
@@ -1,0 +1,107 @@
+# stacks/serverless/analytics-ingest-lambda.yml
+# This stack creates 4 lambda functions subscribed to kinesis streams:
+#   1) TODO: move analytics-bigquery
+#   2) TODO: move analytics-pingbacks
+#   3) TODO: move analytics-redis
+#   4) analytics-dynamodb - IAB 2.0 compliant downloads
+#      a) store temporary 'antebytes' records from dovetail.prx.org in ddb
+#      b) process 'bytes'/'segmentbytes' records from dovetail-counts-lambda,
+#         lookup the records in ddb, change them to type 'postbytes' and place
+#         back onto kinesis to be process by functions 1/2/3.
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Analytics ingest lambda functions
+Parameters:
+  CodeS3Bucket:
+    Type: String
+  CodeS3ObjectVersion:
+    Type: String
+  EnvironmentType:
+    Type: String
+  MetricsKinesisStream:
+    Type: AWS::SSM::Parameter::Value<String>
+  DynamodbKinesisStream:
+    Type: AWS::SSM::Parameter::Value<String>
+  DynamodbTableName:
+    Type: AWS::SSM::Parameter::Value<String>
+  DynamodbAccessRole:
+    Type: AWS::SSM::Parameter::Value<String>
+  DynamodbTTL:
+    Type: AWS::SSM::Parameter::Value<String>
+Resources:
+  # IAM Roles
+  AnalyticsDynamodbExecutionIAMRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+            - Effect: "Allow"
+              Principal:
+                Service:
+                  - "lambda.amazonaws.com"
+              Action:
+                - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyName: KinesisWritePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "kinesis:DescribeStream"
+                  - "kinesis:PutRecord"
+                  - "kinesis:PutRecords"
+                Resource:
+                  - !Ref MetricsKinesisStream
+        - PolicyName: DynamodbAssumeRolePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "sts:AssumeRole"
+                Resource: !Ref DynamodbAccessRole
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
+  # Lambda Functions
+  AnalyticsDynamodbLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: lambda/PRX-analytics-ingest-lambda.zip
+        S3ObjectVersion: !Ref CodeS3ObjectVersion
+      Description: Dovetail analytics to dynamodb
+      Environment:
+        Variables:
+          DYNAMODB: "true" # set function mode = dynamodb
+          DDB_TABLE: !Ref DynamodbTableName
+          DDB_ROLE: !Ref DynamodbAccessRole
+          DDB_TTL: !Ref DynamodbTTL
+          KINESIS_STREAM: !Ref MetricsKinesisStream
+      Handler: index.handler
+      MemorySize: 256
+      Role: !GetAtt AnalyticsDynamodbExecutionIAMRole.Arn
+      Runtime: nodejs8.10
+      Tags:
+        - Key: Project
+          Value: Dovetail
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      Timeout: 30
+  # Lambda Triggers
+  AnalyticsDynamodbKinesisTrigger:
+    Type: "AWS::Lambda::EventSourceMapping"
+    Properties:
+      BatchSize: 100
+      Enabled: true
+      EventSourceArn: !Ref DynamodbKinesisStream
+      FunctionName: !Ref AnalyticsDynamodbLambdaFunction
+      StartingPosition: "LATEST"
+Outputs:
+  DynamodbFunctionArn:
+    Value: !GetAtt AnalyticsDynamodbLambdaFunction.Arn

--- a/stacks/serverless/root.yml
+++ b/stacks/serverless/root.yml
@@ -37,6 +37,8 @@ Parameters:
     Type: String
   CmsImageLambdaCodeS3ObjectVersion:
     Type: String
+  AnalyticsIngestLambdaCodeS3ObjectVersion:
+    Type: String
 Resources:
   UploadLambdaStack:
     Type: "AWS::CloudFormation::Stack"
@@ -201,3 +203,50 @@ Resources:
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "cms-image-lambda.yml"]]
       TimeoutInMinutes: 5
+  AnalyticsIngestLambdasStack:
+    Type: "AWS::CloudFormation::Stack"
+    NotificationARNs:
+      - Fn::ImportValue:
+          !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
+    Parameters:
+      CodeS3Bucket:
+        Fn::ImportValue:
+          !Sub "${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket"
+      CodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
+      EnvironmentType: !Ref EnvironmentType
+      MetricsKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM"
+      DynamodbKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"
+      DynamodbTableName: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME"
+      DynamodbAccessRole: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_ACCESS_ROLE"
+      DynamodbTTL: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TTL"
+    Tags:
+      - Key: "prx:cloudformation:stack-name"
+        Value: !Ref AWS::StackName
+      - Key: "prx:cloudformation:stack-id"
+        Value: !Ref AWS::StackId
+    TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "analytics-ingest-lambdas.yml"]]
+    TimeoutInMinutes: 5
+  AnalyticsIngestAlarmsStack:
+    Type: "AWS::CloudFormation::Stack"
+    NotificationARNs:
+      - Fn::ImportValue:
+          !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
+    Parameters:
+      OpsWarnMessagesSnsTopicArn:
+        Fn::ImportValue:
+          !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+      OpsErrorMessagesSnsTopicArn:
+        Fn::ImportValue:
+          !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      OpsFatalMessagesSnsTopicArn:
+        Fn::ImportValue:
+          !Sub "${InfrastructureNotificationsStackName}-OpsFatalMessagesSnsTopicArn"
+      EnvironmentType: !Ref EnvironmentType
+      DynamodbFunctionArn: !GetAtt AnalyticsIngestLambdasStack.Outputs.DynamodbFunctionArn
+    Tags:
+      - Key: "prx:cloudformation:stack-name"
+        Value: !Ref AWS::StackName
+      - Key: "prx:cloudformation:stack-id"
+        Value: !Ref AWS::StackId
+    TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "analytics-ingest-alarms.yml"]]
+    TimeoutInMinutes: 5

--- a/stacks/serverless/root.yml
+++ b/stacks/serverless/root.yml
@@ -205,48 +205,50 @@ Resources:
       TimeoutInMinutes: 5
   AnalyticsIngestLambdasStack:
     Type: "AWS::CloudFormation::Stack"
-    NotificationARNs:
-      - Fn::ImportValue:
-          !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
-    Parameters:
-      CodeS3Bucket:
-        Fn::ImportValue:
-          !Sub "${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket"
-      CodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
-      EnvironmentType: !Ref EnvironmentType
-      MetricsKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM"
-      DynamodbKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"
-      DynamodbTableName: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME"
-      DynamodbAccessRole: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_ACCESS_ROLE"
-      DynamodbTTL: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TTL"
-    Tags:
-      - Key: "prx:cloudformation:stack-name"
-        Value: !Ref AWS::StackName
-      - Key: "prx:cloudformation:stack-id"
-        Value: !Ref AWS::StackId
-    TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "analytics-ingest-lambdas.yml"]]
-    TimeoutInMinutes: 5
+    Properties:
+      NotificationARNs:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
+      Parameters:
+        CodeS3Bucket:
+          Fn::ImportValue:
+            !Sub "${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket"
+        CodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
+        EnvironmentType: !Ref EnvironmentType
+        MetricsKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM"
+        DynamodbKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"
+        DynamodbTableName: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME"
+        DynamodbAccessRole: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_ACCESS_ROLE"
+        DynamodbTTL: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TTL"
+      Tags:
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "analytics-ingest-lambdas.yml"]]
+      TimeoutInMinutes: 5
   AnalyticsIngestAlarmsStack:
     Type: "AWS::CloudFormation::Stack"
-    NotificationARNs:
-      - Fn::ImportValue:
-          !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
-    Parameters:
-      OpsWarnMessagesSnsTopicArn:
-        Fn::ImportValue:
-          !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
-      OpsErrorMessagesSnsTopicArn:
-        Fn::ImportValue:
-          !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-      OpsFatalMessagesSnsTopicArn:
-        Fn::ImportValue:
-          !Sub "${InfrastructureNotificationsStackName}-OpsFatalMessagesSnsTopicArn"
-      EnvironmentType: !Ref EnvironmentType
-      DynamodbFunctionArn: !GetAtt AnalyticsIngestLambdasStack.Outputs.DynamodbFunctionArn
-    Tags:
-      - Key: "prx:cloudformation:stack-name"
-        Value: !Ref AWS::StackName
-      - Key: "prx:cloudformation:stack-id"
-        Value: !Ref AWS::StackId
-    TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "analytics-ingest-alarms.yml"]]
-    TimeoutInMinutes: 5
+    Properties:
+      NotificationARNs:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
+      Parameters:
+        OpsWarnMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        OpsErrorMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+        OpsFatalMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsFatalMessagesSnsTopicArn"
+        EnvironmentType: !Ref EnvironmentType
+        DynamodbFunctionArn: !GetAtt AnalyticsIngestLambdasStack.Outputs.DynamodbFunctionArn
+      Tags:
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "analytics-ingest-alarms.yml"]]
+      TimeoutInMinutes: 5


### PR DESCRIPTION
Initialize the analytics-dynamodb-lambda.

- [x] Triggered by the `dovetail-ddb-production` stream
- [x] Writes to dynamodb table `antebytes_production`
- [x] Uses the CrossAccountAccessRole in #301 
- [x] Writes records back to kinesis stream `dovetail-metrics-production-6s`

Can confirm those parameterstore values with:

```
aws ssm get-parameters-by-path --path /prx/stag/analytics-ingest-lambda/
aws ssm get-parameters-by-path --path /prx/prod/analytics-ingest-lambda/
```