### PR TITLE
Modernize storage template

### DIFF
--- a/storage/storage.yml
+++ b/storage/storage.yml
@@ -6,8 +6,6 @@ Description: >-
 Parameters:
   BucketNamePrefix:
     Type: String
-Conditions:
-  IsUsEast1: !Equals [!Ref "AWS::Region", us-east-1]
 Resources:
   # S3 Buckets
   InfrastructureSupportBucket:
@@ -97,18 +95,8 @@ Outputs:
   InfrastructureSourceBucketUrl:
     Description: >-
       The complete S3 URL for the Source bucket (e.g.,
-      https://s3.amazonaws.com/acme-us-west-2-source/)
-    Value:
-      Fn::Join:
-        - ""
-        - - "https://s3"
-          - !If
-            - IsUsEast1
-            - ""
-            - !Sub "-${AWS::Region}"
-          - ".amazonaws.com/"
-          - !Ref InfrastructureSourceBucket
-          - "/"
+      https://acme-us-west-2-source.s3.dualstack.us-west-2.amazonaws.com/)
+    Value: !Sub https://${InfrastructureSourceBucket.DualStackDomainName}/
     Export:
       Name: !Sub ${AWS::StackName}-SourceBucketUrl
   InfrastructureConfigBucket:

--- a/storage/storage.yml
+++ b/storage/storage.yml
@@ -1,6 +1,6 @@
 # storage/storage.yml
 AWSTemplateFormatVersion: "2010-09-09"
-Description: >
+Description: >-
   Creates the standard S3 buckets that are necessary for launching the rest of
   the infrastructure
 Parameters:
@@ -90,7 +90,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-InfrastructureSourceBucket
   InfrastructureSourceBucketUrl:
-    Description: >
+    Description: >-
       The complete S3 URL for the Source bucket (e.g.,
       https://s3.amazonaws.com/acme-us-west-2-source/)
     Value:

--- a/storage/storage.yml
+++ b/storage/storage.yml
@@ -25,7 +25,7 @@ Resources:
       VersioningConfiguration:
         Status: Suspended
   InfrastructureSourceBucket:
-    Type: "AWS::S3::Bucket"
+    Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-source
@@ -39,7 +39,7 @@ Resources:
       VersioningConfiguration:
         Status: Suspended
   InfrastructureConfigBucket:
-    Type: "AWS::S3::Bucket"
+    Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-config
@@ -53,7 +53,7 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
   InfrastructureSnapshotsBucket:
-    Type: "AWS::S3::Bucket"
+    Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-snapshots
@@ -67,7 +67,7 @@ Resources:
       VersioningConfiguration:
         Status: Suspended
   InfrastructureApplicationCodeBucket:
-    Type: "AWS::S3::Bucket"
+    Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-application-code

--- a/storage/storage.yml
+++ b/storage/storage.yml
@@ -11,7 +11,7 @@ Conditions:
 Resources:
   # S3 Buckets
   InfrastructureSupportBucket:
-    Type: "AWS::S3::Bucket"
+    Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-support

--- a/storage/storage.yml
+++ b/storage/storage.yml
@@ -13,6 +13,7 @@ Resources:
   InfrastructureSupportBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-support
       Tags:
@@ -27,6 +28,7 @@ Resources:
   InfrastructureSourceBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-source
       Tags:
@@ -41,6 +43,7 @@ Resources:
   InfrastructureConfigBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-config
       Tags:
@@ -55,6 +58,7 @@ Resources:
   InfrastructureSnapshotsBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-snapshots
       Tags:
@@ -69,6 +73,7 @@ Resources:
   InfrastructureApplicationCodeBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${BucketNamePrefix}-${AWS::Region}-application-code
       Tags:


### PR DESCRIPTION
- Adds UpdateReplacePolicy for all bucket resources
- Replaces a `join` to build the bucket URL with a more direct return value, which didn't exist when the template was first made. (This does change the URL from a path-style URL to virtual host. I don't think this value is actually being used anywhere, but it shouldn't matter even if it is)
- Small syntax changes