### PR TITLE
DNS stack cert validation

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -235,9 +235,6 @@ Resources:
     Type: "AWS::CertificateManager::Certificate"
     Properties:
       DomainName: !Sub "*.${AWS::Region}.${AWS::StackName}.prx.tech"
-      DomainValidationOptions:
-        - ValidationDomain: prx.tech
-          DomainName: !Sub "*.${AWS::Region}.${AWS::StackName}.prx.tech"
       Tags:
         - Key: Project
           Value: Infrastructure

--- a/dns/prxu.org-hosted_zone.yml
+++ b/dns/prxu.org-hosted_zone.yml
@@ -218,6 +218,11 @@ Resources:
       HostedZoneId: !Ref HostedZone
       RecordSets:
         - ResourceRecords:
+            - _f3ac86df105ba2b541203e3c55fc1a0b.acm-validations.aws.
+          TTL: "300"
+          Type: CNAME
+          Name: !Sub _4523c88a53cb676ba587436bd336533a.${Domain}
+        - ResourceRecords:
             - _a1223e715b9fc43c557b8daf3fa0df78.ltfvzjuylp.acm-validations.aws.
           TTL: "300"
           Type: CNAME

--- a/etc/wildcard-certificate.yml
+++ b/etc/wildcard-certificate.yml
@@ -7,9 +7,6 @@ Resources:
     Type: AWS::CertificateManager::Certificate
     Properties:
       DomainName: "*.prx.tech"
-      DomainValidationOptions:
-        - ValidationDomain: prx.tech
-          DomainName: "*.prx.tech"
       SubjectAlternativeNames:
         - "*.prx.org"
         - "*.prxu.org"

--- a/stacks/certificate.yml
+++ b/stacks/certificate.yml
@@ -17,9 +17,6 @@ Resources:
     Type: "AWS::CertificateManager::Certificate"
     Properties:
       DomainName: !Sub "*.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech"
-      DomainValidationOptions:
-        - ValidationDomain: prx.tech
-          DomainName: !Sub "*.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech"
       SubjectAlternativeNames:
         - "*.prx.org"
         - "*.prxu.org"
@@ -39,6 +36,7 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
+      ValidationMethod: DNS
 Outputs:
   WildcardCertificateArn:
     Description: The ARN for the wildcard certificate


### PR DESCRIPTION
The `prxu.org` DNS change has already been deployed.

The stack certificate change deploy should be watched somewhat closely. I have made sure that all the validation records it requires to mint the new certificate already exist, so it should deploy without intervention, but in case I missed something we'd want to create those records while it's deploying to prevent a rollback.