### PR TITLE
Analytics ddb alarms

### DIFF
--- a/stacks/serverless/analytics-ingest-alarms.yml
+++ b/stacks/serverless/analytics-ingest-alarms.yml
@@ -43,7 +43,7 @@ Resources:
       AlarmDescription:
         Too many analytics bigquery lambda errors
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
+      EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda
       Period: 60
@@ -115,7 +115,7 @@ Resources:
       AlarmDescription:
         Too many analytics dynamodb lambda errors
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
+      EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda
       Period: 60
@@ -259,7 +259,7 @@ Resources:
       AlarmDescription:
         Too many analytics redis lambda errors
       ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
+      EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda
       Period: 60

--- a/stacks/serverless/analytics-ingest-lambdas.yml
+++ b/stacks/serverless/analytics-ingest-lambdas.yml
@@ -91,6 +91,7 @@ Resources:
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+        - "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
       Tags:
         - Key: Project
           Value: Dovetail
@@ -156,7 +157,7 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
-      Timeout: 30
+      Timeout: 10
   AnalyticsPingbacksLambdaFunction:
     Type: "AWS::Lambda::Function"
     Properties:


### PR DESCRIPTION
- [x] Add xray to analytics ingest lambda role, so we can enable temporarily on the DDB lambda.
- [x] Quiet down alarms on BQ/DDB lambdas, since their operations are all idempotent.
- [x] Quiet down alarms on Redis lambda, since it's a temporary cache for Castle download data and doesn't need to be entirely accurate.