### PR TITLE
Pull dockerhub login from parameterstore

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -216,6 +216,12 @@ Resources:
             Value:
               Fn::ImportValue:
                 !Sub ${InfrastructureStorageStackName}-InfrastructureApplicationCodeBucket
+          - Name: DOCKERHUB_USERNAME
+            Type: PARAMETER_STORE
+            Value: /prx/DOCKERHUB_USERNAME
+          - Name: DOCKERHUB_PASSWORD
+            Type: PARAMETER_STORE
+            Value: /prx/DOCKERHUB_PASSWORD
         Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         PrivilegedMode: true
         Type: LINUX_CONTAINER


### PR DESCRIPTION
Note: this would save a couple lines, but each individual repo's buildspec would still need to run the [docker login](https://github.com/PRX/exchange.prx.org/commit/c016a6f500644b44b492d83371e818354f659c0f#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cR14) command itself.