### PR TITLE
Analytics lambdas tune-up

### DIFF
--- a/stacks/serverless/analytics-ingest-filters.yml
+++ b/stacks/serverless/analytics-ingest-filters.yml
@@ -147,15 +147,6 @@ Resources:
         - MetricName: !Sub "analytics_dynamodb_retries_${EnvironmentTypeAbbreviation}"
           MetricNamespace: LogMetrics
           MetricValue: "1"
-  AnalyticsDynamodbMissingMetric:
-    Type: "AWS::Logs::MetricFilter"
-    Properties:
-      FilterPattern: '{ $.ddb = "missing" }'
-      LogGroupName: !Ref AnalyticsDynamodbLogGroup
-      MetricTransformations:
-        - MetricName: !Sub "analytics_dynamodb_missing_${EnvironmentTypeAbbreviation}"
-          MetricNamespace: LogMetrics
-          MetricValue: "1"
   AnalyticsDynamodbErrorsMetric:
     Type: "AWS::Logs::MetricFilter"
     Properties:
@@ -165,26 +156,6 @@ Resources:
         - MetricName: !Sub "analytics_dynamodb_errors_${EnvironmentTypeAbbreviation}"
           MetricNamespace: LogMetrics
           MetricValue: "1"
-  AnalyticsDynamodbMissingAlarm:
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      ActionsEnabled: true
-      AlarmName: !Sub "[Analytics][DynamoDB][Missing] ${EnvironmentType}"
-      AlarmActions:
-        - !If [IsProduction, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      InsufficientDataActions:
-        - !If [IsProduction, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      OKActions:
-        - !If [IsProduction, !Ref OpsErrorMessagesSnsTopicArn, !Ref OpsWarnMessagesSnsTopicArn]
-      AlarmDescription: Missing DDB redirect-data on the analytics dynamodb function
-      ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 5
-      MetricName: !Sub "analytics_dynamodb_missing_${EnvironmentTypeAbbreviation}"
-      Namespace: LogMetrics
-      Period: 60
-      Statistic: Sum
-      Threshold: 100
-      TreatMissingData: notBreaching
   AnalyticsDynamodbErrorsAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:

--- a/stacks/serverless/analytics-ingest-lambdas.yml
+++ b/stacks/serverless/analytics-ingest-lambdas.yml
@@ -208,7 +208,7 @@ Resources:
   AnalyticsBigqueryKinesisTrigger:
     Type: "AWS::Lambda::EventSourceMapping"
     Properties:
-      BatchSize: 25
+      BatchSize: 100
       Enabled: true
       EventSourceArn: !Ref MetricsKinesisStream
       FunctionName: !Ref AnalyticsBigqueryLambdaFunction

--- a/stacks/serverless/analytics-ingest-lambdas.yml
+++ b/stacks/serverless/analytics-ingest-lambdas.yml
@@ -61,19 +61,6 @@ Resources:
               - "sts:AssumeRole"
       Path: "/"
       Policies:
-        # TODO: no longer needed after CW log subscription
-        - PolicyName: KinesisWritePolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "kinesis:DescribeStream"
-                  - "kinesis:PutRecord"
-                  - "kinesis:PutRecords"
-                Resource:
-                  - !Ref MetricsKinesisStream
-                  - !Ref DynamodbKinesisStream
         - PolicyName: DynamodbAssumeRolePolicy
           PolicyDocument:
             Version: "2012-10-17"
@@ -145,9 +132,6 @@ Resources:
           DDB_TABLE: !Ref DynamodbTableName
           DDB_ROLE: !Ref DynamodbAccessRole
           DDB_TTL: !Ref DynamodbTTL
-          # TODO: no longer needed after CW log subscription
-          KINESIS_STREAM: !Ref MetricsKinesisStream
-          KINESIS_RETRY_STREAM: !Ref DynamodbKinesisStream
       Handler: index.handler
       MemorySize: 512
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn

--- a/stacks/serverless/analytics-ingest-lambdas.yml
+++ b/stacks/serverless/analytics-ingest-lambdas.yml
@@ -106,7 +106,7 @@ Resources:
           PARAMSTORE_PREFIX: !Sub "/prx/${EnvironmentTypeAbbreviation}/analytics-bigquery"
           BQ_PROJECT_ID: "prx-metrics"
       Handler: index.handler
-      MemorySize: 384
+      MemorySize: 512
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
       Runtime: nodejs12.x
       Tags:
@@ -157,7 +157,7 @@ Resources:
         Variables:
           PINGBACKS: "true"
       Handler: index.handler
-      MemorySize: 1600
+      MemorySize: 2048
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
       Runtime: nodejs12.x
       Tags:
@@ -169,7 +169,7 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
-      Timeout: 30
+      Timeout: 60
   AnalyticsRedisLambdaFunction:
     Type: "AWS::Lambda::Function"
     Properties:
@@ -184,7 +184,7 @@ Resources:
           REDIS_IMPRESSIONS_HOST: !Ref RedisImpressionsHost
           REDIS_IMPRESSIONS_TTL: "90000"
       Handler: index.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt AnalyticsLambdaExecutionIAMRole.Arn
       Runtime: nodejs12.x
       Tags:

--- a/stacks/serverless/analytics-ingest-lambdas.yml
+++ b/stacks/serverless/analytics-ingest-lambdas.yml
@@ -208,7 +208,7 @@ Resources:
   AnalyticsBigqueryKinesisTrigger:
     Type: "AWS::Lambda::EventSourceMapping"
     Properties:
-      BatchSize: 400
+      BatchSize: 25
       Enabled: true
       EventSourceArn: !Ref MetricsKinesisStream
       FunctionName: !Ref AnalyticsBigqueryLambdaFunction
@@ -224,7 +224,7 @@ Resources:
   AnalyticsPingbacksKinesisTrigger:
     Type: "AWS::Lambda::EventSourceMapping"
     Properties:
-      BatchSize: 50
+      BatchSize: 25
       Enabled: true
       EventSourceArn: !Ref MetricsKinesisStream
       FunctionName: !Ref AnalyticsPingbacksLambdaFunction
@@ -232,7 +232,7 @@ Resources:
   AnalyticsRedisKinesisTrigger:
     Type: "AWS::Lambda::EventSourceMapping"
     Properties:
-      BatchSize: 400
+      BatchSize: 100
       Enabled: true
       EventSourceArn: !Ref MetricsKinesisStream
       FunctionName: !Ref AnalyticsRedisLambdaFunction


### PR DESCRIPTION
Now that the `analytics-dynamodb-lambda` output is a CloudWatch Log Subscription, it's much more dense (a bunch of gzipped log lines into single kinesis records).

Consequently, we need to decrease batch sizes and increase memory to deal with the increased downloads/impressions-per-batch.