### PR TITLE
Use inline Publish bucket and CDN in production

### DIFF
--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -132,23 +132,11 @@ Resources:
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
             - Name: UPLOAD_S3_ENDPOINT_HOST
-              Value:
-                !If
-                  - CreateProductionResources
-                  - prx-up.s3-accelerate.dualstack.amazonaws.com
-                  - !Sub ${PublishUploadsBucket}.s3-accelerate.dualstack.amazonaws.com
+              Value: !Sub ${PublishUploadsBucket}.s3-accelerate.dualstack.amazonaws.com
             - Name: UPLOAD_BUCKET_NAME
-              Value:
-                !If
-                  - CreateProductionResources
-                  - prx-up
-                  - !Ref PublishUploadsBucket
+              Value: !Ref PublishUploadsBucket
             - Name: UPLOAD_PUBLIC_ACCESS_HOST
-              Value:
-                !If
-                  - CreateProductionResources
-                  - !Ref AWS::NoValue
-                  - !GetAtt PublishUploadsCloudFrontDistribution.DomainName
+              Value: !GetAtt PublishUploadsCloudFrontDistribution.DomainName
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/publish.prx.org:${PublishEcrImageTag}
           LogConfiguration:


### PR DESCRIPTION
Closes #471

Flips the switch on using the new template-provided S3 bucket for Uploads, as well as a CloudFront distribution in front of the bucket to provide the necessary public access to the uploads