### PR TITLE
Remove HTTP listeners, and upgrade all HTTP requests to HTTPS

### DIFF
--- a/stacks/castle.prx.org.yml
+++ b/stacks/castle.prx.org.yml
@@ -22,8 +22,6 @@ Parameters:
     Type: String
   PlatformALBCanonicalHostedZoneID:
     Type: String
-  PlatformALBHTTPListenerArn:
-    Type: String
   PlatformALBHTTPSListenerArn:
     Type: String
   PlatformALBListenerPriorityPrefix:

--- a/stacks/castle.prx.org.yml
+++ b/stacks/castle.prx.org.yml
@@ -106,18 +106,6 @@ Resources:
             - castle.*
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
-  CastleALBHTTPHostWildcardListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref CastleALBTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - castle.*
-      ListenerArn: !Ref PlatformALBHTTPListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
   # ECS Service
   CastleTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"

--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -37,8 +37,6 @@ Parameters:
     Type: String
   PlatformALBCanonicalHostedZoneID:
     Type: String
-  PlatformALBHTTPListenerArn:
-    Type: String
   PlatformALBHTTPSListenerArn:
     Type: String
   # ECS Cluster ################################################################
@@ -140,7 +138,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -238,7 +235,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -330,7 +326,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -434,7 +429,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -477,7 +471,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -548,7 +541,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -592,7 +584,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -658,7 +649,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn
@@ -701,7 +691,6 @@ Resources:
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
         ECSServiceAutoscaleIAMRoleArn: !Ref ECSServiceAutoscaleIAMRoleArn

--- a/stacks/container-apps/web-application.yml
+++ b/stacks/container-apps/web-application.yml
@@ -19,8 +19,6 @@ Parameters:
     Type: String
   PlatformALBCanonicalHostedZoneID:
     Type: String
-  PlatformALBHTTPListenerArn:
-    Type: String
   PlatformALBHTTPSListenerArn:
     Type: String
   PlatformALBListenerPriorityPrefix:

--- a/stacks/container-apps/web-application.yml
+++ b/stacks/container-apps/web-application.yml
@@ -133,18 +133,6 @@ Resources:
             - !Sub ${AppName}.*
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
-  ALBHTTPHostWildcardListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref ALBTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - !Sub ${AppName}.*
-      ListenerArn: !Ref PlatformALBHTTPListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
   ALBHTTPSAlternateWildcardListenerRule:
     Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
     Condition: HasAltName
@@ -158,19 +146,6 @@ Resources:
             - !Sub ${AltName}.*
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "01"]]
-  ALBHTTPAlternateWildcardListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Condition: HasAltName
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref ALBTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - !Sub ${AltName}.*
-      ListenerArn: !Ref PlatformALBHTTPListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "01"]]
   ALBHTTPSExplicitListenerRule:
     Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
     Condition: HasExplicitHostHeader
@@ -183,19 +158,6 @@ Resources:
           Values:
             - !Ref ExplicitHostHeader
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "10"]]
-  ALBHTTPExplicitListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Condition: HasExplicitHostHeader
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref ALBTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - !Ref ExplicitHostHeader
-      ListenerArn: !Ref PlatformALBHTTPListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "10"]]
   # CloudWatch Alarms
   ALBTargetGroup500Alarm:

--- a/stacks/load-balancers.yml
+++ b/stacks/load-balancers.yml
@@ -268,9 +268,6 @@ Outputs:
   PlatformALBCanonicalHostedZoneID:
     Description: The hosted zone ID for the application load balancer
     Value: !GetAtt PlatformALB.CanonicalHostedZoneID
-  PlatformALBHTTPListenerArn:
-    Description: The ARN for the HTTP listener
-    Value: !Ref PlatformALBHTTPListener
   PlatformALBHTTPSListenerArn:
     Description: The ARN for the HTTPS listener
     Value: !Ref PlatformALBHTTPSListener

--- a/stacks/load-balancers.yml
+++ b/stacks/load-balancers.yml
@@ -120,6 +120,9 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
+  # The HTTP listener handles all HTTP traffic with the default action, which
+  # upgrades requests to HTTPS. There are not additional listener rules on the
+  # HTTP listener.
   PlatformALBHTTPListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:
@@ -127,14 +130,6 @@ Resources:
       Port: 80
       Protocol: HTTP
       DefaultActions:
-        - FixedResponseConfig:
-            StatusCode: "404"
-          Type: fixed-response
-  PlatformALBHTTPUpgradeRedirectListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Condition: CreateStagingResources
-    Properties:
-      Actions:
         - RedirectConfig:
             Host: '#{host}'
             Path: '/#{path}'
@@ -143,12 +138,9 @@ Resources:
             Query: '#{query}'
             StatusCode: HTTP_301
           Type: redirect
-      Conditions:
-        - Field: path-pattern
-          Values:
-            - '*'
-      ListenerArn: !Ref PlatformALBHTTPListener
-      Priority: 1
+  # The HTTPS listener has additional rules for handling app-specific traffic.
+  # The default action is a 404 fixed response for when traffic doesn't match
+  # any of the app-specific rules.
   PlatformALBHTTPSListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:

--- a/stacks/metrics.prx.org.yml
+++ b/stacks/metrics.prx.org.yml
@@ -21,8 +21,6 @@ Parameters:
     Type: String
   PlatformALBCanonicalHostedZoneID:
     Type: String
-  PlatformALBHTTPListenerArn:
-    Type: String
   PlatformALBHTTPSListenerArn:
     Type: String
   PlatformALBListenerPriorityPrefix:

--- a/stacks/metrics.prx.org.yml
+++ b/stacks/metrics.prx.org.yml
@@ -102,18 +102,6 @@ Resources:
             - metrics.*
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
-  MetricsALBHTTPHostWildcardListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref MetricsALBTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - metrics.*
-      ListenerArn: !Ref PlatformALBHTTPListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
   # ECS Service
   MetricsTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"

--- a/stacks/play.prx.org.yml
+++ b/stacks/play.prx.org.yml
@@ -104,18 +104,6 @@ Resources:
             - play.*
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
-  PlayALBHTTPHostWildcardListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref PlayALBTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - play.*
-      ListenerArn: !Ref PlatformALBHTTPListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
   # ECS Service
   PlayTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"

--- a/stacks/play.prx.org.yml
+++ b/stacks/play.prx.org.yml
@@ -23,8 +23,6 @@ Parameters:
     Type: String
   PlatformALBCanonicalHostedZoneID:
     Type: String
-  PlatformALBHTTPListenerArn:
-    Type: String
   PlatformALBHTTPSListenerArn:
     Type: String
   PlatformALBListenerPriorityPrefix:

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -21,8 +21,6 @@ Parameters:
     Type: String
   PlatformALBCanonicalHostedZoneID:
     Type: String
-  PlatformALBHTTPListenerArn:
-    Type: String
   PlatformALBHTTPSListenerArn:
     Type: String
   PlatformALBListenerPriorityPrefix:

--- a/stacks/publish.prx.org.yml
+++ b/stacks/publish.prx.org.yml
@@ -102,18 +102,6 @@ Resources:
             - publish.*
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
-  PublishALBHTTPHostWildcardListenerRule:
-    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref PublishALBTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - publish.*
-      ListenerArn: !Ref PlatformALBHTTPListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
   # ECS Service
   PublishTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -284,7 +284,6 @@ Resources:
         PlatformALBDNSName: !GetAtt LoadBalancersStack.Outputs.PlatformALBDualstackDNSName
         PlatformALBFullName: !GetAtt LoadBalancersStack.Outputs.PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !GetAtt LoadBalancersStack.Outputs.PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
         ECSClusterArn: !GetAtt ECSClusterStack.Outputs.ECSClusterArn
@@ -464,7 +463,6 @@ Resources:
         PlatformALBDNSName: !GetAtt LoadBalancersStack.Outputs.PlatformALBDualstackDNSName
         PlatformALBFullName: !GetAtt LoadBalancersStack.Outputs.PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !GetAtt LoadBalancersStack.Outputs.PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Publish, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
@@ -504,7 +502,6 @@ Resources:
         PlatformALBDNSName: !GetAtt LoadBalancersStack.Outputs.PlatformALBDualstackDNSName
         PlatformALBFullName: !GetAtt LoadBalancersStack.Outputs.PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !GetAtt LoadBalancersStack.Outputs.PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Castle, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
@@ -546,7 +543,6 @@ Resources:
         PlatformALBDNSName: !GetAtt LoadBalancersStack.Outputs.PlatformALBDualstackDNSName
         PlatformALBFullName: !GetAtt LoadBalancersStack.Outputs.PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !GetAtt LoadBalancersStack.Outputs.PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Play, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
@@ -586,7 +582,6 @@ Resources:
         PlatformALBDNSName: !GetAtt LoadBalancersStack.Outputs.PlatformALBDualstackDNSName
         PlatformALBFullName: !GetAtt LoadBalancersStack.Outputs.PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !GetAtt LoadBalancersStack.Outputs.PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Crier, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
@@ -725,7 +720,6 @@ Resources:
         PlatformALBDNSName: !GetAtt LoadBalancersStack.Outputs.PlatformALBDualstackDNSName
         PlatformALBFullName: !GetAtt LoadBalancersStack.Outputs.PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !GetAtt LoadBalancersStack.Outputs.PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Id, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
@@ -770,7 +764,6 @@ Resources:
         PlatformALBDNSName: !GetAtt LoadBalancersStack.Outputs.PlatformALBDualstackDNSName
         PlatformALBFullName: !GetAtt LoadBalancersStack.Outputs.PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !GetAtt LoadBalancersStack.Outputs.PlatformALBCanonicalHostedZoneID
-        PlatformALBHTTPListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Metrics, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster


### PR DESCRIPTION
**Hold until this change is ready for production. It is not behind a feature flag.**

This change removes all the app-specific ALB listener rules that were previously added by individual app stacks. The HTTP listener is now used exclusively to upgrade requests to a matching HTTPS request via 301 a redirect. That redirect is configured as the default action on the HTTP listener, and should handle all traffic to the listener, so no other rules are required (in fact, they would break this behavior). The output containing the HTTP listener's ARN was removed to make it difficult to accidentally add rules to the listener, and the related parameters were removed as well.

Blocked by:
- [ ] https://github.com/PRX/networks.prx.org/issues/44