### PR TITLE
Memcached SwapUsage alarms

### DIFF
--- a/stacks/shared-memcached.yml
+++ b/stacks/shared-memcached.yml
@@ -96,37 +96,13 @@ Resources:
     Condition: CreateProductionResources
     Properties:
       ActionsEnabled: true
-      AlarmName: "[Platform][Memcached][Swap] Swap exceeded 50 MB"
-      AlarmActions:
-        - !Ref OpsWarnMessagesSnsTopicArn
-      InsufficientDataActions:
-        - !Ref OpsWarnMessagesSnsTopicArn
-      OKActions:
-        - !Ref OpsWarnMessagesSnsTopicArn
-      AlarmDescription: Memcached swap usage exceeded 50 MB
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: CacheClusterId
-          Value: !Ref SharedMemcachedCluster
-      EvaluationPeriods: 1
-      MetricName: SwapUsage
-      Namespace: AWS/ElastiCache
-      Period: 60
-      Statistic: Maximum
-      Threshold: 50000000
-      TreatMissingData: notBreaching
-  SharedMemcachedHighSwapUsageAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: CreateProductionResources
-    Properties:
-      ActionsEnabled: true
       AlarmName: "[Platform][Memcached][Swap] Swap exceeded 32 MB"
       AlarmActions:
-        - !Ref OpsErrorMessagesSnsTopicArn
+        - !Ref OpsWarnMessagesSnsTopicArn
       InsufficientDataActions:
-        - !Ref OpsErrorMessagesSnsTopicArn
+        - !Ref OpsWarnMessagesSnsTopicArn
       OKActions:
-        - !Ref OpsErrorMessagesSnsTopicArn
+        - !Ref OpsWarnMessagesSnsTopicArn
       AlarmDescription: Memcached swap usage exceeded 32 MB
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -138,6 +114,30 @@ Resources:
       Period: 60
       Statistic: Maximum
       Threshold: 32000000
+      TreatMissingData: notBreaching
+  SharedMemcachedHighSwapUsageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProductionResources
+    Properties:
+      ActionsEnabled: true
+      AlarmName: "[Platform][Memcached][Swap] Swap exceeded 50 MB"
+      AlarmActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      InsufficientDataActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      OKActions:
+        - !Ref OpsErrorMessagesSnsTopicArn
+      AlarmDescription: Memcached swap usage exceeded 50 MB
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: CacheClusterId
+          Value: !Ref SharedMemcachedCluster
+      EvaluationPeriods: 1
+      MetricName: SwapUsage
+      Namespace: AWS/ElastiCache
+      Period: 60
+      Statistic: Maximum
+      Threshold: 50000000
       TreatMissingData: notBreaching
 
 Outputs:

--- a/stacks/shared-memcached.yml
+++ b/stacks/shared-memcached.yml
@@ -96,14 +96,14 @@ Resources:
     Condition: CreateProductionResources
     Properties:
       ActionsEnabled: true
-      AlarmName: "[Platform][Memcached][Swap] Swap exceeded 8 MB"
+      AlarmName: "[Platform][Memcached][Swap] Swap exceeded 50 MB"
       AlarmActions:
         - !Ref OpsWarnMessagesSnsTopicArn
       InsufficientDataActions:
         - !Ref OpsWarnMessagesSnsTopicArn
       OKActions:
         - !Ref OpsWarnMessagesSnsTopicArn
-      AlarmDescription: Memcached swap usage exceeded 8 MB
+      AlarmDescription: Memcached swap usage exceeded 50 MB
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: CacheClusterId
@@ -113,7 +113,7 @@ Resources:
       Namespace: AWS/ElastiCache
       Period: 60
       Statistic: Maximum
-      Threshold: 8000000
+      Threshold: 50000000
       TreatMissingData: notBreaching
   SharedMemcachedHighSwapUsageAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
Per [the docs](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheMetrics.WhichShouldIMonitor.html#metrics-swap-usage) on `SwapUsage` ...

> This metric should not exceed 50 MB. If it does, we recommend that you increase the ConnectionOverhead parameter value.

We don't have a ton of CloudWatch historical data on memcached, but i do see that metric tends to garbage-collect and drop suddenly.  And since we won't take any action until this alarm hits 50 ... changed the "warn" to 32, and "error" to 50.