### PR TITLE
Lambda@Edge support in single-origin CDN template

### DIFF
--- a/cdn/Lambda@Edge/origin-request-path-mapping.yml
+++ b/cdn/Lambda@Edge/origin-request-path-mapping.yml
@@ -1,0 +1,93 @@
+# cdn/Lambda@Edge/origin-request-path-mapping.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Creates a Lambda function intended to be used as a Lambda@Edge origin-request
+  handler. For CDN requests that match the provided path, the origin request
+  will use the defined alternate path.
+Parameters:
+  StaticViewerRequestPath:
+    Type: String
+    Description: >
+      eg. /songexploder. This is a path that will be statically mapped to a path
+      in the origin. It can be used when migrating feeds off of FeedBurner. This
+      would be the path in the feeds.feedburner.com URL.
+  StaticOriginRequestPath:
+    Type: String
+    Description: >
+      eg. /feed-rss.xml. The path that the static viewer request path is
+      remapped to. (ie, If a request is made for /songexploder, the CDN
+      will request /feed-rss.xml from the origin instead.)
+Resources:
+  LambdaExecutionIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - edgelambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaEdgePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:GetFunction
+                  - lambda:EnableReplication*
+                  - iam:CreateServiceLinkedRole
+                Resource:
+                  - "*"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile:
+          Fn::Sub: |
+            exports.handler = (event, context, callback) => {
+              const request = event.Records[0].cf.request;
+              if (request.uri === '${StaticViewerRequestPath}') {
+                request.uri = '${StaticOriginRequestPath}';
+              }
+              callback(null, request);
+            };
+      Description: Remaps static paths on origin requests
+      Handler: index.handler
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionIamRole.Arn
+      Runtime: nodejs12.x
+      Tags:
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId
+      Timeout: 1
+  # Lambda Versions
+  # These versions are referenced EXPLICITLY by CloudFront distributions, which
+  # will not start using new versions as soon as they are available.
+  #
+  # !!!! DO NOT DELETE VERSIONS !!!!
+  #
+  # Instead, create new AWS::Lambda::Version resources when there are updates
+  # to the Lambda code.
+  LambdaFunctionVersion1:
+    Type: AWS::Lambda::Version
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      FunctionName: !GetAtt LambdaFunction.Arn
+Outputs:
+  LambdaFunctionVersion1Arn:
+    Value: !Ref LambdaFunctionVersion1

--- a/cdn/Lambda@Edge/origin-request-path-override.yml
+++ b/cdn/Lambda@Edge/origin-request-path-override.yml
@@ -1,0 +1,82 @@
+# cdn/Lambda@Edge/origin-request-path-override.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Creates a Lambda function intended to be used as a Lambda@Edge origin-request
+  handler. The path of the viewer request is rewritten to the provided path.
+Parameters:
+  StaticOriginRequestPath:
+    Type: String
+    Description: >
+      eg. /feed-rss.xml. The path that all origin requests will use.
+Resources:
+  LambdaExecutionIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - edgelambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaEdgePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:GetFunction
+                  - lambda:EnableReplication*
+                  - iam:CreateServiceLinkedRole
+                Resource:
+                  - "*"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile:
+          Fn::Sub: |
+            exports.handler = (event, context, callback) => {
+              const request = event.Records[0].cf.request;
+              request.uri = '${StaticOriginRequestPath}';
+              callback(null, request);
+            };
+      Description: Remaps static paths on origin requests
+      Handler: index.handler
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionIamRole.Arn
+      Runtime: nodejs12.x
+      Tags:
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId
+      Timeout: 1
+  # Lambda Versions
+  # These versions are referenced EXPLICITLY by CloudFront distributions, which
+  # will not start using new versions as soon as they are available.
+  #
+  # !!!! DO NOT DELETE VERSIONS !!!!
+  #
+  # Instead, create new AWS::Lambda::Version resources when there are updates
+  # to the Lambda code.
+  LambdaFunctionVersion1:
+    Type: AWS::Lambda::Version
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      FunctionName: !GetAtt LambdaFunction.Arn
+Outputs:
+  LambdaFunctionVersion1Arn:
+    Value: !Ref LambdaFunctionVersion1

--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -44,6 +44,11 @@ Conditions:
   UseCertificate: !Or
     - !Condition CreateCertificate
     - !Condition HasAcmCertificateArn
+  HasOriginRequestLambdaFunctionAssociations: !Not [!Equals [!Ref CloudFrontLambdaFunctionAssociationsOriginRequestArn, ""]]
+  HasOriginResponseLambdaFunctionAssociations: !Not [!Equals [!Ref CloudFrontLambdaFunctionAssociationsOriginResponseArn, ""]]
+  HasLambdaFunctionAssociations: !Or
+    - !Condition HasOriginRequestLambdaFunctionAssociations
+    - !Condition HasOriginResponseLambdaFunctionAssociations
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -75,6 +80,8 @@ Metadata:
           - CloudFrontCustom403ErrorResponseCode
           - CloudFrontCustom403ErrorResponsePagePath
           - CloudFrontWebACLId
+          - CloudFrontLambdaFunctionAssociationsOriginRequestArn
+          - CloudFrontLambdaFunctionAssociationsOriginResponseArn
       - Label:
           default: HTTPS Certificate
         Parameters:
@@ -118,6 +125,10 @@ Metadata:
         default: Custom 403 error response page
       CloudFrontWebACLId:
         default: AWS WAF web ACL ID
+      CloudFrontLambdaFunctionAssociationsOriginRequestArn:
+        default: Origin request Lambda@Edge ARN
+      CloudFrontLambdaFunctionAssociationsOriginResponseArn:
+        default: Origin response Lambda@Edge ARN
       AcmCertificateArn:
         default: Certificate ARN
 Parameters:
@@ -264,6 +275,16 @@ Parameters:
     Type: String
     Description: >
       (optional) The AWS WAF web ACL to associate with this distribution
+  CloudFrontLambdaFunctionAssociationsOriginRequestArn:
+    Type: String
+    Description: >
+      (optional) The ARN for a Lambda function version to be used on
+      origin-request events
+  CloudFrontLambdaFunctionAssociationsOriginResponseArn:
+    Type: String
+    Description: >
+      (optional) The ARN for a Lambda function version to be used on
+      origin-response events
   AcmCertificateArn:
     Type: String
     Description: >
@@ -314,7 +335,21 @@ Resources:
             #   - String
             QueryString: false
             # QueryStringCacheKeys:
-          # LambdaFunctionAssociations:
+          LambdaFunctionAssociations:
+            !If
+              - HasLambdaFunctionAssociations
+              -
+                - !If
+                  - HasOriginRequestLambdaFunctionAssociations
+                  - EventType: origin-request
+                    LambdaFunctionARN: !Ref CloudFrontLambdaFunctionAssociationsOriginRequestArn
+                  - !Ref "AWS::NoValue"
+                - !If
+                  - HasOriginResponseLambdaFunctionAssociations
+                  - EventType: origin-response
+                    LambdaFunctionARN: !Ref CloudFrontLambdaFunctionAssociationsOriginResponseArn
+                  - !Ref "AWS::NoValue"
+              - !Ref "AWS::NoValue"
           MaxTTL: !If [HasCloudFrontMaxTtl, !Ref "CloudFrontMaxTtl", !Ref "AWS::NoValue"]
           MinTTL: !If [HasCloudFrontMinTtl, !Ref "CloudFrontMinTtl", !Ref "AWS::NoValue"]
           # SmoothStreaming: Boolean

--- a/cdn/single-origin.yml
+++ b/cdn/single-origin.yml
@@ -123,8 +123,8 @@ Metadata:
 Parameters:
   ProjectTag:
     Type: String
-    AllowedPattern: ^.+$
-    ConstraintDescription: must not be blank
+    AllowedPattern: ^([\p{L}\p{Z}\p{N}_.:\/=+\-@]+)$
+    ConstraintDescription: must not be blank and cannot contain some special characters
     Description: >
       The value used for the Project tag on resources that support tagging.
   Cnames:


### PR DESCRIPTION
- Adds basic support for passing in the ARN for Lambdas to use a Edge handlers on the single origin template
- Adds a couple generic Lambdas to handle basic path rewriting, mainly for use with Feedburner feeds