### PR TITLE
Add Play proxy Lambda function to legacy stack

### DIFF
--- a/stacks/container-apps/play.prx.org.yml
+++ b/stacks/container-apps/play.prx.org.yml
@@ -9,6 +9,7 @@ Mappings:
       name: play-express
 Conditions:
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
+  CreateProductionResources: !Equals [!Ref EnvironmentType, Staging]
 Parameters:
   # VPC ########################################################################
   VPC:
@@ -201,6 +202,159 @@ Resources:
           Value: !Ref PlatformALBFullName
         - Name: TargetGroup
           Value: !GetAtt PlayALBTargetGroup.TargetGroupFullName
+
+  ProxyPathListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: CreateProductionResources
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref ProxyTargetGroup
+          Type: forward
+      Conditions:
+        - Field: host-header
+          Values:
+            - play.*
+        - Field: path-pattern
+          Values:
+            - /proxy*
+      ListenerArn: !Ref AlbHttpsListenerArn
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "20"]]
+
+  ProxyTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn:
+      - ProxyFunctionAlbPermission
+    Properties:
+      HealthCheckEnabled: false
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Play }
+      Targets:
+        - Id: !GetAtt ProxyFunction.Arn
+      TargetType: lambda
+
+  ProxyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: !Sub ${EnvironmentType} Play feed proxy
+      Environment:
+        Variables:
+          MAX_HTTP_REDIRECTS: 4
+      Handler: index.handler
+      InlineCode: |
+        const http = require("http");
+        const https = require("https");
+
+        const PROXY_UA = "play.prx.org feed proxy";
+        const ACCEPTED_TYPES = [
+          "application/rss+xml",
+          "application/rdf+xml;q=0.8",
+          "application/atom+xml;q=0.6",
+          "application/xml;q=0.4",
+          "text/xml;q=0.4",
+        ];
+
+        async function request(url, redirectCount, redirectUrl) {
+          return new Promise((resolve, reject) => {
+            const q = new URL(redirectUrl || url);
+
+            // Setup request options
+            const options = {
+              host: q.host,
+              port: q.port,
+              path: `${q.pathname || ""}${q.search || ""}`,
+              method: "GET",
+              headers: {
+                Accept: ACCEPTED_TYPES.join(","),
+                "User-Agent": PROXY_UA,
+              },
+            };
+
+            const h = q.protocol === "https:" ? https : http;
+            const req = h.request(options, (res) => {
+              res.setEncoding("utf8");
+
+              let resData = "";
+              res.on("data", (chunk) => {
+                resData += chunk;
+                return resData;
+              });
+
+              res.on("end", async () => {
+                if (
+                  (res.statusCode >= 200 && res.statusCode < 300) ||
+                  res.statusCode === 404 ||
+                  res.statusCode === 410
+                ) {
+                  resolve(resData);
+                } else if (res.statusCode === 301 || res.statusCode === 302) {
+                  try {
+                    if (redirectCount > +process.env.MAX_HTTP_REDIRECTS) {
+                      reject(new Error("Too many redirects"));
+                      return;
+                    }
+
+                    const count = redirectCount ? redirectCount + 1 : 1;
+                    await httpRequest(url, count, res.headers.location);
+                    resolve();
+                  } catch (error) {
+                    reject(error);
+                  }
+                } else {
+                  const error = new Error(`Error ${res.statusCode}: ${resData}`);
+                  reject(error);
+                }
+              });
+            });
+
+            req.on("error", (error) => reject(error));
+
+            req.write("");
+            req.end();
+          });
+        }
+
+        exports.handler = async (event) => {
+          const feedUrl = event.queryStringParameters.url;
+
+          res = await request(feedUrl);
+
+          return {
+            statusCode: 200,
+            statusDescription: "200 OK",
+            isBase64Encoded: false,
+            headers: {
+              "Content-Type": "application/rss+xml",
+              "Cache-Control": "public, max-age=90",
+            },
+            body: res,
+          };
+        };
+      MemorySize: 256
+      Runtime: nodejs12.x
+      Tags:
+        prx:meta:tagging-version: "2021-04-07"
+        prx:cloudformation:stack-name: !Ref AWS::StackName
+        prx:cloudformation:stack-id: !Ref AWS::StackId
+        prx:ops:environment: !Ref EnvironmentType
+        prx:dev:application: Play
+      Timeout: 6
+  ProxyFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${ProxyFunction}
+      RetentionInDays: 14
+  ProxyFunctionAlbPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref ProxyFunction
+      Principal: elasticloadbalancing.amazonaws.com
+
 Outputs:
   HostedZoneDNSName:
     Description: Convenience domain name for the ALB in a hosted zone

--- a/stacks/container-apps/play.prx.org.yml
+++ b/stacks/container-apps/play.prx.org.yml
@@ -1,5 +1,6 @@
 # stacks/play.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
 Description: play.prx.org application running in Docker
 Mappings:
   Shared:

--- a/stacks/container-apps/play.prx.org.yml
+++ b/stacks/container-apps/play.prx.org.yml
@@ -9,7 +9,7 @@ Mappings:
       name: play-express
 Conditions:
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
-  CreateProductionResources: !Equals [!Ref EnvironmentType, Staging]
+  CreateStagingResources: !Equals [!Ref EnvironmentType, Staging]
 Parameters:
   # VPC ########################################################################
   VPC:
@@ -205,7 +205,7 @@ Resources:
 
   ProxyPathListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Condition: CreateProductionResources
+    Condition: CreateStagingResources
     Properties:
       Actions:
         - TargetGroupArn: !Ref ProxyTargetGroup

--- a/stacks/container-apps/play.prx.org.yml
+++ b/stacks/container-apps/play.prx.org.yml
@@ -95,7 +95,7 @@ Resources:
           Values:
             - play.*
       ListenerArn: !Ref PlatformALBHTTPSListenerArn
-      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "00"]]
+      Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "30"]]
   # ECS Service
   PlayTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"

--- a/stacks/container-apps/play.prx.org.yml
+++ b/stacks/container-apps/play.prx.org.yml
@@ -218,7 +218,7 @@ Resources:
         - Field: path-pattern
           Values:
             - /proxy*
-      ListenerArn: !Ref AlbHttpsListenerArn
+      ListenerArn: !Ref PlatformALBHTTPSListenerArn
       Priority: !Join ["", [!Ref PlatformALBListenerPriorityPrefix, "20"]]
 
   ProxyTargetGroup:


### PR DESCRIPTION
I have done very rudimentary testing on this, but it's fairly straight forward.

This only creates the `/proxy*` listener rule in staging, so it can safely be deployed to prod without switching to the new proxy.

`https://play.dualstack.infrast-alb-zh49czohymrr-1878189151.us-east-1.elb.amazonaws.com.stag.prx.tech/proxy2?url=http://feed.songexploder.net/SongExploder` is an example of the proxy running in the new cluster, **not** behind CloudFront like it will be in reality.