### PR TITLE
Kinesis traffic trigger

### DIFF
--- a/stacks/serverless/dovetail-traffic-lambda.yml
+++ b/stacks/serverless/dovetail-traffic-lambda.yml
@@ -12,6 +12,8 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
   ScheduleIntervalMinutes:
     Type: AWS::SSM::Parameter::Value<String>
+  MetricsKinesisStream:
+    Type: AWS::SSM::Parameter::Value<String>
 Resources:
   #
   # lambda function
@@ -28,6 +30,7 @@ Resources:
               Action: "sts:AssumeRole"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
       Path: "/"
       Policies:
@@ -101,6 +104,19 @@ Resources:
       Enabled: true
       EventSourceArn: !GetAtt DovetailTrafficSqsQueue.Arn
       FunctionName: !Ref DovetailTrafficLambdaFunction
+  #
+  # Kinesis cloned podcast scheduler
+  #
+  DovetailTrafficKinesisTrigger:
+    Type: "AWS::Lambda::EventSourceMapping"
+    Properties:
+      # use a large batch size. since we only care about a very small subset of
+      # records matching certain podcast ids, we end up discarding most.
+      BatchSize: 1000
+      Enabled: true
+      EventSourceArn: !Ref MetricsKinesisStream
+      FunctionName: !Ref DovetailTrafficLambdaFunction
+      StartingPosition: "LATEST"
   #
   # Cron to trigger the scheduler
   #

--- a/stacks/serverless/root.yml
+++ b/stacks/serverless/root.yml
@@ -179,6 +179,7 @@ Resources:
         CodeS3ObjectVersion: !Ref DovetailTrafficLambdaCodeS3ObjectVersion
         DownloaderBatchSize: !Sub "/prx/${EnvironmentTypeAbbreviation}/dovetail-traffic-lambda/DOWNLOADER_BATCH_SIZE"
         ScheduleIntervalMinutes: !Sub "/prx/${EnvironmentTypeAbbreviation}/dovetail-traffic-lambda/SCHEDULE_INTERVAL_MINUTES"
+        MetricsKinesisStream: !Sub "/prx/${EnvironmentTypeAbbreviation}/dovetail-traffic-lambda/METRICS_KINESIS_STREAM"
       Tags:
         - Key: "prx:cloudformation:stack-name"
           Value: !Ref AWS::StackName


### PR DESCRIPTION
After PRX/dovetail-traffic-lambda#5.  Init a kinesis trigger on `dovetail-metrics-6s`.

Also should check that we have plenty of space for another stream consumer.