### PR TITLE
Set up cors on ad-upload buckets

### DIFF
--- a/storage/multi-region-replication/ad-files.yml
+++ b/storage/multi-region-replication/ad-files.yml
@@ -113,13 +113,13 @@ Resources:
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:
-            - '*'
+              - "*"
             AllowedMethods:
               - GET
               - HEAD
               - POST
             AllowedOrigins:
-              - '*'
+              - "*"
   AdFilesBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Condition: HasCloudFrontOai

--- a/storage/multi-region-replication/ad-files.yml
+++ b/storage/multi-region-replication/ad-files.yml
@@ -120,8 +120,6 @@ Resources:
               - POST
             AllowedOrigins:
               - '*'
-            ExposedHeaders:
-              - Date
   AdFilesBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Condition: HasCloudFrontOai

--- a/storage/multi-region-replication/ad-files.yml
+++ b/storage/multi-region-replication/ad-files.yml
@@ -110,6 +110,18 @@ Resources:
         - !Ref AWS::NoValue
       VersioningConfiguration:
         Status: Enabled # Required for replication
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders:
+            - '*'
+            AllowedMethods:
+              - GET
+              - HEAD
+              - POST
+            AllowedOrigins:
+              - '*'
+            ExposedHeaders:
+              - Date
   AdFilesBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Condition: HasCloudFrontOai


### PR DESCRIPTION
Per https://github.com/PRX/augury.prx.org/issues/545

This sets up some CORS rules for the ad files upload buckets. Opaque uploads alread work via xhr + signed requests, this just allows some response data to come back to the uploader javascript thread.