### PR TITLE
Make sure alarm/metrics namespaces don't collide

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -364,23 +364,6 @@ Resources:
         - MetricName: !Sub InventoryUpdateJobElapsed${EnvironmentType}
           MetricNamespace: PRX/Augury
           MetricValue: $.elapsed
-  AuguryActualsAreBehindAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> NOT FETCHING IMPRESSIONS
-      AlarmDescription: !Sub >-
-        ${EnvironmentType} Augury's worker task has not logged any impression
-        fetching actvitiy for an unusually long time. This could mean incorrect
-        ads are being served.
-      ComparisonOperator: LessThanThreshold
-      EvaluationPeriods: 3
-      MetricName: !GetAtt Constants.ActualsIngestJobInvocationCountMetricName
-      Namespace: PRX/Augury
-      Period: 300
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: breaching
-
   ForecastTaskLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -48,7 +48,7 @@ Resources:
     Type: Custom::Echo
     Properties:
       ServiceToken: !Ref EchoServiceToken
-      ActualsIngestJobInvocationCountMetricName: !Sub ActualsIngestJobInvocationCount${EnvironmentType}
+      ActualsIngestJobInvocationCountMetricName: !Sub ActualsIngestJobInvocationCountNewCluster${EnvironmentType}
 
   HostHeaderListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -364,6 +364,23 @@ Resources:
         - MetricName: !Sub InventoryUpdateJobElapsed${EnvironmentType}
           MetricNamespace: PRX/Augury
           MetricValue: $.elapsed
+  AuguryActualsAreBehindAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> NOT FETCHING IMPRESSIONS
+      AlarmDescription: !Sub >-
+        ${EnvironmentType} Augury's worker task has not logged any impression
+        fetching actvitiy for an unusually long time. This could mean incorrect
+        ads are being served.
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 3
+      MetricName: !GetAtt Constants.ActualsIngestJobInvocationCountMetricName
+      Namespace: PRX/Augury
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: breaching
+
   ForecastTaskLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/stacks/container-apps/augury-alarms.yml
+++ b/stacks/container-apps/augury-alarms.yml
@@ -17,14 +17,14 @@ Resources:
       FilterPattern: '{ $.msg = "*Performed ImpressionsFetchJob*" }'
       LogGroupName: !Ref AuguryWorkerLogGroupName
       MetricTransformations:
-        - MetricName: !Sub "ActualsIngestJobInvocationCountOldCluster${EnvironmentType}"
+        - MetricName: !Sub "ActualsIngestJobInvocationCount${EnvironmentType}"
           MetricNamespace: PRX/Augury
           MetricValue: "1"
   AuguryActualsAreBehindAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub "[Augury][Worker][ActiveJob] ${EnvironmentType} Augury actuals are behind (OldCluster)"
+      AlarmName: !Sub "[Augury][Worker][ActiveJob] ${EnvironmentType} Augury actuals are behind"
       AlarmActions:
         - !Ref OpsErrorMessagesSnsTopicArn
       InsufficientDataActions:
@@ -34,7 +34,7 @@ Resources:
       AlarmDescription: Augury actuals are behind
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 3
-      MetricName: !Sub "ActualsIngestJobInvocationCountOldCluster${EnvironmentType}"
+      MetricName: !Sub "ActualsIngestJobInvocationCount${EnvironmentType}"
       Namespace: PRX/Augury
       Period: 300
       Statistic: Sum

--- a/stacks/container-apps/augury-alarms.yml
+++ b/stacks/container-apps/augury-alarms.yml
@@ -17,14 +17,14 @@ Resources:
       FilterPattern: '{ $.msg = "*Performed ImpressionsFetchJob*" }'
       LogGroupName: !Ref AuguryWorkerLogGroupName
       MetricTransformations:
-        - MetricName: !Sub "ActualsIngestJobInvocationCount${EnvironmentType}"
+        - MetricName: !Sub "ActualsIngestJobInvocationCountOldCluster${EnvironmentType}"
           MetricNamespace: PRX/Augury
           MetricValue: "1"
   AuguryActualsAreBehindAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       ActionsEnabled: true
-      AlarmName: !Sub "[Augury][Worker][ActiveJob] ${EnvironmentType} Augury actuals are behind"
+      AlarmName: !Sub "[Augury][Worker][ActiveJob] ${EnvironmentType} Augury actuals are behind (OldCluster)"
       AlarmActions:
         - !Ref OpsErrorMessagesSnsTopicArn
       InsufficientDataActions:
@@ -34,7 +34,7 @@ Resources:
       AlarmDescription: Augury actuals are behind
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 3
-      MetricName: !Sub "ActualsIngestJobInvocationCount${EnvironmentType}"
+      MetricName: !Sub "ActualsIngestJobInvocationCountOldCluster${EnvironmentType}"
       Namespace: PRX/Augury
       Period: 300
       Statistic: Sum


### PR DESCRIPTION
Took another pass related to https://github.com/PRX/augury.prx.org/issues/527 on clearing up collisions in the metrics / filters namespaces.