### PR TITLE
Modernize VPC subnets

### DIFF
--- a/stacks/vpc.yml
+++ b/stacks/vpc.yml
@@ -200,8 +200,8 @@ Resources:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Join ["", [!Ref "AWS::Region", a]]
       CidrBlock: 10.0.1.0/24
+      AvailabilityZone: !Select [0, !GetAZs ""]
       Tags:
         - Key: Project
           Value: platform.prx.org
@@ -217,8 +217,8 @@ Resources:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !If [IsUsEast1, us-east-1c, !Join ["", [!Ref "AWS::Region", b]]]
       CidrBlock: 10.0.2.0/24
+      AvailabilityZone: !Select [1, !GetAZs ""]
       Tags:
         - Key: Project
           Value: platform.prx.org
@@ -234,8 +234,8 @@ Resources:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !If [IsUsEast1, us-east-1d, !Join ["", [!Ref "AWS::Region", c]]]
       CidrBlock: 10.0.3.0/24
+      AvailabilityZone: !Select [2, !GetAZs ""]
       Tags:
         - Key: Project
           Value: platform.prx.org

--- a/stacks/vpc.yml
+++ b/stacks/vpc.yml
@@ -200,8 +200,8 @@ Resources:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: 10.0.1.0/24
       AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: !Select [0, !Cidr [!GetAtt VPC.CidrBlock, 3, 8]] # 8 CIDR bits = (32 - 8) = /24 mask
       Tags:
         - Key: Project
           Value: platform.prx.org
@@ -217,8 +217,8 @@ Resources:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: 10.0.2.0/24
       AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: !Select [1, !Cidr [!GetAtt VPC.CidrBlock, 3, 8]] # 8 CIDR bits = (32 - 8) = /24 mask
       Tags:
         - Key: Project
           Value: platform.prx.org
@@ -234,8 +234,8 @@ Resources:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: 10.0.3.0/24
       AvailabilityZone: !Select [2, !GetAZs ""]
+      CidrBlock: !Select [2, !Cidr [!GetAtt VPC.CidrBlock, 3, 8]] # 8 CIDR bits = (32 - 8) = /24 mask
       Tags:
         - Key: Project
           Value: platform.prx.org


### PR DESCRIPTION
This could alter which AZs our subnets are in. In particular, it will likely no longer skip `us-east-1b`, since they changed how the letters map to actual AZs, so all accounts are now guaranteed to have sequential AZs available.