### PR TITLE
Reprioritize ALB listener rules

### DIFF
--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -170,18 +170,20 @@ Mappings:
   # Higher-traffic apps should be given a higher priority (lower number) to
   # reduce the number of rules evaluations needed for more common requests
   ALBListenerRulePriorityMap:
+    Play:
+      prefix: 12
     Exchange:
       prefix: 13
     Cms:
       prefix: 15
-    Play:
-      prefix: 21
     Id:
       prefix: 24
-    Publish:
-      prefix: 28
     Castle:
-      prefix: 35
+      prefix: 26
+    Remix:
+      prefix: 29
+    Publish:
+      prefix: 31
     Metrics:
       prefix: 36
     Grove:
@@ -194,8 +196,6 @@ Mappings:
       prefix: 50
     Augury:
       prefix: 55
-    Remix:
-      prefix: 60
     Styleguide:
       prefix: 65
     Networks:


### PR DESCRIPTION
Reorder the rules to optimize for current traffic patterns. Closes #359

It should avoid using any existing rule prefixes, even ones that are being unassigned.