### PR TITLE
Permanently delete non-current object versions

### DIFF
--- a/storage/multi-region-replication/feeds.yml
+++ b/storage/multi-region-replication/feeds.yml
@@ -115,6 +115,10 @@ Resources:
             AllowedMethods: [GET]
             AllowedOrigins: ["*"]
             ExposedHeaders: []
+      LifecycleConfiguration:
+        Rules:
+          - NoncurrentVersionExpirationInDays: 1 # Permanently delete non-current versions
+            Status: Enabled
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/storage/multi-region-replication/mediajoint.yml
+++ b/storage/multi-region-replication/mediajoint.yml
@@ -117,6 +117,8 @@ Resources:
             MaxAge: 3000
       LifecycleConfiguration:
         Rules:
+          - NoncurrentVersionExpirationInDays: 1 # Permanently delete non-current versions
+            Status: Enabled
           - Id: IA after 30 days
             Status: Enabled
             Transitions:

--- a/storage/multi-region-replication/networks.yml
+++ b/storage/multi-region-replication/networks.yml
@@ -115,6 +115,8 @@ Resources:
             MaxAge: 3000
       LifecycleConfiguration:
         Rules:
+          - NoncurrentVersionExpirationInDays: 1 # Permanently delete non-current versions
+            Status: Enabled
           - Id: Move to IA
             Status: Enabled
             Transitions:


### PR DESCRIPTION
The mediajoint, networks, and feeds buckets previously did not have versioning enabled. In order to support replication, version had to be enabled. This will create a lifecycle rule that expires (i.e., permanently deletes) non-current versions of all objects in the bucket, which will prevent any unnecessary buildup of old object versions.