### PR TITLE
Publish S3 bucket refactor

### DIFF
--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -132,7 +132,7 @@ Resources:
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
             - Name: UPLOAD_S3_ENDPOINT_HOST
-              Value: !GetAtt PublishUploadsBucket.DualStackDomainName
+              Value: !Sub ${PublishUploadsBucket}.s3-accelerate.dualstack.amazonaws.com
             - Name: UPLOAD_BUCKET_NAME
               Value: !Ref PublishUploadsBucket
           Essential: true

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -136,7 +136,6 @@ Resources:
             - Name: UPLOAD_BUCKET_NAME
               Value: !Ref PublishUploadsBucket
           Essential: true
-          # TODO
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/publish.prx.org:${PublishEcrImageTag}
           LogConfiguration:
             LogDriver: awslogs

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -131,6 +131,10 @@ Resources:
               Value: !Ref PublishSecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
+            - Name: UPLOAD_S3_ENDPOINT_HOST
+              Value: !GetAtt PublishUploadsBucket.DualStackDomainName
+            - Name: UPLOAD_BUCKET_NAME
+              Value: !Ref PublishUploadsBucket
           Essential: true
           # TODO
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/publish.prx.org:${PublishEcrImageTag}
@@ -220,6 +224,25 @@ Resources:
           Value: !Ref PlatformALBFullName
         - Name: TargetGroup
           Value: !GetAtt PublishALBTargetGroup.TargetGroupFullName
+  # Upload bucket
+  PublishUploadsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 3
+            Status: Enabled
+      Tags:
+        - Key: Project
+          Value: !FindInMap [Shared, Project, name]
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId
 Outputs:
   HostedZoneDNSName:
     Description: Convenience domain name for the ALB in a hosted zone

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -132,9 +132,11 @@ Resources:
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
             - Name: UPLOAD_S3_ENDPOINT_HOST
-              Value: !Sub ${PublishUploadsBucket}.s3-accelerate.dualstack.amazonaws.com
+              # Value: !Sub ${PublishUploadsBucket}.s3-accelerate.dualstack.amazonaws.com
+              Value: prx-up.s3-accelerate.dualstack.amazonaws.com
             - Name: UPLOAD_BUCKET_NAME
-              Value: !Ref PublishUploadsBucket
+              # Value: !Ref PublishUploadsBucket
+              Value: prx-up
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/publish.prx.org:${PublishEcrImageTag}
           LogConfiguration:

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -234,6 +234,11 @@ Resources:
         Rules:
           - ExpirationInDays: 3
             Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]


### PR DESCRIPTION
Creates a new bucket to be used (in the future) for Publish uploads temp storage. For now it just passes the environment variables in in a way that matches how they will work with the new bucket.