### PR TITLE
Dovetail-Router autoscaling

### DIFF
--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -666,7 +666,7 @@ Resources:
       TreatMissingData: notBreaching
       Dimensions:
         - Name: LoadBalancer
-          Value: !Ref DovetailALB
+          Value: !GetAtt DovetailALB.LoadBalancerFullName
         - Name: TargetGroup
           Value: !GetAtt DovetailRouterALBTargetGroup.TargetGroupFullName
   # connect dovetail-router impressions to ddb kinesis

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -62,12 +62,18 @@ Mappings:
     Testing:
       DovetailMinCount: 1
       DovetailMaxCount: 1
+      DovetailRouterMinCount: 1
+      DovetailRouterMaxCount: 1
     Staging:
       DovetailMinCount: 2
       DovetailMaxCount: 4
+      DovetailRouterMinCount: 2
+      DovetailRouterMaxCount: 4
     Production:
       DovetailMinCount: 8
       DovetailMaxCount: 30
+      DovetailRouterMinCount: 3
+      DovetailRouterMaxCount: 10
 Resources:
   DovetailSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
@@ -808,6 +814,29 @@ Resources:
           Value: !Sub ${AWS::StackName}-DovetailApp
         - Name: ClusterName
           Value: !Ref ECSCluster
+  # Dovetail Elixir Autoscaling
+  DovetailRouterScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MinCapacity: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DovetailRouterMinCount]
+      MaxCapacity: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, DovetailRouterMaxCount]
+      ResourceId: !Join ["/", ["service", !Ref ECSCluster, !GetAtt DovetailRouterService.Name]]
+      RoleARN: !GetAtt DovetailAutoScalingIamRole.Arn
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+  DovetailRouterScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ScaleIn
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref DovetailRouterScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ALBRequestCountPerTarget
+          ResourceLabel: !Join ["/", [!GetAtt DovetailALB.LoadBalancerFullName, !GetAtt DovetailRouterALBTargetGroup.TargetGroupFullName]]
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        TargetValue: 2000
 Outputs:
   HostedZoneDNSName:
     Description: Convenience domain name for the ALB in a hosted zone

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -836,7 +836,7 @@ Resources:
           ResourceLabel: !Join ["/", [!GetAtt DovetailALB.LoadBalancerFullName, !GetAtt DovetailRouterALBTargetGroup.TargetGroupFullName]]
         ScaleInCooldown: 60
         ScaleOutCooldown: 60
-        TargetValue: 2000
+        TargetValue: 1000
 Outputs:
   HostedZoneDNSName:
     Description: Convenience domain name for the ALB in a hosted zone

--- a/stacks/dovetail.prx.org.yml
+++ b/stacks/dovetail.prx.org.yml
@@ -827,7 +827,7 @@ Resources:
   DovetailRouterScalingPolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
-      PolicyName: ScaleIn
+      PolicyName: RequestCountScaling
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref DovetailRouterScalableTarget
       TargetTrackingScalingPolicyConfiguration:


### PR DESCRIPTION
Closes PRX/dovetail-router.prx.org#106

Add a `TargetTrackingScaling` autoscaling policy to dovetail-router.

I set the initial target to 1000 requests per target, per 1 minute:

- Prod was previously averaging ~40 requests per-target-per-minute and ~15ms response times.
- Prod is now averaging 180 requests per-target-per-minute, and ~19ms response times.
- Load testing staging, it seem like we could do at least 1000 per target.  At ~5K requests per target, response times degraded to more like 75ms, but things still seemed stable / error-free.

Current Dovetail (nodejs) does something like ~8000 requests per minute, amongst ~20 targets - so more like 400 per target.  And averages ~70ms per request.  So I think we'll at least be able to cut our tasks in half with better response times.