### PR TITLE
Update deletion and update retention policies to retain resources

### DIFF
--- a/db/mysql-instance.yml
+++ b/db/mysql-instance.yml
@@ -144,6 +144,8 @@ Conditions:
 Resources:
   RDSSubnetGroup:
     Type: "AWS::RDS::DBSubnetGroup"
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       DBSubnetGroupName: !Sub Platform-${EnvironmentType}-${AWS::StackName}-db
       DBSubnetGroupDescription: !Ref EnvironmentType
@@ -153,7 +155,10 @@ Resources:
   MasterDB:
     Type: "AWS::RDS::DBInstance"
     DependsOn: RDSSubnetGroup
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
+      DeletionProtection: true
       # CloudFormation cannot update a stack when a custom-named resource requires replacing,
       # so when replacement is required (such as when restoring from snapshot),
       # use a new instance name such as oldname-restoredYYYYMMDD
@@ -189,7 +194,6 @@ Resources:
     # But we have to set this manually because if flipped with a stack update, the RDS instance is rebuilt
     # It does not change with other stack updates if set manually
     #     PubliclyAccessible: true
-    DeletionPolicy: Snapshot
   DiskSpaceAlarm:
     Condition: CreateCloudWatchWarnDiskSpace
     Type: "AWS::CloudWatch::Alarm"

--- a/db/postgresql-instance.yml
+++ b/db/postgresql-instance.yml
@@ -142,6 +142,7 @@ Resources:
   PostgresInstance:
     Type: "AWS::RDS::DBInstance"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       AllocatedStorage: !Ref AllocatedStorage
       AllowMajorVersionUpgrade: false
@@ -178,6 +179,7 @@ Resources:
   PostgresParameterGroup:
     Type: "AWS::RDS::DBParameterGroup"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: !Sub ${UniqueName} ${EnvironmentType} Parameter Group
       Family: !FindInMap [EngineVersionMap, !Ref EngineVersion, family]
@@ -193,6 +195,7 @@ Resources:
   PostgresSubnetGroup:
     Type: "AWS::RDS::DBSubnetGroup"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       DBSubnetGroupDescription: !Sub ${UniqueName} ${EnvironmentType} Subnet Group
       DBSubnetGroupName: !Sub ${UniqueName}-${EnvironmentType}-Postgres
@@ -213,6 +216,7 @@ Resources:
   PostgresVPCSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       GroupName: !Sub ${UniqueName}${EnvironmentType}Postgres
       GroupDescription: !Sub ${UniqueName} ${EnvironmentType} Postgres Security Group


### PR DESCRIPTION
There was a smattering of use of both DeletionProtection to prevent deletes and DeletionPolicy(on psql, but not mysql).
Also add to both the UpdateReplacePolicy to retain resources on update/replace Cfn executions.
(Which, fwiw, also satisfies the cfn-lint warning)
