### PR TITLE
Add Redis connectivity check to ASG cfn-init

### DIFF
--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -50,6 +50,8 @@ Parameters:
     Type: String
   SecretsInstanceAccessPolicyArn:
     Type: String
+  DovetailRedisHostname:
+    Type: String
 Mappings:
   EnvironmentTypeMap:
     Testing:
@@ -467,6 +469,20 @@ Resources:
                   JSON="[{\"InstanceId\": \"${AWSINSTANCEID}\",\"CpuCredits\": \"unlimited\"}]"
                   aws --region=$AWSREGION ec2 modify-instance-credit-specification --instance-credit-specification "${JSON}"
                 fi
+            05_check_redis_connectivity:
+              # Resolve the Dovetail Redis host and check all IPs returned for
+              # connectivity. If any can't connect, the instance is marked as
+              # unhealthy
+              command: !Sub |-
+                #!/bin/bash
+                for IP in $(getent hosts ${DovetailRedisHostname} | awk '{ print $1 }')
+                do
+                  if ! timeout 0.1 bash -c "cat < /dev/null > /dev/tcp/$IP/6379"; then
+                    echo "Unhealthy; Failed to connect to Redis: $IP"
+                    INSTANCE_ID=`ec2-metadata -i`
+                    aws autoscaling set-instance-health --instance-id $INSTANCE_ID --health-status Unhealthy
+                  fi
+                done
           services:
             sysvinit:
               cfn-hup:

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -481,20 +481,20 @@ Resources:
                   JSON="[{\"InstanceId\": \"${AWSINSTANCEID}\",\"CpuCredits\": \"unlimited\"}]"
                   aws --region=$AWSREGION ec2 modify-instance-credit-specification --instance-credit-specification "${JSON}"
                 fi
-            05_check_redis_connectivity:
-              # Resolve the Dovetail Redis host and check all IPs returned for
-              # connectivity. If any can't connect, the instance is marked as
-              # unhealthy
-              command: !Sub |-
-                #!/bin/bash
-                for IP in $(getent hosts ${DovetailRedisHostname} | awk '{ print $1 }')
-                do
-                  if ! timeout 0.1 bash -c "cat < /dev/null > /dev/tcp/$IP/6379"; then
-                    echo "Unhealthy; Failed to connect to Redis: $IP"
-                    INSTANCE_ID=`ec2-metadata -i`
-                    aws autoscaling set-instance-health --instance-id $INSTANCE_ID --health-status Unhealthy
-                  fi
-                done
+            # 05_check_redis_connectivity:
+            #   # Resolve the Dovetail Redis host and check all IPs returned for
+            #   # connectivity. If any can't connect, the instance is marked as
+            #   # unhealthy
+            #   command: !Sub |-
+            #     #!/bin/bash
+            #     for IP in $(getent hosts ${DovetailRedisHostname} | awk '{ print $1 }')
+            #     do
+            #       if ! timeout 0.1 bash -c "cat < /dev/null > /dev/tcp/$IP/6379"; then
+            #         echo "Unhealthy; Failed to connect to Redis: $IP"
+            #         INSTANCE_ID=`ec2-metadata -i`
+            #         aws autoscaling set-instance-health --instance-id $INSTANCE_ID --health-status Unhealthy
+            #       fi
+            #     done
           services:
             sysvinit:
               cfn-hup:

--- a/stacks/ecs.yml
+++ b/stacks/ecs.yml
@@ -276,6 +276,18 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: "prx:cloudformation:stack-id"
           Value: !Ref AWS::StackId
+  ECSInstanceIAMRoleSetHealthPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: AutoscalingSetInstanceHealth
+      PolicyDocument:
+        Statement:
+          - Action: autoscaling:SetInstanceHealth
+            Effect: Allow
+            Resource: !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${ECSClusterASG}
+        Version: "2012-10-17"
+      Roles:
+        - !Ref ECSInstanceIAMRole
   ECSInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -41,6 +41,7 @@ Parameters:
     AllowedValues:
       - Primary
       - Secondary
+  DovetailRedisHostname: { Type: String }
   # Application Specific
   AuguryEcrImageTag: { Type: String }
   AugurySecretsVersion: { Type: String }
@@ -423,6 +424,7 @@ Resources:
           Fn::ImportValue: !Sub ${SecretsStackName}-SecretsInstanceDecryptPolicyArn
         SecretsInstanceAccessPolicyArn:
           Fn::ImportValue: !Sub ${SecretsStackName}-SecretsInstanceAccessPolicyArn
+        DovetailRedisHostname: !Ref DovetailRedisHostname
       Tags:
         - Key: prx:cloudformation:stack-name
           Value: !Ref AWS::StackName
@@ -867,6 +869,7 @@ Resources:
         LoadBalancerSecurityGroupId: !GetAtt SharedAlbStack.Outputs.LoadBalancerSecurityGroupId
         EcsLaunchEndpointsAccessSecurityGroupId: !GetAtt SharedVpcStack.Outputs.EcsLaunchEndpointsAccessSecurityGroupId
         KmsEndpointAccessSecurityGroupId: !GetAtt SharedVpcStack.Outputs.KmsEndpointAccessSecurityGroupId
+        DovetailRedisHostname: !Ref DovetailRedisHostname
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/shared-ecs-asg.yml
+++ b/stacks/shared-ecs-asg.yml
@@ -53,23 +53,6 @@ Resources:
         Version: "2012-10-17"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
-      Policies:
-        - PolicyName: DockerDiskUsagePolicy
-          PolicyDocument:
-            Statement:
-              - Action: cloudwatch:PutMetricData
-                Effect: Allow
-                Resource: "*"
-            Version: "2012-10-17"
-        - PolicyName: ModifyCreditSpecificationPolicy
-          PolicyDocument:
-            Statement:
-              - Action:
-                  - ec2:ModifyInstanceCreditSpecification
-                  - ec2:DescribeInstanceCreditSpecifications
-                Effect: Allow
-                Resource: "*"
-            Version: "2012-10-17"
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/shared-ecs-asg.yml
+++ b/stacks/shared-ecs-asg.yml
@@ -30,6 +30,7 @@ Parameters:
   LoadBalancerSecurityGroupId: { Type: "AWS::EC2::SecurityGroup::Id" }
   EcsLaunchEndpointsAccessSecurityGroupId: { Type: "AWS::EC2::SecurityGroup::Id" }
   KmsEndpointAccessSecurityGroupId: { Type: "AWS::EC2::SecurityGroup::Id" }
+  DovetailRedisHostname: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -268,6 +269,20 @@ Resources:
                 echo "Configuring ECS container agent"
                 echo "Launching instance into cluster: ${EcsClusterName}"
                 echo ECS_CLUSTER=${EcsClusterName} >> /etc/ecs/ecs.config
+            02_check_redis_connectivity:
+              # Resolve the Dovetail Redis host and check all IPs returned for
+              # connectivity. If any can't connect, the instance is marked as
+              # unhealthy
+              command: !Sub |-
+                #!/bin/bash
+                for IP in $(getent hosts ${DovetailRedisHostname} | awk '{ print $1 }')
+                do
+                  if ! timeout 0.1 bash -c "cat < /dev/null > /dev/tcp/$IP/6379"; then
+                    echo "Unhealthy; Failed to connect to Redis: $IP"
+                    INSTANCE_ID=`ec2-metadata -i`
+                    aws autoscaling set-instance-health --instance-id $INSTANCE_ID --health-status Unhealthy
+                  fi
+                done
           services:
             sysvinit:
               cfn-hup:

--- a/stacks/shared-ecs-asg.yml
+++ b/stacks/shared-ecs-asg.yml
@@ -61,6 +61,18 @@ Resources:
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
+  InstanceRoleSetHealthPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: AutoscalingSetInstanceHealth
+      PolicyDocument:
+        Statement:
+          - Action: autoscaling:SetInstanceHealth
+            Effect: Allow
+            Resource: !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${Asg}
+        Version: "2012-10-17"
+      Roles:
+        - !Ref InstanceRole
 
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Only enabled in the new, staging-only ASG for testing.