### PR TITLE
Track how long ECS agents have been disconnected

### DIFF
--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -867,6 +867,29 @@ Resources:
       Targets:
         - Arn: !GetAtt ASGSizerFunction.Arn
           Id: !Sub "${EnvironmentType}-ECS-ASG-Sizing"
+  ASGSizerErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[ECS][ASGSizerLambda] ${EnvironmentType} Errors"
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      InsufficientDataActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      OKActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription: ASG Sizer Lambda errors
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref ASGSizerFunction
 Outputs:
   ECSCluster:
     Description: >

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -767,6 +767,9 @@ Resources:
                   - ecs:DescribeTaskDefinition
                   - ecs:ListContainerInstances
                   - ecs:ListServices
+                  - ecs:DescribeClusters
+                  - ecs:ListTagsForResource
+                  - ecs:TagResource
               - Effect: "Allow"
                 Resource: "*" # TODO: how to get an ASG ARN?
                 Action:

--- a/utility/lambdas/ecs-asg-sizer/lambda_function.py
+++ b/utility/lambdas/ecs-asg-sizer/lambda_function.py
@@ -16,7 +16,7 @@ ecs_client = session.client(service_name='ecs')
 sns_client = session.client(service_name='sns')
 
 EMPTY_SLOTS = 2
-ECS_AGENT_WAIT = 600
+ECS_AGENT_WAIT = 300
 SLACK_CHANNEL = '#ops-debug'
 SLACK_ICON = ':ops-autoscaling:'
 
@@ -24,7 +24,7 @@ SLACK_ICON = ':ops-autoscaling:'
 DISCONNECTS_TAG = 'ecs-asg-sizer:disconnects'
 DISCONNECTS_DELIMITER = ' '
 DISCONNECTS_SEPARATOR = ':'
-DISCONNECT_THRESHOLD_SECONDS = 600
+DISCONNECT_THRESHOLD_SECONDS = 300
 
 def lambda_handler(event, context):
     ASG_NAME = get_env('ASG_NAME')


### PR DESCRIPTION
The ASG sizer lambda has been killing EC2 instances with disconnected ecs-agents a bit too frequently.  Turns out, sometimes the ECS `agentConnected` may briefly report `false` even though the instance is fine.

This encodes in a tag the epoch seconds when an EC2 instance is seen with an ECS agent disconnected.  Then the instance must remain disconnected for 5 minutes for to get manually terminated.