### PR TITLE
HOLD Allow detached CDN certificates

### DIFF
--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -36,10 +36,16 @@ Conditions:
   HasCloudFrontWebACLId: !Not [!Equals [!Ref CloudFrontWebACLId, ""]]
   HasAcmCertificateArn: !Not [!Equals [!Ref AcmCertificateArn, ""]]
   HasNoAcmCertificateArn: !Equals [!Ref AcmCertificateArn, ""]
+  HasDetachedCertificate: !Equals [!Ref CertificateAttachment, "Detached"]
   HasOriginPath: !Not [!Equals [!Ref OriginPath, ""]]
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
+      - Label:
+          default: HTTPS Certificate
+        Parameters:
+          - CertificateAttachment
+          - AcmCertificateArn
       - Label:
           default: Distribution
         Parameters:
@@ -68,10 +74,6 @@ Metadata:
           - CloudFrontCustom403ErrorResponseCode
           - CloudFrontCustom403ErrorResponsePagePath
           - CloudFrontWebACLId
-      - Label:
-          default: HTTPS Certificate
-        Parameters:
-          - AcmCertificateArn
     ParameterLabels:
       ProjectTag:
         default: Project tag
@@ -113,6 +115,8 @@ Metadata:
         default: AWS WAF web ACL ID
       AcmCertificateArn:
         default: Certificate ARN
+      CertificateAttachment:
+        default: Certificate attachment
 Parameters:
   ProjectTag:
     Type: String
@@ -252,9 +256,23 @@ Parameters:
     Description: >
       ARN for the ACM certificate that will be used with the CloudFront
       distribution. If no value is supplied, a new certificate will be created.
+  CertificateAttachment:
+    Type: String
+    Description: >
+      When "Detached" is chosen, an ACM certificate will be created for the
+      provided CNAMEs, but it will not be associated with the CloudFront
+      distribution. The CNAMEs will also not added as aliases to the
+      distribution. This allows the certificate and the distribution to be
+      created simultaneously. If a Certificate ARN is provided this should
+      always be set to "Attached".
+    AllowedValues:
+      - Attached
+      - Detached
 Resources:
-  # ACM Certificate
-  # This gets created when no ARN for a pre-existing certificate is provided
+  # If no ACM certificate ARN was provided as a stack parameter, a new ACM
+  # certificate will be minted. It will be a single certificate covering all
+  # domain names listed in the CNAMEs parameter. The certificate will be
+  # created even if the stack has a detached certificate.
   Certificate:
     Type: "AWS::CertificateManager::Certificate"
     Condition: HasNoAcmCertificateArn
@@ -275,7 +293,11 @@ Resources:
     Type: "AWS::CloudFront::Distribution"
     Properties:
       DistributionConfig:
-        Aliases: !Ref Cnames
+        # Aliases can only be configured on a distribution if there is an
+        # associated, validated certificate that covers every alias domain.
+        # When the stack has a detached certificate, that is not possible, so
+        # the aliases are ignored until the certificate is attached.
+        Aliases: !If [HasDetachedCertificate, !Ref "AWS::NoValue", !Ref "Cnames"]
         # CacheBehaviors:
           # CacheBehavior
         Comment: !Ref CloudFrontComment
@@ -341,11 +363,18 @@ Resources:
         # Restrictions:
         #   Restriction
         ViewerCertificate:
-          AcmCertificateArn: !If [HasAcmCertificateArn, !Ref "AcmCertificateArn", !Ref Certificate]
-          # CloudFrontDefaultCertificate: true
-          # IamCertificateId: String
-          # MinimumProtocolVersion: String
-          SslSupportMethod: sni-only
+          # When the stack has a detached certificate, the distribution will
+          # use the default CloudFront certificate (*.cloudfront.net). When
+          # the certificate is attached it conditionally uses a provided ACM
+          # certificate, or the one created by the stack.
+          !If
+            - HasDetachedCertificate
+            - !Ref "AWS::NoValue"
+            - AcmCertificateArn: !If [HasAcmCertificateArn, !Ref AcmCertificateArn, !Ref Certificate]
+              # CloudFrontDefaultCertificate: true
+              # IamCertificateId: String
+              # MinimumProtocolVersion: String
+              SslSupportMethod: sni-only
         WebACLId: !If [HasCloudFrontWebACLId, !Ref "CloudFrontWebACLId", !Ref "AWS::NoValue"]
       Tags:
         - Key: Project

--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -125,6 +125,9 @@ Parameters:
       comma-delimited list (e.g. "cdn1.example.com,cdn2.example.com")
   OriginDomain:
     Type: String
+    AllowedPattern: ^.+\.[a-zA-Z]+$
+    ConstraintDescription: >
+      must be a hostname or of the format mybucket.s3.amazonaws.com
     Description: >
       The DNS name of the Amazon Simple Storage Service (S3) bucket or the HTTP
       server from which you want CloudFront to get objects for this origin.
@@ -137,7 +140,9 @@ Parameters:
       mark (/) and cannot end with a slash mark.
   CloudFrontLoggingBucket:
     Type: String
-    Default: xyz.s3.amazonaws.com
+    AllowedPattern: ^$|^.+\.s3\.amazonaws\.com$
+    ConstraintDescription: >
+      must be of the format mybucket.s3.amazonaws.com
     Description: >
       The Amazon S3 bucket address where access logs are stored for CloudFront.
       (e.g., mybucket.s3.amazonaws.com)
@@ -145,7 +150,7 @@ Parameters:
     Type: String
     Description: >
       (optional) A prefix for the access log file names for the CloudFront
-      distribution.
+      distribution. (e.g., myprefix/)
   CloudFrontComment:
     Type: String
     Description: >

--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -247,7 +247,7 @@ Parameters:
   CloudFrontCustom403ErrorResponseCode:
     Type: String
     Description: >
-      (optional) A custom HTTP resonse code to return when a 403 is returned by the origin
+      (optional) A custom HTTP response code to return when a 403 is returned by the origin
       by the origin
   CloudFrontCustom403ErrorResponsePagePath:
     Type: String

--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -137,8 +137,12 @@ Parameters:
     Description: >
       The DNS name of the Amazon Simple Storage Service (S3) bucket or the HTTP
       server from which you want CloudFront to get objects for this origin.
+      (e.g. "example.com" or "mybucket.s3.amazonaws.com")
   OriginPath:
     Type: String
+    AllowedPattern: ^$|^\/..+(?<!\/)$
+    ConstraintDescription: >
+      must start with a slash and must not end with a slash
     Description: >
       (optional) The path that CloudFront uses to request content from an S3
       bucket or custom origin. The combination of the DomainName and OriginPath
@@ -260,8 +264,9 @@ Parameters:
   AcmCertificateArn:
     Type: String
     Description: >
-      ARN for the ACM certificate that will be used with the CloudFront
-      distribution. If no value is supplied, a new certificate will be created.
+      (optional) ARN for the ACM certificate that will be used with the
+      CloudFront distribution. If no value is supplied, a new certificate will
+      be created.
   CertificateAttachment:
     Type: String
     Description: >

--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -120,12 +120,14 @@ Metadata:
 Parameters:
   ProjectTag:
     Type: String
+    AllowedPattern: ^.+$
+    ConstraintDescription: must not be blank
     Description: >
       The value used for the Project tag on resources that support tagging.
   Cnames:
     Type: CommaDelimitedList
     Description: >
-      The CNAMEs (alternate domain names) for the distribution, as a
+      (optional) The CNAMEs (alternate domain names) for the distribution, as a
       comma-delimited list (e.g. "cdn1.example.com,cdn2.example.com")
   OriginDomain:
     Type: String
@@ -148,8 +150,8 @@ Parameters:
     ConstraintDescription: >
       must be of the format mybucket.s3.amazonaws.com
     Description: >
-      The Amazon S3 bucket address where access logs are stored for CloudFront.
-      (e.g., mybucket.s3.amazonaws.com)
+      (optional) The Amazon S3 bucket address where access logs are stored for
+      CloudFront. (e.g., mybucket.s3.amazonaws.com)
   CloudFrontLoggingBucketPrefix:
     Type: String
     Description: >
@@ -157,23 +159,26 @@ Parameters:
       distribution. (e.g., myprefix/)
   CloudFrontComment:
     Type: String
+    AllowedPattern: ^.+$
+    ConstraintDescription: must not be blank
     Description: >
       Any comments that you want to include about the CloudFront distribution
     MaxLength: 128
   CloudFrontMinTtl:
     Type: String
     Description: >
-      The minimum amount of time that you want objects to stay in CloudFront
-      caches before CloudFront forwards another request to your origin to
-      determine whether the object has been updated.
+      (optional) The minimum amount of time that you want objects to stay in
+      CloudFront caches before CloudFront forwards another request to your
+      origin to determine whether the object has been updated.
   CloudFrontMaxTtl:
     Type: String
     Description: >
-      The maximum amount of time, in seconds, that you want objects to stay in
-      CloudFront caches before CloudFront forwards another request to your
-      origin to determine whether the object has been updated. The value that
-      you specify applies only when your origin adds HTTP headers such as
-      Cache-Control max-age, Cache-Control s-maxage, and Expires to objects
+      (optional) The maximum amount of time, in seconds, that you want objects
+      to stay in CloudFront caches before CloudFront forwards another request
+      to your origin to determine whether the object has been updated. The
+      value that you specify applies only when your origin adds HTTP headers
+      such as Cache-Control max-age, Cache-Control s-maxage, and Expires to
+      objects
   CloudFrontPriceClass:
     Type: String
     Description: >
@@ -242,15 +247,16 @@ Parameters:
   CloudFrontCustom403ErrorResponseCode:
     Type: String
     Description: >
-      A custom HTTP resonse code to return when a 403 is returned by the origin
+      (optional) A custom HTTP resonse code to return when a 403 is returned by the origin
+      by the origin
   CloudFrontCustom403ErrorResponsePagePath:
     Type: String
     Description: >
-      A custom page to return when a 403 is returned by the origin
+      (optional) A custom page to return when a 403 is returned by the origin
   CloudFrontWebACLId:
     Type: String
     Description: >
-      The AWS WAF web ACL to associate with this distribution
+      (optional) The AWS WAF web ACL to associate with this distribution
   AcmCertificateArn:
     Type: String
     Description: >


### PR DESCRIPTION
🚧 HOLD for now.

**These changes should (must) all be backwards compatible with the previous version of the template.**

Adds a `CertificateAttachment` parameter to the stack, which can be set to either `Attached` or `Detached`.

When set to `Attached` the template should behave as it did previously.

When set to `Detached`, the CloudFront distribution will use the default `*.cloudfront.net` certificate, rather than using the custom ACM certificate created by the stack, which will eliminate the dependency between the distribution and the certificate. This will allow the distribution to get created immediately along with the certificate, rather than waiting for the certificate to validate. 

Because CF aliases can no longer be added to distributions without a matching validated certificate, when `Detached` the aliases are not included.

The CloudFormation stack will not completely deploy until the certificate has been validated, ~but I think that certificate resources have an unlimited timeout, and the stack creation itself also has no timeout, so that should be fine even if it takes hours to days.~ The ACM certificate resource timeout after 12 hours if they're not validated.

In practice, this will allow us to provide both the validation DNS as well as the CF DNS records to the end user in one step. Once the certificate is validated, the stack can be switched to `Attached`, which will add the aliases to the distribution, and associated the custom certificate with the distribution.

The creation of the certificate resource is still solely dependent on whether the ARN of a preexisting certificate is provided in the `AcmCertificateArn` parameter.