### PR TITLE
Per-request DDB table fixes

### DIFF
--- a/db/dynamodb-table.yml
+++ b/db/dynamodb-table.yml
@@ -113,9 +113,11 @@ Parameters:
     Default: PAY_PER_REQUEST
   ProvisionedReadCapacityUnits:
     Type: Number
+    Default: 0
     Description: Only used under provisioned billing
   ProvisionedWriteCapacityUnits:
     Type: Number
+    Default: 0
     Description: Only used under provisioned billing
   EnableAutoScaling:
     Type: String
@@ -126,15 +128,19 @@ Parameters:
     Description: Only used under provisioned billing
   WriteCapacityMin:
     Type: Number
+    Default: 0
     Description: Only used under provisioned billing with auto scaling
   WriteCapacityMax:
     Type: Number
+    Default: 0
     Description: Only used under provisioned billing with auto scaling
   ReadCapacityMin:
     Type: Number
+    Default: 0
     Description: Only used under provisioned billing with auto scaling
   ReadCapacityMax:
     Type: Number
+    Default: 0
     Description: Only used under provisioned billing with auto scaling
   AutoScalingCooldown:
     Type: Number
@@ -166,6 +172,7 @@ Conditions:
   CreateAutoScaling: !And
     - !Condition AutoScalingRequested
     - !Condition HasProvisionedBilling
+  CreateAlarms: !Not [!Equals [!Ref WarnMessagesSnsTopicArn, ""]]
 Mappings:
   DataTypesMap:
     String:
@@ -187,12 +194,11 @@ Resources:
         - AttributeName: !Ref PrimaryKey
           KeyType: HASH
       TableName: !Ref TableName
-      ProvisionedThroughput:
-        !If
-          - HasProvisionedBilling
-          - ReadCapacityUnits: !Ref ProvisionedReadCapacityUnits
-            WriteCapacityUnits: !Ref ProvisionedWriteCapacityUnits
-          - !Ref "AWS::NoValue"
+      ProvisionedThroughput: !If
+        - HasProvisionedBilling
+        - ReadCapacityUnits: !Ref ProvisionedReadCapacityUnits
+          WriteCapacityUnits: !Ref ProvisionedWriteCapacityUnits
+        - !Ref "AWS::NoValue"
       Tags:
         - Key: Project
           Value: !Ref ProjectTag
@@ -203,7 +209,8 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TimeToLiveSpecification:
-        AttributeName: !If [HasExpirationField, !Ref "ExpirationField", !Ref "AWS::NoValue"]
+        AttributeName:
+          !If [HasExpirationField, !Ref "ExpirationField", !Ref "AWS::NoValue"]
         Enabled: !If [HasExpirationField, true, false]
   CrossAccountAccessRole:
     Type: "AWS::IAM::Role"
@@ -214,11 +221,10 @@ Resources:
         Statement:
           - Effect: "Allow"
             Action: "sts:AssumeRole"
-            Principal:
-              !If
-                - HasForeignRole
-                - AWS: !Sub "arn:aws:iam::${ForeignAccountId}:role/${ForeignRoleName}"
-                - AWS: !Ref ForeignAccountId
+            Principal: !If
+              - HasForeignRole
+              - AWS: !Sub "arn:aws:iam::${ForeignAccountId}:role/${ForeignRoleName}"
+              - AWS: !Ref ForeignAccountId
       Path: "/"
       Policies:
         - PolicyName: DynamoDBWritePolicy
@@ -298,6 +304,7 @@ Resources:
   # Alarms
   ScanThrottledRequestsAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: CreateAlarms
     Properties:
       ActionsEnabled: true
       AlarmName: !Sub ${AWS::StackName} Scan throttling
@@ -307,8 +314,7 @@ Resources:
         - !Ref WarnMessagesSnsTopicArn
       OKActions:
         - !Ref WarnMessagesSnsTopicArn
-      AlarmDescription:
-        Scan operations are being throttled
+      AlarmDescription: Scan operations are being throttled
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       MetricName: ThrottledRequests
@@ -324,6 +330,7 @@ Resources:
           Value: Scan
   BatchGetItemThrottledRequestsAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: CreateAlarms
     Properties:
       ActionsEnabled: true
       AlarmName: !Sub ${AWS::StackName} BatchGetItem throttling
@@ -333,8 +340,7 @@ Resources:
         - !Ref WarnMessagesSnsTopicArn
       OKActions:
         - !Ref WarnMessagesSnsTopicArn
-      AlarmDescription:
-        BatchGetItem operations are being throttled
+      AlarmDescription: BatchGetItem operations are being throttled
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       MetricName: ThrottledRequests
@@ -350,6 +356,7 @@ Resources:
           Value: BatchGetItem
   BatchWriteItemThrottledRequestsAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: CreateAlarms
     Properties:
       ActionsEnabled: true
       AlarmName: !Sub ${AWS::StackName} BatchWriteItem throttling
@@ -359,8 +366,7 @@ Resources:
         - !Ref WarnMessagesSnsTopicArn
       OKActions:
         - !Ref WarnMessagesSnsTopicArn
-      AlarmDescription:
-        BatchWriteItem operations are being throttled
+      AlarmDescription: BatchWriteItem operations are being throttled
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       MetricName: ThrottledRequests
@@ -375,6 +381,10 @@ Resources:
         - Name: Operation
           Value: BatchWriteItem
 Outputs:
+  RoleArn:
+    Condition: HasForeignAccount
+    Description: The created DynamoDB table ARN
+    Value: !GetAtt CrossAccountAccessRole.Arn
   TableArn:
     Description: The created DynamoDB table ARN
     Value: !GetAtt DynamoDBTable.Arn


### PR DESCRIPTION
I've already deployed these changes to the Dovetail "arrangements" tables in the data accounts.

I'm using pay-per-request tables with 0 alarms there, until we get a bit closer to this being live.  Then will add some alarms, and maybe flip prod to the cheaper provisioned eventually.