### PR TITLE
Create CMS memcached in CMS stack

### DIFF
--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -344,6 +344,11 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
+            - Fn::If:
+                - CreateProductionResources
+                - !Ref AWS::NoValue
+                - Name: MEMCACHE_SERVERS
+                  Value: !GetAtt CmsMemcacheCluster.ConfigurationEndpoint.Address
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/${AppName}.prx.org:${EcrImageTag}
           LogConfiguration:

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -1,0 +1,392 @@
+# stacks/container-apps/web-application.yml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Docker web application with optional worker, using the shared platform ALB
+Conditions:
+  CreateWorkerResources: !Equals [!Ref CreateWorker, true]
+  CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+  HasMemoryReservation: !Not [!Equals [!Ref ContainerMemoryReservation, ""]]
+  HasAltName: !Not [!Equals [!Ref AltName, ""]]
+  HasExplicitHostHeader: !Not [!Equals [!Ref ExplicitHostHeader, ""]]
+Parameters:
+  # VPC ########################################################################
+  VPC:
+    Type: "AWS::EC2::VPC::Id"
+  # Load Balancer ##############################################################
+  PlatformALBDNSName:
+    Type: String
+  PlatformALBFullName:
+    Type: String
+  PlatformALBCanonicalHostedZoneID:
+    Type: String
+  PlatformALBHTTPListenerArn:
+    Type: String
+  PlatformALBHTTPSListenerArn:
+    Type: String
+  PlatformALBListenerPriorityPrefix:
+    Type: String
+  # ECS Cluster ################################################################
+  ECSCluster:
+    Type: String
+  ECSServiceAutoscaleIAMRoleArn:
+    Type: String
+  ECSServiceIAMRole:
+    Type: String
+  # Misc #######################################################################
+  OpsDebugMessagesSnsTopicArn:
+    Type: String
+  OpsErrorMessagesSnsTopicArn:
+    Type: String
+  EnvironmentType:
+    Type: String
+  EnvironmentTypeAbbreviation:
+    Type: String
+  SecretsBase:
+    Type: String
+  EcrRegion:
+    Type: String
+  EcrImageTag:
+    Type: String
+  CreateWorker:
+    Type: String
+  DesiredWebs:
+    Type: String
+    Default: 2
+  DesiredWorkers:
+    Type: String
+    Default: 1
+  DesiredWebsProduction:
+    Type: String
+    Default: 2
+  DesiredWorkersProduction:
+    Type: String
+    Default: 1
+  ErrorAlarmThreshold:
+    Type: String
+    Default: 0
+  # App ENV #################################################################
+  AppName:
+    Type: String # castle, crier, cms, feeder
+  AltName:
+    Type: String
+    Default: ""
+  ExplicitHostHeader:
+    Type: String
+    Default: ""
+  SecretsVersion:
+    Type: String
+  ContainerPort:
+    Type: String
+    Default: 3000
+  ContainerMemory:
+    Type: String
+    Default: 500
+  ContainerMemoryReservation:
+    Type: String
+    Default: ""
+  ContainerCpu:
+    Type: String
+    Default: 128
+  WebContainerCommand:
+    Type: String
+    Default: web
+  HealthCheckPath:
+    Type: String
+    Default: /api/v1
+Resources:
+  ALBTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
+      HealthCheckPath: !Ref HealthCheckPath
+      Name: !Sub ${AppName}-${EnvironmentTypeAbbreviation}
+      Port: 80
+      Protocol: HTTP
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: "30"
+      Tags:
+        - Key: Project
+          Value: !Ref AppName
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: Name
+          Value: !Sub ${AppName}-${EnvironmentType}
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      VpcId: !Ref VPC
+  # ALB Listener Rules
+  ALBHTTPSHostWildcardListenerRule:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref ALBTargetGroup
+          Type: forward
+      Conditions:
+        - Field: host-header
+          Values:
+            - !Sub ${AppName}.*
+      ListenerArn: !Ref PlatformALBHTTPSListenerArn
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
+  ALBHTTPHostWildcardListenerRule:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref ALBTargetGroup
+          Type: forward
+      Conditions:
+        - Field: host-header
+          Values:
+            - !Sub ${AppName}.*
+      ListenerArn: !Ref PlatformALBHTTPListenerArn
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
+  ALBHTTPSAlternateWildcardListenerRule:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+    Condition: HasAltName
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref ALBTargetGroup
+          Type: forward
+      Conditions:
+        - Field: host-header
+          Values:
+            - !Sub ${AltName}.*
+      ListenerArn: !Ref PlatformALBHTTPSListenerArn
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "01"]]
+  ALBHTTPAlternateWildcardListenerRule:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+    Condition: HasAltName
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref ALBTargetGroup
+          Type: forward
+      Conditions:
+        - Field: host-header
+          Values:
+            - !Sub ${AltName}.*
+      ListenerArn: !Ref PlatformALBHTTPListenerArn
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "01"]]
+  ALBHTTPSExplicitListenerRule:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+    Condition: HasExplicitHostHeader
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref ALBTargetGroup
+          Type: forward
+      Conditions:
+        - Field: host-header
+          Values:
+            - !Ref ExplicitHostHeader
+      ListenerArn: !Ref PlatformALBHTTPSListenerArn
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "10"]]
+  ALBHTTPExplicitListenerRule:
+    Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+    Condition: HasExplicitHostHeader
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref ALBTargetGroup
+          Type: forward
+      Conditions:
+        - Field: host-header
+          Values:
+            - !Ref ExplicitHostHeader
+      ListenerArn: !Ref PlatformALBHTTPListenerArn
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "10"]]
+  # CloudWatch Alarms
+  ALBTargetGroup500Alarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Condition: CreateProductionResources
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "[${AppName}][ALB][Error] Target 5XX"
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      InsufficientDataActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      OKActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription: !Sub |
+        5XX server errors originating from the ${AppName} target group exceeded 0
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Period: 60
+      Statistic: Sum
+      Threshold: !Ref ErrorAlarmThreshold
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !Ref PlatformALBFullName
+        - Name: TargetGroup
+          Value: !GetAtt ALBTargetGroup.TargetGroupFullName
+  # ECS Service - Web
+  WebLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      RetentionInDays: 14
+  WebTaskDefinition:
+    Type: "AWS::ECS::TaskDefinition"
+    Properties:
+      ContainerDefinitions:
+        - Cpu: !Ref ContainerCpu
+          Environment:
+            - Name: APP_NAME
+              Value: !Ref AppName
+            - Name: APP_ENV
+              Value: !Ref EnvironmentTypeAbbreviation
+            - Name: AWS_SECRETS_BASE
+              Value: !Ref SecretsBase
+            - Name: AWS_SECRETS_VERSION
+              Value: !Ref SecretsVersion
+            - Name: AWS_DEFAULT_REGION
+              Value: !Ref AWS::Region
+          Essential: true
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/${AppName}.prx.org:${EcrImageTag}
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref WebLogGroup
+              awslogs-region: !Ref AWS::Region
+          Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
+          Name: !Sub ${AppName}-web
+          PortMappings:
+            - HostPort: 0
+              ContainerPort: !Ref ContainerPort
+          Command:
+            - !Ref WebContainerCommand
+      Tags:
+        - Key: Project
+          Value: !Ref AppName
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+  WebService:
+    Type: "AWS::ECS::Service"
+    Properties:
+      Cluster: !Ref ECSCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+      DesiredCount: !If [CreateProductionResources, !Ref DesiredWebsProduction, !Ref DesiredWebs]
+      LoadBalancers:
+        - ContainerName: !Sub ${AppName}-web
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref ALBTargetGroup
+      Role: !Ref ECSServiceIAMRole
+      Tags:
+        - Key: Project
+          Value: !Ref AppName
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TaskDefinition: !Ref WebTaskDefinition
+  # Route 53
+  WebRecordSetGroup:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      Comment: Record sets for dualstack web traffic to a web app instance
+      HostedZoneName: prx.tech.
+      RecordSets:
+        - Type: AAAA
+          Name: !Sub ${AppName}.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech.
+          AliasTarget:
+            DNSName: !Ref PlatformALBDNSName
+            HostedZoneId: !Ref PlatformALBCanonicalHostedZoneID
+        - Type: A
+          Name: !Sub ${AppName}.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech.
+          AliasTarget:
+            DNSName: !Ref PlatformALBDNSName
+            HostedZoneId: !Ref PlatformALBCanonicalHostedZoneID
+  # ECS Service - Worker
+  WorkerLogGroup:
+    Condition: CreateWorkerResources
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      RetentionInDays: 14
+  WorkerTaskDefinition:
+    Condition: CreateWorkerResources
+    Type: "AWS::ECS::TaskDefinition"
+    Properties:
+      ContainerDefinitions:
+        - Cpu: !Ref ContainerCpu
+          Environment:
+            - Name: APP_NAME
+              Value: !Ref AppName
+            - Name: APP_ENV
+              Value: !Ref EnvironmentTypeAbbreviation
+            - Name: AWS_SECRETS_BASE
+              Value: !Ref SecretsBase
+            - Name: AWS_SECRETS_VERSION
+              Value: !Ref SecretsVersion
+            - Name: AWS_DEFAULT_REGION
+              Value: !Ref AWS::Region
+          Essential: true
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/${AppName}.prx.org:${EcrImageTag}
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref WorkerLogGroup
+              awslogs-region: !Ref AWS::Region
+          Memory: !Ref ContainerMemory
+          MemoryReservation: !If [HasMemoryReservation, !Ref ContainerMemoryReservation, !Ref "AWS::NoValue"]
+          Name: !Sub ${AppName}-worker
+          Command:
+            - worker
+      Tags:
+        - Key: Project
+          Value: !Ref AppName
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+  WorkerService:
+    Condition: CreateWorkerResources
+    Type: "AWS::ECS::Service"
+    Properties:
+      Cluster: !Ref ECSCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+      DesiredCount: !If [CreateProductionResources, !Ref DesiredWorkersProduction, !Ref DesiredWorkers]
+      Tags:
+        - Key: Project
+          Value: !Ref AppName
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
+      TaskDefinition: !Ref WorkerTaskDefinition
+Outputs:
+  WorkerTaskDefinitionArn:
+    Description: Arn for the worker task definition
+    Value: !If [CreateWorkerResources, !Ref WorkerTaskDefinition, ""]
+  WorkerTaskDefinitionName:
+    Description: Name of the worker task definition
+    Value: !Sub ${AppName}-worker
+  WorkerServiceName:
+    Description: Name of the worker service
+    Value: !If [CreateWorkerResources, !GetAtt WorkerService.Name, ""]
+  WorkerLogGroupName:
+    Description: Name of the worker log group
+    Value: !If [CreateWorkerResources, !Ref WorkerLogGroup, ""]
+  HostedZoneDNSName:
+    Description: Convenience domain name for the ALB in a hosted zone
+    Value: !Sub |
+      ${AppName}.${EnvironmentTypeAbbreviation}-${VPC}.prx.tech.

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -384,7 +384,6 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TaskDefinition: !Ref WorkerTaskDefinition
-
   # memcached
   CmsMemcacheSubnetGroup:
     Type: AWS::ElastiCache::SubnetGroup

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -1,4 +1,4 @@
-# stacks/container-apps/web-application.yml
+# stacks/container-apps/cms.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, using the shared platform ALB
@@ -252,6 +252,11 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
+            - Fn::If:
+                - CreateProductionResources
+                - !Ref AWS::NoValue
+                - Name: MEMCACHE_SERVERS
+                  Value: !GetAtt CmsMemcacheCluster.ConfigurationEndpoint.Address
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${EcrRegion}.amazonaws.com/${AppName}.prx.org:${EcrImageTag}
           LogConfiguration:
@@ -379,6 +384,58 @@ Resources:
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
       TaskDefinition: !Ref WorkerTaskDefinition
+
+  # memcached
+  CmsMemcacheSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      Description: !Sub CMS ${EnvironmentType} memcache subnet group
+      SubnetIds:
+        - !Ref VPCSubnet1
+        - !Ref VPCSubnet2
+  CmsMemcacheSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref VPC
+      GroupDescription: !Sub CMS ${EnvironmentType} memcached security group
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: tcp
+          FromPort: 11211
+          ToPort: 11211
+        - CidrIpv6: ::/0
+          IpProtocol: tcp
+          FromPort: 11211
+          ToPort: 11211
+  CmsMemcacheCluster:
+    Type: AWS::ElastiCache::CacheCluster
+    Properties:
+      AutoMinorVersionUpgrade: true
+      AZMode: !If
+        - CreateProductionResources
+        - cross-az
+        - single-az
+      Engine: memcached
+      CacheNodeType: !If
+        - CreateProductionResources
+        - cache.t3.micro
+        - cache.t3.micro
+      NumCacheNodes: !If
+        - CreateProductionResources
+        - 2
+        - 1
+      CacheSubnetGroupName: !Ref CmsMemcacheSubnetGroup
+      VpcSecurityGroupIds:
+        - !GetAtt CmsMemcacheSecurityGroup.GroupId
+      Tags:
+        - Key: Project
+          Value: !Ref AppName
+        - Key: Environment
+          Value: !Ref EnvironmentType
+        - Key: prx:cloudformation:stack-name
+          Value: !Ref AWS::StackName
+        - Key: prx:cloudformation:stack-id
+          Value: !Ref AWS::StackId
 Outputs:
   WorkerTaskDefinitionArn:
     Description: Arn for the worker task definition

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -12,6 +12,12 @@ Parameters:
   # VPC ########################################################################
   VPC:
     Type: "AWS::EC2::VPC::Id"
+  VPCSubnet1:
+    Type: "AWS::EC2::Subnet::Id"
+  VPCSubnet2:
+    Type: "AWS::EC2::Subnet::Id"
+  VPCSubnet3:
+    Type: "AWS::EC2::Subnet::Id"
   # Load Balancer ##############################################################
   PlatformALBDNSName:
     Type: String

--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -478,7 +478,7 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
-      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "web-application.yml"]]
+      TemplateURL: !Join ["", [!Ref TemplateUrlPrefix, "cms.prx.org.yml"]]
       TimeoutInMinutes: 5
   CmsAlarmsStack:
     Type: "AWS::CloudFormation::Stack"

--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -447,6 +447,9 @@ Resources:
         - Fn::ImportValue: !Sub "${InfrastructureNotificationsStackName}-CloudFormationNotificationSnsTopic"
       Parameters:
         VPC: !Ref VPC
+        VPCSubnet1: !Ref VPCSubnet1
+        VPCSubnet2: !Ref VPCSubnet2
+        VPCSubnet3: !Ref VPCSubnet3
         PlatformALBDNSName: !Ref PlatformALBDNSName
         PlatformALBFullName: !Ref PlatformALBFullName
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID


### PR DESCRIPTION
Moves CMS into its own template, rather than using the shared web-app template (necessary for IAM role changes as well).

Creates the CMS memcached cluster along side the other CMS app resources. Currently the cluster is created, but dormant, in production.