### PR TITLE
Turn on cloudwatch logging for shared PG instance

### DIFF
--- a/db/postgresql-instance.yml
+++ b/db/postgresql-instance.yml
@@ -174,6 +174,8 @@ Resources:
       PreferredMaintenanceWindow: "tue:06:15-tue:06:45"
       PubliclyAccessible: true
       StorageType: !If [UseProvisionedStorage, "io1", "gp2"]
+      EnableCloudwatchLogsExports:
+        - "postgres"
       Tags:
         - Key: Project
           Value: !Ref ProjectName


### PR DESCRIPTION
Per https://github.com/PRX/augury.prx.org/issues/577

This turns on cloudwatch logging for the shared postgres database

[The docs indicate ](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-enablecloudwatchlogsexports)that this is not going to interrupt the database.