### PR TITLE
Remove Jingle stack

### DIFF
--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -79,13 +79,6 @@ Parameters:
     Type: String
   CmsEcrImageTag:
     Type: String
-  # Jingle Specific ############################################################
-  JinglePlatformALBListenerPriorityPrefix:
-    Type: String
-  JingleSecretsVersion:
-    Type: String
-  JingleEcrImageTag:
-    Type: String
   # Styleguide Specific ############################################################
   StyleguidePlatformALBListenerPriorityPrefix:
     Type: String
@@ -436,50 +429,6 @@ Resources:
         AppName: "cms"
         CreateWorker: "true"
         ContainerPort: "3000"
-        HealthCheckPath: "/api/v1"
-      Tags:
-        - Key: "prx:cloudformation:stack-name"
-          Value: !Ref AWS::StackName
-        - Key: "prx:cloudformation:stack-id"
-          Value: !Ref AWS::StackId
-      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "web-application.yml"]]
-      TimeoutInMinutes: 5
-  JingleStack:
-    Type: "AWS::CloudFormation::Stack"
-    Condition: IsStaging
-    Properties:
-      NotificationARNs:
-        - Fn::ImportValue:
-            !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
-      Parameters:
-        VPC: !Ref VPC
-        PlatformALBDNSName: !Ref PlatformALBDNSName
-        PlatformALBFullName: !Ref PlatformALBFullName
-        PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
-        PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
-        ECSCluster: !Ref ECSCluster
-        ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
-        OpsDebugMessagesSnsTopicArn:
-          Fn::ImportValue:
-            !Sub "${InfrastructureNotificationsStackName}-OpsDebugMessagesSnsTopicArn"
-        OpsErrorMessagesSnsTopicArn:
-          Fn::ImportValue:
-            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
-        EnvironmentType: !Ref EnvironmentType
-        EnvironmentTypeAbbreviation: !Ref EnvironmentTypeAbbreviation
-        EcrRegion: !Ref EcrRegion
-        SecretsBase: !Ref SecretsBase
-        ContainerMemory: !Ref ContainerMemory
-        ContainerMemoryReservation: !Ref ContainerMemoryReservation
-        ContainerCpu: !Ref ContainerCpu
-        PlatformALBListenerPriorityPrefix: !Ref JinglePlatformALBListenerPriorityPrefix
-        EcrImageTag: !Ref JingleEcrImageTag
-        SecretsVersion: !Ref JingleSecretsVersion
-        AppName: "jingle"
-        CreateWorker: "false"
-        ContainerPort: "4000"
         HealthCheckPath: "/api/v1"
       Tags:
         - Key: "prx:cloudformation:stack-name"

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -48,10 +48,6 @@ Parameters:
     Type: String
   MetricsSecretsVersion:
     Type: String
-  JingleEcrImageTag:
-    Type: String
-  JingleSecretsVersion:
-    Type: String
   StyleguideEcrImageTag:
     Type: String
   StyleguideSecretsVersion:
@@ -190,8 +186,6 @@ Mappings:
       prefix: 35
     Metrics:
       prefix: 36
-    Jingle:
-      prefix: 38
     Grove:
       prefix: 40
     Crier:
@@ -345,10 +339,6 @@ Resources:
         AuguryPlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Augury, prefix]
         AuguryEcrImageTag: !Ref AuguryEcrImageTag
         AugurySecretsVersion: !Ref AugurySecretsVersion
-        # Jingle
-        JinglePlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Jingle, prefix]
-        JingleEcrImageTag: !Ref JingleEcrImageTag
-        JingleSecretsVersion: !Ref JingleSecretsVersion
         # Styleguide
         StyleguidePlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Styleguide, prefix]
         StyleguideEcrImageTag: !Ref StyleguideEcrImageTag


### PR DESCRIPTION
Not sure we've ever removed a stack before. The parameters will have to be removed from the template config manually before it's deployable, even for production.