### PR TITLE
Make CI Slack notifications more intuitive

### DIFF
--- a/ci/lambdas/ci-status-notification-handler/index.js
+++ b/ci/lambdas/ci-status-notification-handler/index.js
@@ -99,7 +99,6 @@ function attachmentsForCiCallback(ciResult) {
     if (ciResult.success) {
         attachment.color = 'good';
         attachment.fallback = `Built ${repo}${extra} with commit ${sha7}`;
-        attachment.title = `Built <${buildUrl}|${repo}>${extra} with commit <${commitUrl}|${sha7}>`;
         attachment.title = `<${buildUrl}|Built> ${repo}${extra} with commit <${commitUrl}|${sha7}>`;
 
         if (ciResult.prxGithubPr) {

--- a/ci/lambdas/ci-status-notification-handler/index.js
+++ b/ci/lambdas/ci-status-notification-handler/index.js
@@ -100,6 +100,7 @@ function attachmentsForCiCallback(ciResult) {
         attachment.color = 'good';
         attachment.fallback = `Built ${repo}${extra} with commit ${sha7}`;
         attachment.title = `Built <${buildUrl}|${repo}>${extra} with commit <${commitUrl}|${sha7}>`;
+        attachment.title = `<${buildUrl}|Built> ${repo}${extra} with commit <${commitUrl}|${sha7}>`;
 
         if (ciResult.prxGithubPr) {
             const num = ciResult.prxGithubPr;

--- a/ci/lambdas/ci-status-notification-handler/index.js
+++ b/ci/lambdas/ci-status-notification-handler/index.js
@@ -44,11 +44,11 @@ function attachmentsForGitHubEvent(gitHubEvent, gitHubBuild) {
         const action = gitHubEvent.action.charAt(0).toUpperCase() + gitHubEvent.action.slice(1);
 
         attachment.fallback = `Building ${repo} #${pr.number} with commit ${sha7}`;
-        attachment.title = `Building <${buildUrl}|${repo}> with commit <${commitUrl}|${sha7}>`;
+        attachment.title = `<${buildUrl}|Building> ${repo} with commit <${commitUrl}|${sha7}>`;
         attachment.text = `${action} <${pr.html_url}|#${pr.number}> ${pr.title} – ${pr.user.login}`;
     } else {
         attachment.fallback = `Building ${repo}:${branch} with commit ${sha7}`;
-        attachment.title = `Building <${buildUrl}|${repo}:${branch}> with commit <${commitUrl}|${sha7}>`;
+        attachment.title = `<${buildUrl}|Building> ${repo}:${branch} with commit <${commitUrl}|${sha7}>`;
 
         const compareUrl = `https://github.com/${repo}/compare/${gitHubEvent.before}...${gitHubEvent.after}`;
 
@@ -92,6 +92,7 @@ function attachmentsForCiCallback(ciResult) {
     } else {
         // This assumes that anything other than PR is master, which, for the
         // time being, is true. But that may not always be the case
+        // TODO This needs to be determined from the event info
         extra = ':master';
     }
 
@@ -114,6 +115,7 @@ function attachmentsForCiCallback(ciResult) {
         attachment.color = 'danger';
         attachment.fallback = `Failed to build ${repo}${extra} with commit ${sha7}`;
         attachment.title = `Failed to build <${buildUrl}|${repo}>${extra} with commit <${commitUrl}|${sha7}>`;
+        attachment.title = `Failed to <${buildUrl}|build> ${repo}${extra} with commit <${commitUrl}|${sha7}>`;
         attachment.text = `> _${ciResult.reason}_`;
     }
 

--- a/ci/lambdas/ci-status-notification-handler/index.js
+++ b/ci/lambdas/ci-status-notification-handler/index.js
@@ -115,7 +115,6 @@ function attachmentsForCiCallback(ciResult) {
     } else {
         attachment.color = 'danger';
         attachment.fallback = `Failed to build ${repo}${extra} with commit ${sha7}`;
-        attachment.title = `Failed to build <${buildUrl}|${repo}>${extra} with commit <${commitUrl}|${sha7}>`;
         attachment.title = `Failed to <${buildUrl}|build> ${repo}${extra} with commit <${commitUrl}|${sha7}>`;
         attachment.text = `> _${ciResult.reason}_`;
     }

--- a/ci/lambdas/codebuild-callback-handler/lambda_function.py
+++ b/ci/lambdas/codebuild-callback-handler/lambda_function.py
@@ -213,7 +213,7 @@ def post_notification_status(sns_message):
     if attrs['STATUS']['Value'] == 'true':
         attachment['color'] = 'good'
         attachment['fallback'] = f"Built {repo}{extra} with commit {sha7}"
-        attachment['title'] = f"Built <{build_url}|{repo}>{extra} with commit <{commit_url}|{sha7}>"
+        attachment['title'] = f"<{build_url}|Built> {repo}{extra} with commit <{commit_url}|{sha7}>"
 
         text_lines = []
 
@@ -240,7 +240,7 @@ def post_notification_status(sns_message):
     else:
         attachment['color'] = 'danger'
         attachment['fallback'] = f"Failed to build {repo}{extra} with commit {sha7}"
-        attachment['title'] = f"Failed to build <{build_url}|{repo}>{extra} with commit <{commit_url}|{sha7}>"
+        attachment['title'] = f"Failed to <{build_url}|build> {repo}{extra} with commit <{commit_url}|{sha7}>"
         attachment['text'] = f"> _{message}_"
 
     slack_message = json.dumps({

--- a/ci/lambdas/github-event-handler/index.js
+++ b/ci/lambdas/github-event-handler/index.js
@@ -153,7 +153,7 @@ function triggerBuild(versionId, ciContentsResponse, event, callback) {
         const num = event.pull_request.number;
         const branch = event.pull_request.head.ref;
         environmentVariables.push({ name: 'PRX_GITHUB_PR', value: `${num}` });
-        environmentVariables.push({ name: 'PRX_BRANCH', value: branch});
+        environmentVariables.push({ name: 'PRX_BRANCH', value: branch });
         environmentVariables.push({ name: 'PRX_CI_PUBLISH', value: 'false' });
     } else {
         // All other events should be code pushes to the master branch. These
@@ -163,7 +163,7 @@ function triggerBuild(versionId, ciContentsResponse, event, callback) {
         // push the code, etc).
 
         const branch = (event.ref || 'unknown').replace(/^refs\/heads\//, '');
-        environmentVariables.push({ name: 'PRX_BRANCH', value: branch});
+        environmentVariables.push({ name: 'PRX_BRANCH', value: branch });
         environmentVariables.push({ name: 'PRX_CI_PUBLISH', value: 'true' });
     }
 

--- a/stacks/container-apps/sphinx-nlb.yml
+++ b/stacks/container-apps/sphinx-nlb.yml
@@ -474,7 +474,7 @@ Resources:
           TargetGroupArn: !Ref NLBSphinxTargetGroup
       # Role: !Ref ECSServiceIAMRole
       NetworkConfiguration:
-        AwsVpcConfiguration:
+        AwsvpcConfiguration:
           SecurityGroups:
             - !Ref SphinxInboundSecurityGroup
             - !Ref SphinxOutboundSecurityGroup


### PR DESCRIPTION
Currently in a build notification the repo name (e.g., "PRX/Porter") is hyperlinked to CodeBuild. This changes that to the word "build" or "building" to be more obvious

Closes #434 