### PR TITLE
Pixel tracker

### DIFF
--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -92,6 +92,8 @@ Parameters:
     Type: String
   RadiotopiaTowerLambdaCodeS3ObjectVersion:
     Type: String
+  PixelPrxOrgCodeS3ObjectVersion:
+    Type: String
   UploadLambdaCodeS3ObjectVersion:
     Type: String
   AnalyticsIngestLambdaCodeS3ObjectVersion:
@@ -236,6 +238,7 @@ Resources:
         CmsImageLambdaCodeS3ObjectVersion: !Ref CmsImageLambdaCodeS3ObjectVersion
         AnalyticsIngestLambdaCodeS3ObjectVersion: !Ref AnalyticsIngestLambdaCodeS3ObjectVersion
         RadiotopiaTowerLambdaCodeS3ObjectVersion: !Ref RadiotopiaTowerLambdaCodeS3ObjectVersion
+        PixelPrxOrgCodeS3ObjectVersion: !Ref PixelPrxOrgCodeS3ObjectVersion
       Tags:
         - Key: "prx:cloudformation:stack-name"
           Value: !Ref AWS::StackName

--- a/stacks/serverless/pixel.prx.org.yml
+++ b/stacks/serverless/pixel.prx.org.yml
@@ -1,0 +1,231 @@
+# stacks/serverless/pixel.prx.org.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: API Gateway pixel tracker
+Conditions:
+  CreateStagingResources: !Equals [!Ref EnvironmentType, Staging]
+  CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+Parameters:
+  OpsWarnMessagesSnsTopicArn:
+    Type: String
+  OpsErrorMessagesSnsTopicArn:
+    Type: String
+  CodeS3Bucket:
+    Type: String
+  CodeS3ObjectVersion:
+    Type: String
+  EnvironmentType:
+    Type: String
+  EnvironmentTypeAbbreviation:
+    Type: String
+Mappings:
+  EnvironmentTypeMap:
+    Testing:
+      DomainName: "pixel.test.prx.tech"
+      HostedZoneName: "prx.tech."
+      ValidationDomain: "prx.tech"
+    Staging:
+      DomainName: "pixel.staging.prx.tech"
+      HostedZoneName: "prx.tech."
+      ValidationDomain: "prx.tech"
+    Production:
+      DomainName: "pixel.prx.org"
+      HostedZoneName: "prx.org."
+      ValidationDomain: "prx.org"
+Resources:
+  Certificate:
+    Type: "AWS::CertificateManager::Certificate"
+    Properties:
+      DomainName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
+      DomainValidationOptions:
+        - ValidationDomain: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, ValidationDomain]
+          DomainName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
+      Tags:
+        - Key: Project
+          Value: pixel.prx.org
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: Name
+          Value: !Sub PixelPrxOrg-${EnvironmentType}
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+  PixelLambdaIamRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+            - Effect: "Allow"
+              Principal:
+                Service:
+                  - "lambda.amazonaws.com"
+              Action:
+                - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  PixelLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: lambda/PRX-pixel.prx.org.zip
+        S3ObjectVersion: !Ref CodeS3ObjectVersion
+      Description: API Gateway pixel tracker
+      Handler: index.handler
+      MemorySize: 192
+      Role: !GetAtt PixelLambdaIamRole.Arn
+      Runtime: nodejs8.10
+      Timeout: 30
+      Tags:
+        - Key: Project
+          Value: pixel.prx.org
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: Name
+          Value: !Sub PixelPrxOrg-${EnvironmentType}
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+  PixelRestApi:
+    Type: "AWS::ApiGateway::RestApi"
+    Properties:
+      Name: !Sub "${AWS::StackName} API"
+      Description: "API used by PRX Pixel Tracker Lambda"
+      BinaryMediaTypes:
+        - "image/gif"
+  PixelRestApiResource:
+    Type: "AWS::ApiGateway::Resource"
+    Properties:
+      ParentId: !GetAtt PixelRestApi.RootResourceId
+      PathPart: "{proxy+}"
+      RestApiId: !Ref PixelRestApi
+  PixelRestApiRootMethod:
+    Type: "AWS::ApiGateway::Method"
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: ANY
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PixelLambdaFunction.Arn}/invocations
+      RestApiId: !Ref PixelRestApi
+      ResourceId: !GetAtt PixelRestApi.RootResourceId
+  PixelRestApiMethod:
+    Type: "AWS::ApiGateway::Method"
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: ANY
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PixelLambdaFunction.Arn}/invocations
+      RestApiId: !Ref PixelRestApi
+      ResourceId: !Ref PixelRestApiResource
+  PixelRestApiDeployment:
+    Type: "AWS::ApiGateway::Deployment"
+    DependsOn:
+      - PixelRestApiRootMethod
+      - PixelRestApiMethod
+    Properties:
+      RestApiId: !Ref PixelRestApi
+  PixelRestApiStage:
+    Type: "AWS::ApiGateway::Stage"
+    Properties:
+      DeploymentId: !Ref PixelRestApiDeployment
+      Description: Pixel tracker lambda API gateway integration
+      RestApiId: !Ref PixelRestApi
+      StageName: prod
+  PixelRestApiLambdaPermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: "lambda:InvokeFunction"
+      FunctionName: !Ref PixelLambdaFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PixelRestApi}/${PixelRestApiStage}/*"
+  PixelRestApiDomainName:
+    Type: "AWS::ApiGateway::DomainName"
+    Properties:
+      CertificateArn: !Ref Certificate
+      DomainName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
+  PixelRestApiBasePathMapping:
+    Type: "AWS::ApiGateway::BasePathMapping"
+    Properties:
+      DomainName: !Ref PixelRestApiDomainName
+      RestApiId: !Ref PixelRestApi
+      Stage: prod
+  PixelRestApiDomainNameRecordSetGroup:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Record sets for proxy server API
+      HostedZoneName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, HostedZoneName]
+      RecordSets:
+        - Type: AAAA
+          Name: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
+          AliasTarget:
+            DNSName: !GetAtt ProxyRestApiDomainName.DistributionDomainName
+            HostedZoneId: Z2FDTNDATAQYW2
+        - Type: A
+          Name: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
+          AliasTarget:
+            DNSName: !GetAtt ProxyRestApiDomainName.DistributionDomainName
+            HostedZoneId: Z2FDTNDATAQYW2
+  ProductionRedirectRestApiDomainName:
+    Type: "AWS::ApiGateway::DomainName"
+    Condition: CreateProductionResources
+    Properties:
+      CertificateArn: !Ref Certificate
+      DomainName: prx.org
+  ProductionRedirectRestApiBasePathMapping:
+    Type: "AWS::ApiGateway::BasePathMapping"
+    Condition: CreateProductionResources
+    Properties:
+      DomainName: !Ref ProductionRedirectRestApiDomainName
+      RestApiId: !Ref ProxyRestApi
+      Stage: prod
+  ProductionRestApiDomainName:
+    Type: "AWS::ApiGateway::DomainName"
+    Condition: CreateProductionResources
+    Properties:
+      CertificateArn: !Ref Certificate
+      DomainName: www.prx.org
+  ProductionRestApiBasePathMapping:
+    Type: "AWS::ApiGateway::BasePathMapping"
+    Condition: CreateProductionResources
+    Properties:
+      DomainName: !Ref ProductionRestApiDomainName
+      RestApiId: !Ref ProxyRestApi
+      Stage: prod
+  ApiGateway5XXAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[proxy.prx.org][${EnvironmentType}] 5XXErrors"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription: >
+        Too many 500 errors from the corporate site proxy
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} API"
+      EvaluationPeriods: 3
+      MetricName: 5xxError
+      Namespace: AWS/ApiGateway
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+Outputs:
+  ApiDomainName:
+    Description: The custom API domain name
+    Value: !Ref ProxyRestApiDomainName
+  DistributionDomainName:
+    Description: The Amazon CloudFront distribution domain name that's mapped to the custom domain name
+    Value: !GetAtt ProxyRestApiDomainName.DistributionDomainName

--- a/stacks/serverless/pixel.prx.org.yml
+++ b/stacks/serverless/pixel.prx.org.yml
@@ -2,7 +2,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: API Gateway pixel tracker
 Conditions:
-  CreateStagingResources: !Equals [!Ref EnvironmentType, Staging]
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
 Parameters:
   OpsWarnMessagesSnsTopicArn:
@@ -14,8 +13,6 @@ Parameters:
   CodeS3ObjectVersion:
     Type: String
   EnvironmentType:
-    Type: String
-  EnvironmentTypeAbbreviation:
     Type: String
 Mappings:
   EnvironmentTypeMap:
@@ -159,18 +156,18 @@ Resources:
   PixelRestApiDomainNameRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
-      Comment: Record sets for proxy server API
+      Comment: Record sets for pixel tracker server API
       HostedZoneName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, HostedZoneName]
       RecordSets:
         - Type: AAAA
           Name: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
           AliasTarget:
-            DNSName: !GetAtt ProxyRestApiDomainName.DistributionDomainName
+            DNSName: !GetAtt PixelRestApiDomainName.DistributionDomainName
             HostedZoneId: Z2FDTNDATAQYW2
         - Type: A
           Name: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
           AliasTarget:
-            DNSName: !GetAtt ProxyRestApiDomainName.DistributionDomainName
+            DNSName: !GetAtt PixelRestApiDomainName.DistributionDomainName
             HostedZoneId: Z2FDTNDATAQYW2
   ProductionRedirectRestApiDomainName:
     Type: "AWS::ApiGateway::DomainName"
@@ -183,7 +180,7 @@ Resources:
     Condition: CreateProductionResources
     Properties:
       DomainName: !Ref ProductionRedirectRestApiDomainName
-      RestApiId: !Ref ProxyRestApi
+      RestApiId: !Ref PixelRestApi
       Stage: prod
   ProductionRestApiDomainName:
     Type: "AWS::ApiGateway::DomainName"
@@ -196,13 +193,13 @@ Resources:
     Condition: CreateProductionResources
     Properties:
       DomainName: !Ref ProductionRestApiDomainName
-      RestApiId: !Ref ProxyRestApi
+      RestApiId: !Ref PixelRestApi
       Stage: prod
   ApiGateway5XXAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub "[proxy.prx.org][${EnvironmentType}] 5XXErrors"
+      AlarmName: !Sub "[pixel.prx.org][${EnvironmentType}] 5XXErrors"
       AlarmActions:
         - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
       InsufficientDataActions:
@@ -210,7 +207,7 @@ Resources:
       OKActions:
         - !If [CreateProductionResources, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
       AlarmDescription: >
-        Too many 500 errors from the corporate site proxy
+        Too many 500 errors from the pixel tracker
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: ApiName
@@ -225,7 +222,7 @@ Resources:
 Outputs:
   ApiDomainName:
     Description: The custom API domain name
-    Value: !Ref ProxyRestApiDomainName
+    Value: !Ref PixelRestApiDomainName
   DistributionDomainName:
     Description: The Amazon CloudFront distribution domain name that's mapped to the custom domain name
-    Value: !GetAtt ProxyRestApiDomainName.DistributionDomainName
+    Value: !GetAtt PixelRestApiDomainName.DistributionDomainName

--- a/stacks/serverless/pixel.prx.org.yml
+++ b/stacks/serverless/pixel.prx.org.yml
@@ -36,6 +36,7 @@ Resources:
       DomainValidationOptions:
         - ValidationDomain: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, ValidationDomain]
           DomainName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
+      ValidationMethod: DNS
       Tags:
         - Key: Project
           Value: pixel.prx.org

--- a/stacks/serverless/pixel.prx.org.yml
+++ b/stacks/serverless/pixel.prx.org.yml
@@ -19,23 +19,17 @@ Mappings:
     Testing:
       DomainName: "pixel.test.prx.tech"
       HostedZoneName: "prx.tech."
-      ValidationDomain: "prx.tech"
     Staging:
       DomainName: "pixel.staging.prx.tech"
       HostedZoneName: "prx.tech."
-      ValidationDomain: "prx.tech"
     Production:
       DomainName: "pixel.prx.org"
       HostedZoneName: "prx.org."
-      ValidationDomain: "prx.org"
 Resources:
   Certificate:
     Type: "AWS::CertificateManager::Certificate"
     Properties:
       DomainName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
-      DomainValidationOptions:
-        - ValidationDomain: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, ValidationDomain]
-          DomainName: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DomainName]
       ValidationMethod: DNS
       Tags:
         - Key: Project

--- a/stacks/serverless/root.yml
+++ b/stacks/serverless/root.yml
@@ -41,6 +41,8 @@ Parameters:
     Type: String
   RadiotopiaTowerLambdaCodeS3ObjectVersion:
     Type: String
+  PixelPrxOrgCodeS3ObjectVersion:
+    Type: String
 Resources:
   UploadLambdaStack:
     Type: "AWS::CloudFormation::Stack"
@@ -260,4 +262,29 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "analytics-ingest-alarms.yml"]]
+      TimeoutInMinutes: 5
+  PixelPrxOrgStack:
+    Type: "AWS::CloudFormation::Stack"
+    Properties:
+      NotificationARNs:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
+      Parameters:
+        OpsWarnMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        OpsErrorMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+        CodeS3Bucket:
+          Fn::ImportValue:
+            !Sub "${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket"
+        CodeS3ObjectVersion: !Ref PixelPrxOrgCodeS3ObjectVersion
+        EnvironmentType: !Ref EnvironmentType
+      Tags:
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "pixel.prx.org.yml"]]
       TimeoutInMinutes: 5


### PR DESCRIPTION
Initial deployment for a pixel tracker API gateway [pixel.prx.org](https://github.com/PRX/pixel.prx.org).

This goes the same route as proxy.prx.org, and just sends _all_ HTTP methods and paths on to the lambda.  May dial that back at some point, to reduce load.  But this seemed like an easy place to start.