### PR TITLE
Add in statuspage email verification CNAMEs

### DIFF
--- a/dns/prx.org-hosted_zone.yml
+++ b/dns/prx.org-hosted_zone.yml
@@ -483,7 +483,7 @@ Resources:
           Type: A
           Name: !Sub fixer.${Domain}
         - ResourceRecords:
-            - !Sub prx-categorizer.herokuapp.com.
+            - prx-categorizer.herokuapp.com.
           TTL: "300"
           Type: CNAME
           Name: !Sub categorizer.${Domain}
@@ -1525,6 +1525,21 @@ Resources:
           TTL: "300"
           Type: CNAME
           Name: !Sub status.${Domain}
+        - ResourceRecords:
+            - spg.domainkey.u1834393.wl144.sendgrid.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub spg._domainkey.notifications.${Domain}
+        - ResourceRecords:
+            - spg2.domainkey.u1834393.wl144.sendgrid.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub spg2._domainkey.notifications.${Domain}
+        - ResourceRecords:
+            - u1834393.wl144.sendgrid.net.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub statuspage-notifications.notifications.${Domain}
   ZenDesk:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:


### PR DESCRIPTION
Need to add 3 CNAMEs

CNAME spg._domainkey.notifications.prx.org. spg.domainkey.u1834393.wl144.sendgrid.net

CNAME spg2._domainkey.notifications.prx.org. spg2.domainkey.u1834393.wl144.sendgrid.net

CNAME statuspage-notifications.notifications.prx.org. u1834393.wl144.sendgrid.net