### PR TITLE
Remove ECS service role

### DIFF
--- a/stacks/container-apps/augury.prx.org.yml
+++ b/stacks/container-apps/augury.prx.org.yml
@@ -28,8 +28,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -279,7 +277,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !Ref AppName

--- a/stacks/container-apps/castle.prx.org.yml
+++ b/stacks/container-apps/castle.prx.org.yml
@@ -38,8 +38,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   RedisSecurityGroupSourceSecurityGroupId:
     Type: AWS::EC2::SecurityGroup::Id
@@ -168,7 +166,6 @@ Resources:
         - ContainerName: !FindInMap [Shared, Container, name]
           ContainerPort: 4000
           TargetGroupArn: !Ref CastleALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -26,8 +26,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsWarnMessagesSnsTopicArn:
     Type: String
@@ -250,7 +248,6 @@ Resources:
         - ContainerName: cms-web
           ContainerPort: 3000
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: cms

--- a/stacks/container-apps/dovetail.prx.org.yml
+++ b/stacks/container-apps/dovetail.prx.org.yml
@@ -18,8 +18,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsWarnMessagesSnsTopicArn:
     Type: String
@@ -405,7 +403,6 @@ Resources:
       PlacementStrategies:
         - Type: spread
           Field: instanceId
-      Role: !Ref ECSServiceIAMRole
       ServiceName: !Sub ${AWS::StackName}-DovetailApp
       Tags:
         - Key: Project
@@ -498,7 +495,6 @@ Resources:
         - ContainerName: "dovetail-router"
           ContainerPort: 4000
           TargetGroupArn: !Ref DovetailRouterALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: Dovetail

--- a/stacks/container-apps/exchange.prx.org.yml
+++ b/stacks/container-apps/exchange.prx.org.yml
@@ -34,8 +34,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   SharedMemcachedEndpointAddress:
     Type: String
@@ -291,7 +289,6 @@ Resources:
         - ContainerName: exchange-web
           ContainerPort: 3000
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: exchange

--- a/stacks/container-apps/feeder.prx.org.yml
+++ b/stacks/container-apps/feeder.prx.org.yml
@@ -23,8 +23,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsWarnMessagesSnsTopicArn:
     Type: String
@@ -416,7 +414,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !Ref AppName

--- a/stacks/container-apps/grove.prx.org.yml
+++ b/stacks/container-apps/grove.prx.org.yml
@@ -28,8 +28,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -240,7 +238,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !Ref AppName

--- a/stacks/container-apps/id.prx.org.yml
+++ b/stacks/container-apps/id.prx.org.yml
@@ -26,8 +26,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -243,7 +241,6 @@ Resources:
         - ContainerName: id-web
           ContainerPort: 3000
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: id

--- a/stacks/container-apps/iframely.prx.org.yml
+++ b/stacks/container-apps/iframely.prx.org.yml
@@ -25,8 +25,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -223,7 +221,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: 8061
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !Ref AppName

--- a/stacks/container-apps/networks.prx.org.yml
+++ b/stacks/container-apps/networks.prx.org.yml
@@ -32,8 +32,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   SharedMemcachedEndpointAddress:
     Type: String
@@ -295,7 +293,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !Ref AppName

--- a/stacks/container-apps/play.prx.org.yml
+++ b/stacks/container-apps/play.prx.org.yml
@@ -29,8 +29,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -148,7 +146,6 @@ Resources:
         - ContainerName: !FindInMap [Shared, Container, name]
           ContainerPort: 4300
           TargetGroupArn: !Ref PlayALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]

--- a/stacks/container-apps/publish.prx.org.yml
+++ b/stacks/container-apps/publish.prx.org.yml
@@ -35,8 +35,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -163,7 +161,6 @@ Resources:
         - ContainerName: !FindInMap [Shared, Container, name]
           ContainerPort: 4200
           TargetGroupArn: !Ref PublishALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !FindInMap [Shared, Project, name]

--- a/stacks/container-apps/remix.yml
+++ b/stacks/container-apps/remix.yml
@@ -28,8 +28,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -98,7 +96,6 @@ Resources:
       HealthyThresholdCount: 3
       UnhealthyThresholdCount: 3
       HealthCheckPath: !Ref HealthCheckPath
-      Name: !Sub ${AppName}-${EnvironmentTypeAbbreviation}
       Port: 80
       Protocol: HTTP
       TargetGroupAttributes:
@@ -279,7 +276,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !Ref AppName

--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -60,8 +60,6 @@ Parameters:
     Type: String
   ECSServiceAutoscaleIAMRoleArn:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # App ENV ####################################################################
   EcrRegion:
     Type: String
@@ -150,7 +148,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         UploadSigningEndpointUrl: !Ref UploadSigningEndpointUrl
         UploadSigningAccessKeyId: !Ref UploadSigningAccessKeyId
         SharedMemcachedEndpointAddress: !Ref SharedMemcachedEndpointAddress
@@ -192,7 +189,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         UploadSigningEndpointUrl: !Ref UploadSigningEndpointUrl
         UploadSigningAccessKeyId: !Ref UploadSigningAccessKeyId
         SharedMemcachedEndpointAddress: !Ref SharedMemcachedEndpointAddress
@@ -275,7 +271,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
         EnvironmentType: !Ref EnvironmentType
@@ -363,7 +358,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
         EnvironmentType: !Ref EnvironmentType
@@ -400,7 +394,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         SharedMemcachedEndpointAddress: !Ref SharedMemcachedEndpointAddress
         OpsWarnMessagesSnsTopicArn:
           Fn::ImportValue: !Sub ${InfrastructureNotificationsStackName}-OpsWarnMessagesSnsTopicArn
@@ -441,7 +434,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
         EnvironmentType: !Ref EnvironmentType
@@ -479,7 +471,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
         EnvironmentType: !Ref EnvironmentType
@@ -537,7 +528,6 @@ Resources:
         PlatformALBHTTPListenerArn: !Ref PlatformALBHTTPListenerArn
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
         EnvironmentType: !Ref EnvironmentType
@@ -573,7 +563,6 @@ Resources:
         PlatformALBCanonicalHostedZoneID: !Ref PlatformALBCanonicalHostedZoneID
         PlatformALBHTTPSListenerArn: !Ref PlatformALBHTTPSListenerArn
         ECSCluster: !Ref ECSCluster
-        ECSServiceIAMRole: !Ref ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub "${InfrastructureNotificationsStackName}-OpsErrorMessagesSnsTopicArn"
         EnvironmentType: !Ref EnvironmentType

--- a/stacks/container-apps/sphinx-nlb.yml
+++ b/stacks/container-apps/sphinx-nlb.yml
@@ -471,7 +471,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: 9312
           TargetGroupArn: !Ref NLBSphinxTargetGroup
-      # Role: !Ref ECSServiceIAMRole
       NetworkConfiguration:
         AwsvpcConfiguration:
           SecurityGroups:

--- a/stacks/container-apps/web-application.yml
+++ b/stacks/container-apps/web-application.yml
@@ -28,8 +28,6 @@ Parameters:
   # ECS Cluster ################################################################
   ECSCluster:
     Type: String
-  ECSServiceIAMRole:
-    Type: String
   # Misc #######################################################################
   OpsErrorMessagesSnsTopicArn:
     Type: String
@@ -279,7 +277,6 @@ Resources:
         - ContainerName: !Sub ${AppName}-web
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ALBTargetGroup
-      Role: !Ref ECSServiceIAMRole
       Tags:
         - Key: Project
           Value: !Ref AppName

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -157,6 +157,34 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
+  ECSServiceIAMRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+      Tags:
+        - Key: Project
+          Value: platform.prx.org
+        - Key: "prx:cloudformation:stack-name"
+          Value: !Ref AWS::StackName
+        - Key: "prx:cloudformation:stack-id"
+          Value: !Ref AWS::StackId
   ECSServiceAutoscaleIAMRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -157,34 +157,6 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
-  ECSServiceIAMRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - ecs.amazonaws.com
-            Action:
-              - "sts:AssumeRole"
-          - Effect: Allow
-            Principal:
-              Service:
-                - ec2.amazonaws.com
-            Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
-      Tags:
-        - Key: Project
-          Value: platform.prx.org
-        - Key: "prx:cloudformation:stack-name"
-          Value: !Ref AWS::StackName
-        - Key: "prx:cloudformation:stack-id"
-          Value: !Ref AWS::StackId
   ECSServiceAutoscaleIAMRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -926,11 +898,3 @@ Outputs:
     Description: >
       The ARN of the IAM role used for service auto scaling
     Value: !GetAtt ECSServiceAutoscaleIAMRole.Arn
-  ECSServiceIAMRole:
-    Description: >
-      The resource name of the IAM role used by ECS services
-    Value: !Ref ECSServiceIAMRole
-  ECSServiceIAMRoleArn:
-    Description: >
-      The Arn of the IAM role used by ECS services
-    Value: !GetAtt ECSServiceIAMRole.Arn

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -290,7 +290,6 @@ Resources:
         ECSClusterArn: !GetAtt ECSClusterStack.Outputs.ECSClusterArn
         ECSInstanceIAMRoleArn: !GetAtt ECSClusterStack.Outputs.ECSInstanceIAMRoleArn
         ECSServiceAutoscaleIAMRoleArn: !GetAtt ECSClusterStack.Outputs.ECSServiceAutoscaleIAMRoleArn
-        ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
         EcrRegion: !Ref EcrRegion
         SharedMemcachedEndpointAddress: !GetAtt SharedMemcachedStack.Outputs.CacheEndpointAddress
         SharedMemcachedEndpointPort: !GetAtt SharedMemcachedStack.Outputs.CacheEndpointPort
@@ -468,7 +467,6 @@ Resources:
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Publish, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
-        ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
         UploadSigningUserName: !GetAtt ServerlessRootStack.Outputs.UploadSigningUserName
         UploadSigningEndpointUrl: !GetAtt ServerlessRootStack.Outputs.UploadSigningEndpointUrl
         UploadSigningAccessKeyId: !GetAtt ServerlessRootStack.Outputs.UploadSigningAccessKeyId
@@ -508,7 +506,6 @@ Resources:
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Castle, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
-        ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
         RedisSecurityGroupSourceSecurityGroupId: !GetAtt ECSClusterStack.Outputs.ECSInstanceOutboundSecurityGroupId
         OpsWarnMessagesSnsTopicArn:
           Fn::ImportValue: !Sub ${NotificationsStackName}-OpsWarnMessagesSnsTopicArn
@@ -545,7 +542,6 @@ Resources:
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Play, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
-        ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub ${NotificationsStackName}-OpsErrorMessagesSnsTopicArn
         EnvironmentType: !Ref EnvironmentType
@@ -576,7 +572,6 @@ Resources:
         VPCSubnet3: !GetAtt VPCStack.Outputs.Subnet3
         VPCCertificateArn: !GetAtt CertificateStack.Outputs.WildcardCertificateArn
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
-        ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
         OpsWarnMessagesSnsTopicArn:
           Fn::ImportValue: !Sub ${NotificationsStackName}-OpsWarnMessagesSnsTopicArn
         OpsErrorMessagesSnsTopicArn:
@@ -620,7 +615,6 @@ Resources:
         VPCSubnet3: !GetAtt VPCStack.Outputs.Subnet3
         VPCCertificateArn: !GetAtt CertificateStack.Outputs.WildcardCertificateArn
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
-        ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
         DynamodbKinesisStream: !Join ["", ["/prx/", !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation], "/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM"]]
         OpsWarnMessagesSnsTopicArn:
           Fn::ImportValue: !Sub ${NotificationsStackName}-OpsWarnMessagesSnsTopicArn
@@ -658,7 +652,6 @@ Resources:
         PlatformALBHTTPSListenerArn: !GetAtt LoadBalancersStack.Outputs.PlatformALBHTTPSListenerArn
         PlatformALBListenerPriorityPrefix: !FindInMap [ALBListenerRulePriorityMap, Id, prefix]
         ECSCluster: !GetAtt ECSClusterStack.Outputs.ECSCluster
-        ECSServiceIAMRole: !GetAtt ECSClusterStack.Outputs.ECSServiceIAMRole
         OpsErrorMessagesSnsTopicArn:
           Fn::ImportValue: !Sub ${NotificationsStackName}-OpsErrorMessagesSnsTopicArn
         EnvironmentType: !Ref EnvironmentType


### PR DESCRIPTION
This removes all traces of the ECS service role, which has been replaced by an ECS service-link role that AWS manages, and was serving no real purpose. 