### PR TITLE
Create a fargate-compatible task def

### DIFF
--- a/stacks/container-apps/augury-forecast.yml
+++ b/stacks/container-apps/augury-forecast.yml
@@ -1,0 +1,72 @@
+# stacks/container-apps/augury-forecast.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Augury Forecast FARGATE execution, using the normal ECS service role
+Parameters:
+  # ECS Cluster ################################################################
+  ECSServiceIAMRole:
+    Type: String
+  # Configuration ##############################################################
+  EcrImageTag:
+    Type: String
+  EcrRegion:
+    Type: String
+  EnvironmentType:
+    Type: String
+  EnvironmentTypeAbbreviation:
+    Type: String
+  SecretsBase:
+    Type: String
+  SecretsVersion:
+    Type: String
+  # Monitoring #################################################################
+  OpsDebugMessagesSnsTopicArn:
+    Type: String
+  OpsWarnMessagesSnsTopicArn:
+    Type: String
+  OpsErrorMessagesSnsTopicArn:
+    Type: String
+Resources:
+  AuguryForecastLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      RetentionInDays: 14
+  AuguryForecastTaskDefinition:
+    Type: "AWS::ECS::TaskDefinition"
+    Properties:
+      ContainerDefinitions:
+        - Environment:
+            - Name: APP_NAME
+              Value: augury
+            - Name: APP_ENV
+              Value: !Ref EnvironmentTypeAbbreviation
+            - Name: AWS_SECRETS_BASE
+              Value: !Ref SecretsBase
+            - Name: AWS_SECRETS_VERSION
+              Value: !Ref SecretsVersion
+            - Name: AWS_DEFAULT_REGION
+              Value: !Ref AWS::Region
+          Essential: true
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/augury.prx.org:${EcrImageTag}
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref AuguryForecastLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: augury-forecast
+          Name: augury-forecast
+      Cpu: '4096'
+      ExecutionRoleArn: !Ref ECSServiceIAMRole
+      Memory: '8192'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Tags:
+        - Key: Project
+          Value: augury
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId

--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -357,6 +357,36 @@ Resources:
           Value: !Ref AWS::StackId
       TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "web-application.yml"]]
       TimeoutInMinutes: 5
+  AuguryForecastStack:
+    Type: "AWS::CloudFormation::Stack"
+    Properties:
+      NotificationARNs:
+        - Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
+      Parameters:
+        ECSServiceIAMRole: !Ref ECSServiceIAMRole
+        EcrImageTag: !Ref AuguryEcrImageTag
+        EcrRegion: !Ref EcrRegion
+        EnvironmentType: !Ref EnvironmentType
+        EnvironmentTypeAbbreviation: !Ref EnvironmentTypeAbbreviation
+        SecretsBase: !Ref SecretsBase
+        SecretsVersion: !Ref AugurySecretsVersion
+        OpsDebugMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsDebugMessagesSnsTopicArn"
+        OpsWarnMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn"
+        OpsErrorMessagesSnsTopicArn:
+          Fn::ImportValue:
+            !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
+      Tags:
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "augury-forecast.yml"]]
+      TimeoutInMinutes: 5
   CourierStack:
     Type: "AWS::CloudFormation::Stack"
     Condition: IsStaging


### PR DESCRIPTION
Starting down the road of executing Augury forecasts (Rails calling out to the Rscript) through Fargate.

Was cleanest to create a separate task-def from the Worker.  Will use this to test executing forecast runs through the API and maybe EventBridge, to decide how Augury-web will call this.