### PR TITLE
Exchange worker autoscaling

### DIFF
--- a/stacks/container-apps/exchange-alarms.yml
+++ b/stacks/container-apps/exchange-alarms.yml
@@ -1,0 +1,172 @@
+# stacks/container-apps/exchange-alarms.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Exchange alarms
+Conditions:
+  CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+Parameters:
+  OpsWarnMessagesSnsTopicArn:
+    Type: String
+  OpsErrorMessagesSnsTopicArn:
+    Type: String
+  OpsFatalMessagesSnsTopicArn:
+    Type: String
+  EnvironmentType:
+    Type: String
+  ECSCluster:
+    Type: String
+  WorkerServiceName:
+    Type: String
+Mappings:
+  EnvironmentTypeMap:
+    Staging:
+      WorkerMinCount: 1
+      WorkerMaxCount: 4
+    Production:
+      WorkerMinCount: 2
+      WorkerMaxCount: 20
+Resources:
+  # exchange worker autoscaling
+  ExchangeAutoScalingIamRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "application-autoscaling.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
+  ExchangeWorkerAutoScaling:
+    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+    Properties:
+      MinCapacity: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, WorkerMinCount]
+      MaxCapacity: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, WorkerMaxCount]
+      ResourceId: !Join ["/", ["service", !Ref ECSCluster, !Ref WorkerServiceName]]
+      RoleARN: !GetAtt ExchangeAutoScalingIamRole.Arn
+      ScalableDimension: "ecs:service:DesiredCount"
+      ServiceNamespace: "ecs"
+  ExchangeWorkerAutoScalingInPolicy:
+    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Properties:
+      PolicyName: ScaleIn
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ExchangeWorkerAutoScaling
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: 60
+        MetricAggregationType: Average
+        StepAdjustments:
+        - MetricIntervalLowerBound: -21
+          MetricIntervalUpperBound: -19
+          ScalingAdjustment: -2
+        - MetricIntervalUpperBound: 0
+          ScalingAdjustment: -1
+  ExchangeWorkerAutoScalingScaleInAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[Exchange][Worker][AS:In] ${EnvironmentType} Scale In"
+      AlarmActions: [!Ref ExchangeWorkerAutoScalingInPolicy]
+      AlarmDescription: Scale in exchange workers
+      ComparisonOperator: LessThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Average
+      Threshold: 20
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Sub "Prx3${EnvironmentType}DeliveryUpdate"
+  ExchangeWorkerAutoScalingOutPolicy:
+    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Properties:
+      PolicyName: ScaleOut
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ExchangeWorkerAutoScaling
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: 120
+        MetricAggregationType: Average
+        StepAdjustments:
+        - MetricIntervalLowerBound: 0
+          MetricIntervalUpperBound: 80
+          ScalingAdjustment: 2
+        - MetricIntervalLowerBound: 80
+          MetricIntervalUpperBound: 380
+          ScalingAdjustment: 4
+        - MetricIntervalLowerBound: 380
+          ScalingAdjustment: 6
+  ExchangeWorkerAutoScalingScaleOutAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[Exchange][Worker][AS:Out] ${EnvironmentType} Scale Out"
+      AlarmActions: [!Ref ExchangeWorkerAutoScalingOutPolicy]
+      AlarmDescription: Scale out exchange workers
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Average
+      Threshold: 20
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Sub "Prx3${EnvironmentType}DeliveryUpdate"
+  # exchange/fixer queue depth alarms
+  ExchangeDeliveryUpdateAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[Exchange][Worker][SQS] ${EnvironmentType} Deliveries Not Processing"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription:
+        Deliveries are very behind
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 12
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 300
+      Statistic: Average
+      Threshold: 100
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Sub "Prx3${EnvironmentType}DeliveryUpdate"
+  ExchangeSayWhenAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[Exchange][Worker][SQS] ${EnvironmentType} SayWhen Not Processing"
+      AlarmActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      InsufficientDataActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      OKActions:
+        - !If [CreateProductionResources, !Ref OpsFatalMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
+      AlarmDescription:
+        SayWhen is very behind
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 12
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 300
+      Statistic: Average
+      Threshold: 50
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !Sub "Prx3${EnvironmentType}SayWhen"

--- a/stacks/container-apps/exchange-alarms.yml
+++ b/stacks/container-apps/exchange-alarms.yml
@@ -61,8 +61,8 @@ Resources:
         Cooldown: 60
         MetricAggregationType: Average
         StepAdjustments:
-        - MetricIntervalLowerBound: -21
-          MetricIntervalUpperBound: -19
+        - MetricIntervalLowerBound: -10
+          MetricIntervalUpperBound: -9
           ScalingAdjustment: -2
         - MetricIntervalUpperBound: 0
           ScalingAdjustment: -1
@@ -79,7 +79,7 @@ Resources:
       Namespace: AWS/SQS
       Period: 60
       Statistic: Average
-      Threshold: 20
+      Threshold: 10
       TreatMissingData: notBreaching
       Dimensions:
         - Name: QueueName

--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -194,6 +194,32 @@ Resources:
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "exchange-say-when.yml"]]
       TimeoutInMinutes: 5
+  ExchangeAlarmsStack:
+    Type: "AWS::CloudFormation::Stack"
+    Properties:
+      NotificationARNs:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
+      Parameters:
+        OpsWarnMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        OpsErrorMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+        OpsFatalMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsFatalMessagesSnsTopicArn"
+        EnvironmentType: !Ref EnvironmentType
+        ECSCluster: !Ref ECSCluster
+        WorkerServiceName: !GetAtt ExchangeStack.WorkerServiceName
+      Tags:
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "exchange-alarms.yml"]]
+      TimeoutInMinutes: 5
   NetworksStack:
     Type: "AWS::CloudFormation::Stack"
     Condition: IsStaging

--- a/stacks/container-apps/web-application.yml
+++ b/stacks/container-apps/web-application.yml
@@ -377,6 +377,9 @@ Outputs:
   WorkerTaskDefinitionName:
     Description: Name of the worker task definition
     Value: !Sub ${AppName}-worker
+  WorkerServiceName:
+    Description: Name of the worker service
+    Value: !If [CreateWorkerResources, !GetAtt WorkerService.Name, ""]
   HostedZoneDNSName:
     Description: Convenience domain name for the ALB in a hosted zone
     Value: !Sub |


### PR DESCRIPTION
For PRX/exchange.prx.org#508

- Adds fatal alarms for `Prx3ProductionDeliveryUpdate` and `Prx3ProductionSayWhen`
    _(We actually already had some alarms, but they were ops-error, and the thresholds may have been a bit too lenient.  Will delete them after this deploys)_
- Adds autoscaling to the ECS Worker tasks, but not the say_when task, which I _think_ per PRX/exchange.prx.org#446 has to be a singleton.  (Running more than one would result in duplicate tasks getting scheduled)

The scaling rules I went with, using Prx3ProductionDeliveryUpdate ApproximateNumberOfMessagesVisible:

- If between 0 and 1 once in 1 minute, scale in by 2
- If between 1 and 10 once in 1 minute, scale in by 1
- If between 20 and 100 once in 1 minute, scale out by 2 (cooldown 2 minutes)
- If between 100 and 400 once in 1 minute, scale out by 4 (cooldown 2 minutes)
- If above 400 once in 1 minute, scale out by 6 (cooldown 2 minutes)

Will have to watch these, and see if they behave okay.  I wanted the 1 minute alarm so these would scale quickly.  May need a longer cooldown though.