### PR TITLE
Remove legacy WordPress DNS records

### DIFF
--- a/dns/prx.org-hosted_zone.yml
+++ b/dns/prx.org-hosted_zone.yml
@@ -857,11 +857,6 @@ Resources:
             - "199.119.122.230"
           TTL: "300"
           Type: A
-          Name: !Sub themoth.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
           Name: !Sub wiki.${Domain}
         - ResourceRecords:
             - "199.119.122.230"
@@ -877,11 +872,6 @@ Resources:
             - "199.119.122.230"
           TTL: "300"
           Type: A
-          Name: !Sub 99percentinvisible.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
           Name: !Sub toe.${Domain}
         - ResourceRecords:
             - "199.119.122.230"
@@ -892,37 +882,7 @@ Resources:
             - "199.119.122.230"
           TTL: "300"
           Type: A
-          Name: !Sub radiodiaries.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub fugitivewaves.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub radiotopia.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
           Name: !Sub reveal.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub strangers.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub heart.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub mortified.${Domain}
         - ResourceRecords:
             - "199.119.122.230"
           TTL: "300"
@@ -932,72 +892,7 @@ Resources:
             - "199.119.122.230"
           TTL: "300"
           Type: A
-          Name: !Sub allusionist.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub loveandradio.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub htba.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
           Name: !Sub stem.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub esquire.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub israel.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub orbital.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub outside.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub hermoney.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub bugle.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub millennial.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub cpk.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub ffh.${Domain}
-        - ResourceRecords:
-            - "199.119.122.230"
-          TTL: "300"
-          Type: A
-          Name: !Sub offshore.${Domain}
   Prx03:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:


### PR DESCRIPTION
Continues the work on https://github.com/PRX/internal/issues/520