### PR TITLE
Modernize CI Lambdas

### DIFF
--- a/ci/lambdas/ci-status-notification-handler/index.js
+++ b/ci/lambdas/ci-status-notification-handler/index.js
@@ -1,19 +1,23 @@
-// Invoked by: SNS Subscription
-// Returns: Error or status message
-//
-// Recieves notifications from the CI process, generally as a result of
-// CodeBuild status changes. The messages are sent to the Slack Message Relay
-// SNS topic in order to be sent to Slack. All messages handled by this function
-// are sent to the #ops-builds (this could change at some point).
-//
-// CI Status message can be sent from several sources. The GitHub event handler
-// will send messages after a build has started, and includes data about the
-// GitHub event that triggered the build, and the build itself.
-// eg { event: {...}, build: {...} }
+/**
+ * Invoked by: SNS Subscription
+ * Returns: Error or status message
+ *
+ * Recieves notifications from the CI process, generally as a result of
+ * CodeBuild status changes. The messages are sent to the Slack Message Relay
+ * SNS topic in order to be sent to Slack. All messages handled by this function
+ * are sent to the #ops-builds (this could change at some point).
+ *
+ * CI Status message can be sent from several sources. The GitHub event handler
+ * will send messages after a build has started, and includes data about the
+ * GitHub event that triggered the build, and the build itself.
+ * eg { event: {...}, build: {...} }
+*/
 
 const AWS = require('aws-sdk');
 
 const sns = new AWS.SNS({ apiVersion: '2010-03-31' });
+
+/** @typedef { import('aws-lambda').SNSEvent } SNSEvent */
 
 const SLACK_CHANNEL = '#ops-builds';
 const SLACK_ICON = ':ops-codebuild:';
@@ -120,7 +124,9 @@ function attachmentsForCiCallback(ciResult) {
     return [attachment];
 }
 
-// This event argument is the standard Lambda execution event data
+/**
+ * @param {SNSEvent} event
+ */
 function messageForEvent(event) {
     const noteJson = event.Records[0].Sns.Message;
     const note = JSON.parse(noteJson);
@@ -146,27 +152,15 @@ function messageForEvent(event) {
     };
 }
 
-function main(event, context, callback) {
+/**
+ * @param {SNSEvent} event
+ * @returns {Promise<void>}
+ */
+exports.handler = async (event) => {
     const message = messageForEvent(event);
 
-    const messageJson = JSON.stringify(message);
-
-    sns.publish({
+    await sns.publish({
         TopicArn: process.env.SLACK_MESSAGE_RELAY_TOPIC_ARN,
-        Message: messageJson,
-    }, (err) => {
-        if (err) {
-            callback(err);
-        } else {
-            callback(null);
-        }
-    });
-}
-
-exports.handler = (event, context, callback) => {
-    try {
-        main(event, context, callback);
-    } catch (e) {
-        callback(e);
-    }
+        Message: JSON.stringify(message),
+    }).promise();
 };

--- a/ci/lambdas/codebuild-callback-handler/lambda_function.py
+++ b/ci/lambdas/codebuild-callback-handler/lambda_function.py
@@ -208,7 +208,7 @@ def post_notification_status(sns_message):
         pr_url = f"https://github.com/{repo}/pull/{num}"
         extra = f" <{pr_url}|#{num}>"
     else:
-        extra = ':master'
+        extra = f":{attrs['PRX_BRANCH']['Value']}"
 
     if attrs['STATUS']['Value'] == 'true':
         attachment['color'] = 'good'

--- a/ci/lambdas/github-event-handler/index.js
+++ b/ci/lambdas/github-event-handler/index.js
@@ -191,14 +191,7 @@ async function triggerBuild(versionId, ciContentsResponse, event) {
     const status = updateGitHubStatus(event, data.build);
     const notification = postNotification(event, data.build);
 
-    Promise.all([status, notification])
-        .then(() => {
-            console.log('...Post-build actions finished!');
-        })
-        .catch((e) => {
-            console.error('...Post-build actions failed!');
-            throw e;
-        });
+    Promise.all([status, notification]);
 }
 
 /**

--- a/ci/lambdas/github-event-handler/index.js
+++ b/ci/lambdas/github-event-handler/index.js
@@ -1,18 +1,20 @@
-// Invoked by: SNS Subscription
-// Returns: Error or status message
-//
-// Handles GitHub events that have been forwarded from the webhook endpoint.
-// This function handles the start of the build process for default branches and
-// pull requests (for repositories that are designed to work with CodeBuild).
-// Broadly, it does the following:
-// 1. Check to make sure this event should trigger a build
-// 2. Trigger a CodeBuild by copying current code to S3 (the CodeBuild source)
-// 3. Send a notification that the build is starting (for Slack/etc)
-// 4. Set the GitHub status to 'pending' for the sha
-// This Lambda should not be considered to be entirely or even mostly
-// responsible for the configuration of CodeBuild environment. It should only
-//  worry about the parts of the configuration that result from the events
-// the function is intended to handle.
+/**
+ * Invoked by: SNS Subscription
+ * Returns: Error or status message
+ *
+ * Handles GitHub events that have been forwarded from the webhook endpoint.
+ * This function handles the start of the build process for default branches and
+ * pull requests (for repositories that are designed to work with CodeBuild).
+ * Broadly, it does the following:
+ * 1. Check to make sure this event should trigger a build
+ * 2. Trigger a CodeBuild by copying current code to S3 (the CodeBuild source)
+ * 3. Send a notification that the build is starting (for Slack/etc)
+ * 4. Set the GitHub status to 'pending' for the sha
+ * This Lambda should not be considered to be entirely or even mostly
+ * responsible for the configuration of CodeBuild environment. It should only
+ * worry about the parts of the configuration that result from the events
+ * the function is intended to handle.
+ */
 
 const url = require('url');
 const https = require('https');

--- a/ci/lambdas/github-event-handler/index.js
+++ b/ci/lambdas/github-event-handler/index.js
@@ -485,6 +485,7 @@ function handlePushEvent(event) {
 
 /**
  * @param {SNSEvent} event
+ * @returns {Promise<void>}
  */
 exports.handler = async (event) => {
     const snsMsg = event.Records[0].Sns;

--- a/ci/lambdas/github-event-handler/index.js
+++ b/ci/lambdas/github-event-handler/index.js
@@ -2,7 +2,7 @@
 // Returns: Error or status message
 //
 // Handles GitHub events that have been forwarded from the webhook endpoint.
-// This function handles the start of the build process for master branches and
+// This function handles the start of the build process for default branches and
 // pull requests (for repositories that are designed to work with CodeBuild).
 // Broadly, it does the following:
 // 1. Check to make sure this event should trigger a build
@@ -23,6 +23,12 @@ const codebuild = new AWS.CodeBuild({ apiVersion: '2016-10-06' });
 const sns = new AWS.SNS({ apiVersion: '2010-03-31' });
 const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
+const PR_ACTION_TRIGGERS = [
+    'opened',
+    'reopened',
+    'synchronize',
+    'ready_for_review',
+];
 const USER_AGENT = 'PRX/Infrastructure (github-event-handler)';
 const GITHUB_HEADERS = {
     Authorization: `token ${process.env.GITHUB_ACCESS_TOKEN}`,
@@ -30,10 +36,15 @@ const GITHUB_HEADERS = {
     'User-Agent': USER_AGENT,
 };
 
-// Note: The response to this request should be a 201
-// https://developer.github.com/v3/repos/statuses/#create-a-status
+/**
+ * Note: The response to this request should be a 201
+ * https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#statuses
+ * @param {object} event
+ * @param {object} build
+ * @returns {Promise<object>}
+ */
 function updateGitHubStatus(event, build) {
-    return (new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         console.log('...Updating GitHub status...');
 
         // Get request properties
@@ -90,32 +101,31 @@ function updateGitHubStatus(event, build) {
 
         req.write(json);
         req.end();
-    }));
+    });
 }
 
+/**
+ * @param {object} event
+ * @param {object} build
+ * @returns {Promise<object>}
+ */
 function postNotification(event, build) {
-    return (new Promise((resolve, reject) => {
-        console.log('...Posting build status notification...');
-
-        sns.publish({
+    return sns
+        .publish({
             TopicArn: process.env.CI_STATUS_TOPIC_ARN,
             Message: JSON.stringify({ event, build }),
-        }, (err) => {
-            if (err) {
-                console.error('...Status notification posted...');
-                reject(err);
-            } else {
-                console.log('...Status notification posted...');
-                resolve(event);
-            }
-        });
-    }));
+        })
+        .promise();
 }
 
-// `startBuild` returns a Build object
-// https://docs.aws.amazon.com/codebuild/latest/APIReference/API_Build.html
-//
-function triggerBuild(versionId, ciContentsResponse, event, callback) {
+/**
+ * `startBuild` returns a Build object
+ * https://docs.aws.amazon.com/codebuild/latest/APIReference/API_Build.html
+ * @param {string} versionId - The S3 version ID of the repository zip archive
+ * @param {string} ciContentsResponse - The response from the GitHub repository contents API for buildspec.yml
+ * @param {object} event
+ */
+async function triggerBuild(versionId, ciContentsResponse, event) {
     console.log('...Starting CodeBuild run...');
 
     // ciContentsResponse is the JSON body response from a Contents API request
@@ -129,17 +139,17 @@ function triggerBuild(versionId, ciContentsResponse, event, callback) {
     // be designed for use with CI. Look for an `PRX_` string as a test.
     if (!buildspec.includes('PRX_')) {
         console.log('Skipping unsupported buildspec.yml');
-        callback(null);
         return;
     }
 
-    const commitRef = (event.after || event.pull_request.head.sha);
+    const commitRef = event.after || event.pull_request.head.sha;
 
     const environmentVariables = [
         {
             name: 'PRX_REPO',
             value: event.repository.full_name,
-        }, {
+        },
+        {
             name: 'PRX_COMMIT',
             value: commitRef,
         },
@@ -153,286 +163,300 @@ function triggerBuild(versionId, ciContentsResponse, event, callback) {
         const num = event.pull_request.number;
         const branch = event.pull_request.head.ref;
         environmentVariables.push({ name: 'PRX_GITHUB_PR', value: `${num}` });
-        environmentVariables.push({ name: 'PRX_BRANCH', value: branch});
+        environmentVariables.push({ name: 'PRX_BRANCH', value: branch });
         environmentVariables.push({ name: 'PRX_CI_PUBLISH', value: 'false' });
     } else {
-        // All other events should be code pushes to the master branch. These
+        // All other events should be code pushes to the default branch. These
         // should get tested and published. The buildspec.yml file will contain
         // environment variables that allow the post_build.sh script to
         // determine where and how to handle successful builds (e.g. where to
         // push the code, etc).
 
         const branch = (event.ref || 'unknown').replace(/^refs\/heads\//, '');
-        environmentVariables.push({ name: 'PRX_BRANCH', value: branch});
+        environmentVariables.push({ name: 'PRX_BRANCH', value: branch });
         environmentVariables.push({ name: 'PRX_CI_PUBLISH', value: 'true' });
     }
 
-    codebuild.startBuild({
-        projectName: process.env.CODEBUILD_PROJECT_NAME,
-        sourceVersion: versionId,
-        buildspecOverride: buildspec,
-        environmentVariablesOverride: environmentVariables,
-    }, (err, data) => {
-        if (err) {
-            console.error('...CodeBuild failed to start!');
-            console.error(err);
-            callback(err);
-        } else {
-            console.log('...CodeBuild started...');
+    const data = await codebuild
+        .startBuild({
+            projectName: process.env.CODEBUILD_PROJECT_NAME,
+            sourceVersion: versionId,
+            buildspecOverride: buildspec,
+            environmentVariablesOverride: environmentVariables,
+        })
+        .promise();
 
-            const status = updateGitHubStatus(event, data.build);
-            const notification = postNotification(event, data.build);
+    console.log('...CodeBuild started...');
 
-            Promise.all([status, notification])
-                .then(() => {
-                    console.log('...Post-build actions finished!');
-                    callback(null);
-                })
-                .catch((e) => {
-                    console.error('...Post-build actions failed!');
-                    callback(e);
-                });
-        }
-    });
+    const status = updateGitHubStatus(event, data.build);
+    const notification = postNotification(event, data.build);
+
+    Promise.all([status, notification])
+        .then(() => {
+            console.log('...Post-build actions finished!');
+        })
+        .catch((e) => {
+            console.error('...Post-build actions failed!');
+            throw e;
+        });
 }
 
-function copyToS3(file, ciContentsResponse, event, callback) {
+/**
+ * Copies a repository zip archive at the given path to S3
+ * @param {string} path - The path of the file to copy to S3
+ * @returns {string} The S3 version ID of the resulting object
+ */
+async function copyToS3(path) {
     console.log('...Copying archive to S3...');
 
     const params = {
         Bucket: process.env.CODEBUILD_SOURCE_ARCHIVE_BUCKET,
         Key: process.env.CODEBUILD_SOURCE_ARCHIVE_KEY,
-        Body: fs.createReadStream(file),
+        Body: fs.createReadStream(path),
     };
 
-    s3.putObject(params, (err, data) => {
-        if (err) {
-            console.error('...S3 copy failed!');
-            callback(err);
-        } else {
-            console.error('...Finished copying to S3...');
-            triggerBuild(data.VersionId, ciContentsResponse, event, callback);
-        }
-    });
+    const data = await s3.putObject(params).promise();
+    return data.VersionId;
 }
 
-// Follows the redirect location from the previous request to the GitHub API
-// for the zipball of a repo at a given commit hash
-function getSourceArchive(location, ciContentsResponse, event, callback) {
-    console.log('...Saving source archive...');
+/**
+ * Requests the URL to download a repository zip archive
+ * https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#download-a-repository-archive-zip
+ * @param {object} event
+ * @returns {Promise<string>} The URL of the zip archive
+ */
+function getSourceArchiveLink(event) {
+    return new Promise((resolve, reject) => {
+        console.log('...Getting source code archive URL...');
 
-    // Setup request options
-    const options = url.parse(location);
-    options.method = 'GET';
-    options.headers = GITHUB_HEADERS;
-    options.headers['Content-Length'] = Buffer.byteLength('');
+        // Get request properties
+        const api = 'api.github.com';
+        const repo = event.repository.full_name;
+        const sha = event.after || event.pull_request.head.sha;
 
-    // Setup write stream
-    const dest = `/tmp/${Date.now()}`;
-    const file = fs.createWriteStream(dest);
+        // Setup request options
+        const apiUrl = `https://${api}/repos/${repo}/zipball/${sha}`;
+        const options = url.parse(apiUrl);
+        options.method = 'GET';
+        options.headers = GITHUB_HEADERS;
+        options.headers['Content-Length'] = Buffer.byteLength('');
 
-    // Request with response handler
-    const req = https.request(options, (res) => {
-        if (res.statusCode !== 200) {
-            console.error('...Source archive request failed!');
-            callback(new Error('Could not get source archive'));
-        } else {
-            res.pipe(file);
+        // Request with response handler
+        console.log(`...Calling archive link API: ${apiUrl}...`);
+        const req = https.request(options, (res) => {
+            res.setEncoding('utf8');
 
-            file.on('finish', () => {
-                file.close(() => {
-                    console.log('...Finished downloading archive...');
-                    copyToS3(dest, ciContentsResponse, event, callback);
-                });
+            let json = '';
+            res.on('data', (chunk) => {
+                json += chunk;
             });
-        }
+            res.on('end', () => {
+                switch (res.statusCode) {
+                    case 302:
+                        console.log('...GitHub archive URL found...');
+                        resolve(res.headers.location);
+                        break;
+                    default:
+                        console.error(
+                            '...GitHub archive link request failed...',
+                        );
+                        console.error(`...HTTP ${res.statusCode}...`);
+                        console.error(json);
+                        reject(
+                            new Error('GitHub archive link request failed!'),
+                        );
+                }
+            });
+        });
+
+        // Generic request error handling
+        req.on('error', e => reject(e));
+
+        req.write('');
+        req.end();
     });
-
-    // Generic request error handling
-    req.on('error', e => callback(e));
-
-    // Generic file error handling
-    file.on('error', (e) => { // Handle errors
-        fs.unlink(dest);
-        callback(e);
-    });
-
-    req.write('');
-    req.end();
 }
 
-// The zipball request returns a 301, and because I'm too lazy to install a
-// better HTTP library, I'm just making a second request
-function getSourceArchiveLink(ciContentsResponse, event, callback) {
-    console.log('...Getting source code archive URL...');
+/**
+ * Downloads the zip archive of a reposity to a temporary local file and
+ * returns the file path
+ * @param {object} event
+ * @returns {Promise<string>} The local file path
+ */
+async function getSourceArchive(event) {
+    const location = await getSourceArchiveLink(event);
 
-    // Get request properties
-    const api = 'api.github.com';
-    const repo = event.repository.full_name;
-    const sha = event.after || event.pull_request.head.sha;
+    return new Promise((resolve, reject) => {
+        console.log('...Saving source archive...');
 
-    // Setup request options
-    const apiUrl = `https://${api}/repos/${repo}/zipball/${sha}`;
-    const options = url.parse(apiUrl);
-    options.method = 'GET';
-    options.headers = GITHUB_HEADERS;
-    options.headers['Content-Length'] = Buffer.byteLength('');
+        // Setup request options
+        const options = url.parse(location);
+        options.method = 'GET';
+        options.headers = GITHUB_HEADERS;
+        options.headers['Content-Length'] = Buffer.byteLength('');
 
-    // Request with response handler
-    console.log(`...Calling archive link API: ${apiUrl}...`);
-    const req = https.request(options, (res) => {
-        res.setEncoding('utf8');
+        // Setup write stream
+        const dest = `/tmp/${Date.now()}`;
+        const file = fs.createWriteStream(dest);
 
-        let json = '';
-        res.on('data', (chunk) => {
-            json += chunk;
-        });
-        res.on('end', () => {
-            switch (res.statusCode) {
-                case 302:
-                    console.log('...GitHub archive URL found...');
-                    getSourceArchive(res.headers.location, ciContentsResponse, event, callback);
-                    break;
-                default:
-                    console.error('...GitHub status update failed...');
-                    console.error(`...HTTP ${res.statusCode}...`);
-                    console.error(json);
-                    callback(new Error('GitHub archive link request failed!'));
+        // Request with response handler
+        const req = https.request(options, (res) => {
+            if (res.statusCode !== 200) {
+                console.error('...Source archive request failed!');
+                reject(new Error('Could not get source archive'));
+            } else {
+                res.pipe(file);
+
+                file.on('finish', () => {
+                    file.close(() => {
+                        console.log('...Finished downloading archive...');
+                        resolve(dest);
+                    });
+                });
             }
         });
+
+        // Generic request error handling
+        req.on('error', e => reject(e));
+
+        // Generic file error handling
+        file.on('error', (e) => {
+            // Handle errors
+            fs.unlink(dest);
+            reject(e);
+        });
+
+        req.write('');
+        req.end();
     });
-
-    // Generic request error handling
-    req.on('error', e => callback(e));
-
-    req.write('');
-    req.end();
 }
 
-// Hits the GitHub contents API to determine if the commit that triggered this
-// event supports the PRX CI system, by looking for a .prxci file
-// https://developer.github.com/v3/repos/contents/#get-contents
-function checkCodeBuildSupport(event, callback) {
-    console.log('...Checking for CodeBuild support...');
+/**
+ * Hits the GitHub repot contents API to determine if the commit that triggered
+ * event supports the PRX CI system by looking for a buildspec.yml file
+ * https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#contents
+ * @param {object} event
+ * @returns {Promise<string>} The JSON response
+ */
+function getBuildspecContentJson(event) {
+    return new Promise((resolve, reject) => {
+        console.log('...Checking for CodeBuild support...');
 
-    // Get request properties
-    const api = 'api.github.com';
-    const repo = event.repository.full_name;
-    const path = 'buildspec.yml';
-    const ref = event.after || event.pull_request.head.sha;
+        // Get request properties
+        const api = 'api.github.com';
+        const repo = event.repository.full_name;
+        const path = 'buildspec.yml';
+        const ref = event.after || event.pull_request.head.sha;
 
-    // Setup request options
-    const apiUrl = `https://${api}/repos/${repo}/contents/${path}?ref=${ref}`;
-    const options = url.parse(apiUrl);
-    options.method = 'GET';
-    options.headers = GITHUB_HEADERS;
-    options.headers['Content-Length'] = Buffer.byteLength('');
+        // Setup request options
+        const apiUrl = `https://${api}/repos/${repo}/contents/${path}?ref=${ref}`;
+        const options = url.parse(apiUrl);
+        options.method = 'GET';
+        options.headers = GITHUB_HEADERS;
+        options.headers['Content-Length'] = Buffer.byteLength('');
 
-    // Request with response handler
-    console.log(`...Calling contents API: ${apiUrl}...`);
-    const req = https.request(options, (res) => {
-        res.setEncoding('utf8');
+        // Request with response handler
+        console.log(`...Calling contents API: ${apiUrl}...`);
+        const req = https.request(options, (res) => {
+            res.setEncoding('utf8');
 
-        let json = '';
-        res.on('data', (chunk) => {
-            console.log(chunk);
-            json += chunk;
+            let json = '';
+            res.on('data', (chunk) => {
+                console.log(chunk);
+                json += chunk;
+            });
+            res.on('end', () => {
+                switch (res.statusCode) {
+                    case 200:
+                        console.log('...Found CodeBuild support...');
+                        resolve(json);
+                        break;
+                    case 404:
+                        console.log('...No CodeBuild support!');
+                        resolve(false);
+                        break;
+                    default:
+                        console.error(`...Request failed ${res.statusCode}!`);
+                        console.error(json);
+                        reject(new Error('Contents request failed!'));
+                }
+            });
         });
-        res.on('end', () => {
-            switch (res.statusCode) {
-                case 200:
-                    console.log('...Found CodeBuild support...');
-                    getSourceArchiveLink(json, event, callback);
-                    break;
-                case 404:
-                    console.log('...No CodeBuild support!');
-                    callback(null);
-                    break;
-                default:
-                    console.error(`...Request failed ${res.statusCode}!`);
-                    console.error(json);
-                    callback(new Error('Contents request failed!'));
-            }
+
+        req.setTimeout(1000, () => {
+            console.log('========= request timed out');
         });
+
+        // Generic request error handling
+        req.on('error', e => reject(e));
+
+        req.write('');
+        req.end();
     });
-
-    req.setTimeout(1000, () => {
-        console.log('========= request timed out');
-    });
-
-    // Generic request error handling
-    req.on('error', e => callback(e));
-
-    req.write('');
-    req.end();
 }
 
-// We'll want to trigger a build when a pull request is: 'opened', 'reopened',
-// or 'synchronized'
-// https://developer.github.com/v3/activity/events/types/#pullrequestevent
-function handlePullRequestEvent(event, callback) {
+async function handleCiEvent(event) {
+    const buildspecContentJson = await getBuildspecContentJson(event);
+
+    if (buildspecContentJson) {
+        const filePath = await getSourceArchive(event);
+        const versionId = await copyToS3(filePath);
+        await triggerBuild(versionId, buildspecContentJson, event);
+    }
+}
+
+/**
+ * We'll want to trigger a build when actions on the pull request represent
+ * a change that requires CI, such as opening, synchornizing, or moving from
+ * draft to ready for review.
+ * https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
+ * @param {object} event
+ */
+function handlePullRequestEvent(event) {
     console.log('...Handling pull_request event...');
 
-    const { action } = event;
-    const triggers = ['opened', 'reopened', 'synchronize', 'ready_for_review'];
-
-    if (triggers.includes(action)) {
-        console.log(`...With action: ${action}...`);
-        checkCodeBuildSupport(event, callback);
-    } else {
-        // Blackhole events that aren't code changes
-        console.log('...Ignoring this pull request action!');
-        callback(null);
+    if (PR_ACTION_TRIGGERS.includes(event.action)) {
+        console.log(`...With action: ${event.action}...`);
+        handleCiEvent(event);
     }
 }
 
-// Push events will get delivered for any branch. For pushes to pull requests,
-// there will be an additional `pull_request` event that we will use to trigger
-// the build, so this only needs to proceed if the event is for the master
-// branch.
-// https://developer.github.com/v3/activity/events/types/#pushevent
-function handlePushEvent(event, callback) {
+/**
+ * Push events will get delivered for any branch. For pushes to pull requests,
+ * there will be an additional `pull_request` event that we will use to trigger
+ * the build, so this only needs to proceed if the event is for the default
+ * branch.
+ * https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#push
+ * @param {object} event
+ */
+function handlePushEvent(event) {
     console.log('...Handling push event...');
 
-    switch (event.ref) {
-        case 'refs/heads/master':
-            console.log('...Push event was for master branch...');
-            checkCodeBuildSupport(event, callback);
-            break;
-        default:
-            // Blackhole all push events not on master
-            console.log('...Ignoring this push!');
-            callback(null);
+    if (event.ref === `refs/heads/${event.repository.default_branch}`) {
+        console.log('...Push event was for default branch...');
+        handleCiEvent(event);
     }
 }
 
-function main(event, context, callback) {
+/**
+ * @param {object} event
+ */
+exports.handler = async (event) => {
     const snsMsg = event.Records[0].Sns;
 
     const githubEvent = snsMsg.MessageAttributes.githubEvent.Value;
     const githubEventObj = JSON.parse(snsMsg.Message);
 
     console.log(`Received message for event: ${githubEvent}...`);
-    callback(null);
 
     switch (githubEvent) {
         case 'push':
-            handlePushEvent(githubEventObj, callback);
+            handlePushEvent(githubEventObj);
             break;
         case 'pull_request':
-            handlePullRequestEvent(githubEventObj, callback);
+            handlePullRequestEvent(githubEventObj);
             break;
         default:
             console.log('...Ignoring this event type!');
-            callback(null);
-    }
-}
-
-exports.handler = (event, context, callback) => {
-    try {
-        main(event, context, callback);
-    } catch (e) {
-        console.error('Unhandled exception!');
-        callback(e);
     }
 };

--- a/ci/lambdas/github-webhook-endpoint/index.js
+++ b/ci/lambdas/github-webhook-endpoint/index.js
@@ -12,14 +12,14 @@ const OK_RESPONSE = { statusCode: 200, headers: {}, body: null };
 
 const sns = new AWS.SNS({ apiVersion: '2010-03-31' });
 
-function publishEvent(event, callback) {
-    console.log('...Publishing event to SNS...');
+function publishEvent(event) {
+    console.log('Publishing event to SNS');
 
-    const body = event.isBase64Encoded ? Buffer.from(event.body, 'base64').toString('utf-8') : event.body;
-
-    sns.publish({
+    return sns.publish({
         TopicArn: process.env.GITHUB_EVENT_HANDLER_TOPIC_ARN,
-        Message: body,
+        Message: event.isBase64Encoded
+            ? Buffer.from(event.body, 'base64').toString('utf-8')
+            : event.body,
         MessageAttributes: {
             githubEvent: {
                 DataType: 'String',
@@ -30,53 +30,31 @@ function publishEvent(event, callback) {
                 StringValue: event.headers['x-github-delivery'],
             },
         },
-    }, (err) => {
-        if (err) {
-            console.error('...Publishing event failed!');
-            callback(err);
-        } else {
-            console.log('...Event published!');
-            callback(null, OK_RESPONSE);
-        }
-    });
+    }).promise();
 }
 
-function handleEvent(event, callback) {
-    console.log(`...Handling event: ${event.headers['x-github-event']}...`);
-    switch (event.headers['x-github-event']) {
-        case 'ping':
-            // Blackhole `ping` events
-            callback(null, OK_RESPONSE);
-            break;
-        default:
-            publishEvent(event, callback);
-    }
-}
-
-function main(event, context, callback) {
+exports.handler = async (event) => {
     const githubSignature = event.headers['x-hub-signature'].split('=')[1];
 
-    console.log(`Checking event signature: ${githubSignature}...`);
+    console.log(`Checking event signature: ${githubSignature}`);
 
     const key = process.env.GITHUB_WEBHOOK_SECRET;
     const data = event.body;
     const check = crypto.createHmac('sha1', key).update(data).digest('hex');
 
-    if (githubSignature === check) {
-        handleEvent(event, callback);
-    } else {
-        // Raising an error here so it's visible if we start getting requests
-        // that aren't valid.
-        console.error('...Request signature was invalid!');
-        callback(new Error('Invalid signature!'));
+    if (githubSignature !== check) {
+        throw new Error('Invalid signature!');
     }
-}
 
-exports.handler = (event, context, callback) => {
-    try {
-        main(event, context, callback);
-    } catch (e) {
-        console.error('Unhandled exception!');
-        callback(e);
+    console.log(`Handling event: ${event.headers['x-github-event']}`);
+
+    switch (event.headers['x-github-event']) {
+        case 'ping':
+            // Blackhole `ping` events
+            break;
+        default:
+            await publishEvent(event);
     }
+
+    return OK_RESPONSE;
 };

--- a/ci/utility/post_build.sh
+++ b/ci/utility/post_build.sh
@@ -19,6 +19,7 @@ send_sns_callback_message() {
     MSGATR+=",\"PRX_AWS_ACCOUNT_ID\": {\"DataType\": \"String\", \"StringValue\": \"$PRX_AWS_ACCOUNT_ID\"}"
     MSGATR+=",\"PRX_REPO\": {\"DataType\": \"String\", \"StringValue\": \"$PRX_REPO\"}"
     MSGATR+=",\"PRX_COMMIT\": {\"DataType\": \"String\", \"StringValue\": \"$PRX_COMMIT\"}"
+    MSGATR+=",\"PRX_BRANCH\": {\"DataType\": \"String\", \"StringValue\": \"$PRX_BRANCH\"}"
 
     # Optional GitHub pull request number parameter (pass-through)
     [ -z "$PRX_GITHUB_PR" ] || MSGATR+=",\"PRX_GITHUB_PR\": {\"DataType\": \"String\", \"StringValue\": \"$PRX_GITHUB_PR\"}"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "infrastructure",
+  "version": "1.0.0",
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/PRX/Infrastructure.git"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.663.0",
+    "aws-xray-sdk": "^3.0.0"
+  },
+  "devDependencies": {
+    "aws-sdk-mock": "^5.1.0",
+    "dotenv": "^8.2.0",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.1.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-prettier": "^3.1.3",
+    "jest": "^26.0.1",
+    "prettier": "^2.0.5",
+    "typescript": "^4.0",
+    "yaml-cfn": "^0.2.3",
+    "@types/aws-lambda": "^8.10.63",
+    "@octokit/rest": "^18.0.6"
+  },
+  "scripts": {
+    "eslint": "eslint",
+    "prettier": "prettier",
+    "tsc": "tsc"
+  }
+}

--- a/stacks/container-apps/sphinx-nlb.yml
+++ b/stacks/container-apps/sphinx-nlb.yml
@@ -474,7 +474,7 @@ Resources:
           TargetGroupArn: !Ref NLBSphinxTargetGroup
       # Role: !Ref ECSServiceIAMRole
       NetworkConfiguration:
-        AwsVpcConfiguration:
+        AwsvpcConfiguration:
           SecurityGroups:
             - !Ref SphinxInboundSecurityGroup
             - !Ref SphinxOutboundSecurityGroup

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "jsx": "preserve",
+    "checkJs": true,
+    "noEmit": true,
+    "allowJs": true
+  },
+  "exclude": ["node_modules", "**/node_modules/*"],
+  "include": ["ci"]
+}


### PR DESCRIPTION
In preparation for [the upcoming changes](https://github.com/github/renaming/) to default branch naming, this will allow the CI system to build properly for any default branch name, not just `master`.

This PR also modernizes the Lambda code for several steps in the CI process. Key changes are: replacing some callbacks and `then` calls with asycn/await; adding type hinting; replacing several uses of a deprecated url method.