### PR TITLE
Subscribe impressions to the ddb kinesis stream

### DIFF
--- a/etc/commitchange-ses.yml
+++ b/etc/commitchange-ses.yml
@@ -189,7 +189,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt MessageHandlerFunctionIamRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Tags:
         - Key: Project
           Value: Misc

--- a/etc/sample-step-functions.yml
+++ b/etc/sample-step-functions.yml
@@ -188,7 +188,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt SnsTopicLambdaIamRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Tags:
         - Key: foo
           Value: bar
@@ -333,7 +333,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt AnalyzeLambdaIamRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Tags:
         - Key: foo
           Value: bar

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -51,9 +51,8 @@ Parameters:
     Type: String
   DovetailSecretsVersion:
     Type: String
-  DynamodbKinesisArn:
-    Type: String
-    default: Kinesis Stream Arn
+  DynamodbKinesisStream:
+    Type: AWS::SSM::Parameter::Value<String>
   # Dovetail Elixir ############################################################
   DovetailRouterEcrImageTag:
     Type: String

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -52,7 +52,7 @@ Parameters:
   DovetailSecretsVersion:
     Type: String
   DynamodbKinesisArn:
-    type: String
+    Type: String
     default: Kinesis Stream Arn
   # Dovetail Elixir ############################################################
   DovetailRouterEcrImageTag:

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -51,6 +51,9 @@ Parameters:
     Type: String
   DovetailSecretsVersion:
     Type: String
+  DynamodbKinesisArn:
+    type: String
+    default: Kinesis Stream Arn
   # Dovetail Elixir ############################################################
   DovetailRouterEcrImageTag:
     Type: String
@@ -509,6 +512,46 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
+  # connect dovetail-router impressions to ddb kinesis
+  DovetailRouterSubscriptionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+            - Effect: "Allow"
+              Principal:
+                Service:
+                  - !Sub "logs.${AWS::Region}.amazonaws.com"
+              Action:
+                - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyName: DovetailRouterSubscriptionKinesisPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "kinesis:DescribeStream"
+                  - "kinesis:PutRecord"
+                  - "kinesis:PutRecords"
+                Resource:
+                  - !Ref DynamodbKinesisArn
+      Tags:
+        - Key: Project
+          Value: Dovetail
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+  DovetailRouterDynamodbKinesisSubscriptionFilter:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Properties:
+      DestinationArn: !Ref DynamodbKinesisArn
+      FilterPattern: '{$.msg = impression}'
+      LogGroupName: !Ref DovetailRouterLogGroup.LogGroupName
+      RoleArn: !GetAtt DovetailRouterSubscriptionRole.arn
   # Autoscaling
   DovetailAutoScaling:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -514,6 +514,7 @@ Resources:
   # connect dovetail-router impressions to ddb kinesis
   DovetailRouterSubscriptionRole:
     Type: "AWS::IAM::Role"
+    Condition: CreateStagingResources
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -537,7 +537,7 @@ Resources:
                   - "kinesis:PutRecord"
                   - "kinesis:PutRecords"
                 Resource:
-                  - !Ref DynamodbKinesisArn
+                  - !Ref DynamodbKinesisStream
       Tags:
         - Key: Project
           Value: Dovetail
@@ -548,7 +548,7 @@ Resources:
   DovetailRouterDynamodbKinesisSubscriptionFilter:
     Type: "AWS::Logs::SubscriptionFilter"
     Properties:
-      DestinationArn: !Ref DynamodbKinesisArn
+      DestinationArn: !Ref DynamodbKinesisStream
       FilterPattern: '{$.msg = impression}'
       LogGroupName: !Ref DovetailRouterLogGroup.LogGroupName
       RoleArn: !GetAtt DovetailRouterSubscriptionRole.arn

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -550,8 +550,8 @@ Resources:
     Properties:
       DestinationArn: !Ref DynamodbKinesisStream
       FilterPattern: '{$.msg = impression}'
-      LogGroupName: !Ref DovetailRouterLogGroup.LogGroupName
-      RoleArn: !GetAtt DovetailRouterSubscriptionRole.arn
+      LogGroupName: !Ref DovetailRouterLogGroup
+      RoleArn: !GetAtt DovetailRouterSubscriptionRole.Arn
   # Autoscaling
   DovetailAutoScaling:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -712,7 +712,7 @@ Resources:
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !GetAtt ECSClusterStack.Outputs.ECSServiceAutoscaleIAMRoleArn
         ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
-        DynamodbKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"
+        DynamodbKinesisStream: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"]]
         OpsDebugMessagesSnsTopicArn:
           Fn::ImportValue:
             !Sub "${NotificationsStackName}-OpsDebugMessagesSnsTopicArn"

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -712,6 +712,7 @@ Resources:
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !GetAtt ECSClusterStack.Outputs.ECSServiceAutoscaleIAMRoleArn
         ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
+        DynamodbKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"
         OpsDebugMessagesSnsTopicArn:
           Fn::ImportValue:
             !Sub "${NotificationsStackName}-OpsDebugMessagesSnsTopicArn"


### PR DESCRIPTION
Sets up a subscription to the dovetail router log -- pushing those logs onto the bytes kinesis stream . Eventually, these dt-router impressions will be ingested by the bytes lambda as type 'ante-bytes' messages.