### PR TITLE
CDN 5XX rate alarms

### DIFF
--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -195,7 +195,7 @@ Resources:
       Namespace: AWS/CloudFront
       Period: 60
       Statistic: Average
-      Threshold: 0.03
+      Threshold: 0.5
       TreatMissingData: notBreaching
       Unit: Percent
   CloudFrontDistributionFatal500Alarm:
@@ -225,7 +225,7 @@ Resources:
       Namespace: AWS/CloudFront
       Period: 60
       Statistic: Average
-      Threshold: 0.5
+      Threshold: 2.0
       TreatMissingData: notBreaching
       Unit: Percent
 Outputs:


### PR DESCRIPTION
For PRX/internal#518.

We've been running "unofficial" dovetail CDN alarms for awhile - since our rate mysteriously increased in December.  This PR updates them, and makes them more permissive of our overnight error rate (which appears to go up, as there's less overall traffic but the same-ish number of 5XXs?).  