### PR TITLE
Use prx.org as certificate common name

### DIFF
--- a/stacks/certificate.yml
+++ b/stacks/certificate.yml
@@ -16,15 +16,15 @@ Resources:
   VpcWildcardCertificate:
     Type: "AWS::CertificateManager::Certificate"
     Properties:
-      DomainName: !Sub "*.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech"
+      DomainName: "*.prx.org"
       SubjectAlternativeNames:
-        - "*.prx.org"
         - "*.prxu.org"
         - "*.staging.prxu.org"
         - "*.prx.tech"
         - "*.staging.prx.tech"
         - "*.prx.mx"
         - "*.pri.org"
+        - !Sub "*.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech"
         - !Sub "*.cdn.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech"
       Tags:
         - Key: Project


### PR DESCRIPTION
To make it more obvious that the certificate is legitimate