### PR TITLE
Replace default ALB action

### DIFF
--- a/stacks/load-balancers.yml
+++ b/stacks/load-balancers.yml
@@ -115,8 +115,9 @@ Resources:
       Port: 80
       Protocol: HTTP
       DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref PlatformALBDefaultTargetGroup
+        - FixedResponseConfig:
+            StatusCode: "404"
+          Type: fixed-response
   PlatformALBHTTPSListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:
@@ -126,8 +127,9 @@ Resources:
       Port: 443
       Protocol: HTTPS
       DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref PlatformALBDefaultTargetGroup
+        - FixedResponseConfig:
+            StatusCode: "404"
+          Type: fixed-response
   # Logging
   PlatformALBLogsBucket:
     Type: "AWS::S3::Bucket"


### PR DESCRIPTION
Makes the default action for ALB listeners a fixed 404 response, rather than forwarding to the default target group. This is part of #350. If the results are as expected, the fourohfour service (and default TG) can be removed.