### PR TITLE
Update CI Docker image version

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -214,7 +214,7 @@ Resources:
             Value:
               Fn::ImportValue:
                 !Sub ${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         PrivilegedMode: true
         Type: LINUX_CONTAINER
       # NOTE If Name changes, the CodeBuild Role Logs policy also must change


### PR DESCRIPTION
V1 doesn't look to be supported any more, and is missing new runtimes, like node 12