### PR TITLE
Unmodernize subnets

### DIFF
--- a/stacks/vpc.yml
+++ b/stacks/vpc.yml
@@ -201,8 +201,8 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [0, !GetAZs ""]
-      CidrBlock: !Select [4, !Cidr [!GetAtt VPC.CidrBlock, 7, 8]] # 8 CIDR bits = (32 - 8) = /24 mask
+      AvailabilityZone: !Join ["", [!Ref "AWS::Region", a]]
+      CidrBlock: 10.0.1.0/24
       Tags:
         - Key: Project
           Value: platform.prx.org
@@ -219,8 +219,8 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [1, !GetAZs ""]
-      CidrBlock: !Select [5, !Cidr [!GetAtt VPC.CidrBlock, 7, 8]] # 8 CIDR bits = (32 - 8) = /24 mask
+      AvailabilityZone: !If [IsUsEast1, us-east-1c, !Join ["", [!Ref "AWS::Region", b]]]
+      CidrBlock: 10.0.2.0/24
       Tags:
         - Key: Project
           Value: platform.prx.org
@@ -237,8 +237,8 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [2, !GetAZs ""]
-      CidrBlock: !Select [6, !Cidr [!GetAtt VPC.CidrBlock, 7, 8]] # 8 CIDR bits = (32 - 8) = /24 mask
+      AvailabilityZone: !If [IsUsEast1, us-east-1d, !Join ["", [!Ref "AWS::Region", c]]]
+      CidrBlock: 10.0.3.0/24
       Tags:
         - Key: Project
           Value: platform.prx.org

--- a/stacks/vpc.yml
+++ b/stacks/vpc.yml
@@ -198,6 +198,7 @@ Resources:
       VpcId: !Ref VPC
   Subnet1:
     Type: "AWS::EC2::Subnet"
+    UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [0, !GetAZs ""]
@@ -215,6 +216,7 @@ Resources:
           Value: !Ref AWS::StackId
   Subnet2:
     Type: "AWS::EC2::Subnet"
+    UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [1, !GetAZs ""]
@@ -232,6 +234,7 @@ Resources:
           Value: !Ref AWS::StackId
   Subnet3:
     Type: "AWS::EC2::Subnet"
+    UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [2, !GetAZs ""]


### PR DESCRIPTION
This should revert the VPC subnet CIDR blocks and AZs to the *exact* values that they've been for the last few years.

It also adds an `UpdateReplacePolicy` set to `Retain` for the subnet resources. This only comes into play when a stack update needs to replace a resource (ie, create a new one and delete the old one after dependencies have been switched over), which is the case for changing the AZ or CIDR on a subnet. With the resources set to `Retain`, CloudFormation will do all it's normal things, but leave the old subnets around rather than delete them. It *won't* keep them as stack resources – it doesn't delete them but it does forget about them (also what we want).

[Here's](https://github.com/PRX/Infrastructure/compare/d3c94b8e12649a8de03ce3e60398b26bf973065f..5a9d7c1c788960838dd047aa34be53fe70515d86) and arbitrary comparison of this PR and a commit from earlier in the week, to ensure that it's fully reverting to that state (aside from the new retain policy)