### PR TITLE
Use stack params for db host/port

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -41,7 +41,6 @@ Parameters:
   SharedAuroraPostgresqlEndpoint: { Type: String }
 
 Conditions:
-  IsStaging: !Equals [!Ref EnvironmentType, Staging]
   IsProduction: !Equals [!Ref EnvironmentType, Production]
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
   HasRdsEndpoint: !Not [!Equals [!Ref SharedRdsPostgresqlEndpoint, ""]]
@@ -246,16 +245,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_HOST
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: POSTGRES_HOST
+              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+            - Name: POSTGRES_PORT
+              Value: !If [IsProduction, "5432", "3306"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -305,16 +298,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_HOST
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: POSTGRES_HOST
+              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+            - Name: POSTGRES_PORT
+              Value: !If [IsProduction, "5432", "3306"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -471,16 +458,10 @@ Resources:
               Value: "prx-mrr-us-east-1-ad-files.s3.us-east-1.amazonaws.com"
             - Name: UPLOAD_ADFILE_PUBLIC_ACCESS_HOST
               Value: "a.prxu.org"
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_HOST
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: POSTGRES_HOST
+              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+            - Name: POSTGRES_PORT
+              Value: !If [IsProduction, "5432", "3306"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/apps/cms.yml
+++ b/stacks/apps/cms.yml
@@ -244,6 +244,8 @@ Resources:
               Value: !Sub https://${ElasticsearchDomain.DomainEndpoint}:9200
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -298,6 +300,8 @@ Resources:
               Value: !Sub https://${ElasticsearchDomain.DomainEndpoint}:9200
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/apps/cms.yml
+++ b/stacks/apps/cms.yml
@@ -46,7 +46,7 @@ Conditions:
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
   HasRdsEndpoint: !Not [!Equals [!Ref SharedRdsMysqlEndpoint, ""]]
   HasAuroraEndpoint: !Not [!Equals [!Ref SharedAuroraMysqlEndpoint, ""]]
-  EnableWorkers: !And [!Condition HasRdsEndpoints, !Condition IsPrimaryRegion]
+  EnableWorkers: !And [!Condition HasAuroraEndpoint, !Condition IsPrimaryRegion]
 
 Resources:
   HostHeaderListenerRule:
@@ -167,7 +167,7 @@ Resources:
 
   WebEcsService:
     Type: AWS::ECS::Service
-    Condition: HasRdsEndpoints # See README
+    Condition: HasAuroraEndpoint # See README
     Properties:
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:

--- a/stacks/apps/cms.yml
+++ b/stacks/apps/cms.yml
@@ -44,12 +44,8 @@ Parameters:
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
-  HasRdsEndpoints: !And
-    - !Not [!Equals [!Ref SharedRdsMysqlEndpoint, ""]]
-    - !Not [!Equals [!Ref SharedRdsPostgresqlEndpoint, ""]]
-  HasAuroraEndpoints: !And
-    - !Not [!Equals [!Ref SharedAuroraMysqlEndpoint, ""]]
-    - !Not [!Equals [!Ref SharedAuroraPostgresqlEndpoint, ""]]
+  HasRdsEndpoint: !Not [!Equals [!Ref SharedRdsMysqlEndpoint, ""]]
+  HasAuroraEndpoint: !Not [!Equals [!Ref SharedAuroraMysqlEndpoint, ""]]
   EnableWorkers: !And [!Condition HasRdsEndpoints, !Condition IsPrimaryRegion]
 
 Resources:

--- a/stacks/apps/exchange.yml
+++ b/stacks/apps/exchange.yml
@@ -50,7 +50,7 @@ Conditions:
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
   HasRdsEndpoint: !Not [!Equals [!Ref SharedRdsMysqlEndpoint, ""]]
   HasAuroraEndpoint: !Not [!Equals [!Ref SharedAuroraMysqlEndpoint, ""]]
-  EnableWorkers: !And [!Condition HasRdsEndpoint, !Condition IsPrimaryRegion]
+  EnableWorkers: !And [!Condition HasAuroraEndpoint, !Condition IsPrimaryRegion]
 
 Resources:
   ExchangeWildcardHostHeaderListenerRule:
@@ -246,7 +246,7 @@ Resources:
 
   WebEcsService:
     Type: AWS::ECS::Service
-    Condition: HasRdsEndpoint # See README
+    Condition: HasAuroraEndpoint # See README
     Properties:
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:

--- a/stacks/apps/exchange.yml
+++ b/stacks/apps/exchange.yml
@@ -297,6 +297,8 @@ Resources:
               Value: !Ref S3SigningAccessKeyId
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: MEMCACHED_PORT_11211_TCP_ADDR
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT
@@ -388,6 +390,8 @@ Resources:
               Value: !Ref S3SigningAccessKeyId
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: MEMCACHED_PORT_11211_TCP_ADDR
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT
@@ -557,6 +561,8 @@ Resources:
               Value: !Ref S3SigningAccessKeyId
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: MEMCACHED_PORT_11211_TCP_ADDR
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -84,7 +84,6 @@ Parameters:
   SharedGlueDatabaseName: { Type: String }
 
 Conditions:
-  IsStaging: !Equals [!Ref EnvironmentType, Staging]
   IsProduction: !Equals [!Ref EnvironmentType, Production]
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
   HasRdsEndpoint: !Not [!Equals [!Ref SharedRdsPostgresqlEndpoint, ""]]
@@ -739,16 +738,10 @@ Resources:
               Value: !Ref AWS::Region
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsProduction, "5432", "3306"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -824,16 +817,10 @@ Resources:
               Value: !Ref AWS::Region
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsProduction, "5432", "3306"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/apps/id.yml
+++ b/stacks/apps/id.yml
@@ -114,7 +114,7 @@ Resources:
 
   EcsService:
     Type: AWS::ECS::Service
-    Condition: HasRdsEndpoint
+    Condition: HasAuroraEndpoint # See README
     Properties:
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:

--- a/stacks/apps/id.yml
+++ b/stacks/apps/id.yml
@@ -201,6 +201,8 @@ Resources:
               Value: !Ref AWS::Region
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: SMTP_ADDRESS
               Value: !Sub email-smtp.${AWS::Region}.amazonaws.com
             - Name: SMTP_AUTHENTICATION

--- a/stacks/apps/networks.yml
+++ b/stacks/apps/networks.yml
@@ -146,7 +146,7 @@ Resources:
   # HTTPS traffic via the shared application load balancer.
   PublicWebEcsService:
     Type: AWS::ECS::Service
-    Condition: HasRdsEndpoint
+    Condition: HasAuroraEndpoint # See README
     Properties:
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
@@ -445,7 +445,7 @@ Resources:
   # the image act as a Sphinx server.
   SphinxServerEcsService:
     Type: AWS::ECS::Service
-    Condition: HasRdsEndpoint
+    Condition: HasAuroraEndpoint # See README
     DependsOn:
       - SphinxServerSearchdNlbListener
       - SphinxServerWebNlbListener

--- a/stacks/apps/networks.yml
+++ b/stacks/apps/networks.yml
@@ -249,6 +249,8 @@ Resources:
               Value: !GetAtt Constants.SphinxBaseUrl
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -564,6 +566,8 @@ Resources:
               Value: "true"
             - Name: DB_PORT_3306_TCP_ADDR
               Value: !If [IsProduction, !Ref SharedRdsMysqlEndpoint, !Ref SharedAuroraMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/apps/remix.yml
+++ b/stacks/apps/remix.yml
@@ -36,7 +36,6 @@ Parameters:
   SharedAuroraPostgresqlEndpoint: { Type: String }
 
 Conditions:
-  IsStaging: !Equals [!Ref EnvironmentType, Staging]
   IsProduction: !Equals [!Ref EnvironmentType, Production]
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
   HasRdsEndpoint: !Not [!Equals [!Ref SharedRdsPostgresqlEndpoint, ""]]
@@ -220,16 +219,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsProduction, "5432", "3306"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -278,16 +271,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsProduction, "5432", "3306"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/augury-forecast.yml
+++ b/stacks/container-apps/augury-forecast.yml
@@ -109,16 +109,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_HOST
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: POSTGRES_HOST
+              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+            - Name: POSTGRES_PORT
+              Value: !If [IsStaging, "3306", "5432"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/augury.prx.org.yml
+++ b/stacks/container-apps/augury.prx.org.yml
@@ -1,4 +1,4 @@
-# stacks/container-apps/web-application.yml
+# stacks/container-apps/augury.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, using the shared platform ALB

--- a/stacks/container-apps/augury.prx.org.yml
+++ b/stacks/container-apps/augury.prx.org.yml
@@ -249,16 +249,10 @@ Resources:
               Value: "prx-mrr-us-east-1-ad-files.s3.us-east-1.amazonaws.com"
             - Name: UPLOAD_ADFILE_PUBLIC_ACCESS_HOST
               Value: "a.prxu.org"
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_HOST
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: POSTGRES_HOST
+              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+            - Name: POSTGRES_PORT
+              Value: !If [IsStaging, "3306", "5432"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -346,16 +340,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_HOST
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: POSTGRES_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: POSTGRES_HOST
+              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+            - Name: POSTGRES_PORT
+              Value: !If [IsStaging, "3306", "5432"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -191,11 +191,10 @@ Resources:
               Value: !Ref AWS::Region
             - Name: MEMCACHE_SERVERS
               Value: !Ref SharedMemcachedEndpointAddress
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_3306_TCP_ADDR
-                  Value: !Ref SharedAuroraMysqlEndpoint
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/exchange.prx.org.yml
+++ b/stacks/container-apps/exchange.prx.org.yml
@@ -244,11 +244,10 @@ Resources:
               Value: !Ref UploadSigningEndpointUrl
             - Name: AWS_SIGNER_KEY
               Value: !Ref UploadSigningAccessKeyId
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_3306_TCP_ADDR
-                  Value: !Ref SharedAuroraMysqlEndpoint
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: MEMCACHED_PORT_11211_TCP_ADDR
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT
@@ -354,11 +353,10 @@ Resources:
               Value: !Ref UploadSigningEndpointUrl
             - Name: AWS_SIGNER_KEY
               Value: !Ref UploadSigningAccessKeyId
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_3306_TCP_ADDR
-                  Value: !Ref SharedAuroraMysqlEndpoint
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: MEMCACHED_PORT_11211_TCP_ADDR
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT
@@ -617,11 +615,10 @@ Resources:
               Value: !Ref AWS::Region
             - Name: SAY_WHEN_THREAD
               Value: "true"
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_3306_TCP_ADDR
-                  Value: !Ref SharedAuroraMysqlEndpoint
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: MEMCACHED_PORT_11211_TCP_ADDR
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT

--- a/stacks/container-apps/feeder.prx.org.yml
+++ b/stacks/container-apps/feeder.prx.org.yml
@@ -381,16 +381,10 @@ Resources:
               Value: !Ref AWS::Region
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsStaging, "3306", "5432"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -470,16 +464,10 @@ Resources:
               Value: !Ref AWS::Region
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsStaging, "3306", "5432"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/id.prx.org.yml
+++ b/stacks/container-apps/id.prx.org.yml
@@ -171,11 +171,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_3306_TCP_ADDR
-                  Value: !Ref SharedAuroraMysqlEndpoint
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
             - Name: SMTP_ADDRESS
               Value: !Sub email-smtp.${AWS::Region}.amazonaws.com
             - Name: SMTP_AUTHENTICATION

--- a/stacks/container-apps/id.prx.org.yml
+++ b/stacks/container-apps/id.prx.org.yml
@@ -1,4 +1,4 @@
-# stacks/container-apps/web-application.yml
+# stacks/container-apps/id.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, using the shared platform ALB

--- a/stacks/container-apps/iframely.prx.org.yml
+++ b/stacks/container-apps/iframely.prx.org.yml
@@ -1,4 +1,4 @@
-# stacks/container-apps/web-application.yml
+# stacks/container-apps/iframely.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, using the shared platform ALB

--- a/stacks/container-apps/networks.prx.org.yml
+++ b/stacks/container-apps/networks.prx.org.yml
@@ -1,4 +1,4 @@
-# stacks/container-apps/web-application.yml
+# stacks/container-apps/networks.prx.org.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, using the shared platform ALB

--- a/stacks/container-apps/networks.prx.org.yml
+++ b/stacks/container-apps/networks.prx.org.yml
@@ -264,11 +264,10 @@ Resources:
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT
               Value: !Ref SharedMemcachedEndpointPort
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_3306_TCP_ADDR
-                  Value: !Ref SharedAuroraMysqlEndpoint
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -364,6 +363,10 @@ Resources:
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT
               Value: !Ref SharedMemcachedEndpointPort
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/remix.yml
+++ b/stacks/container-apps/remix.yml
@@ -1,4 +1,4 @@
-# stacks/container-apps/web-application.yml
+# stacks/container-apps/remix.yml
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Docker web application with optional worker, using the shared platform ALB

--- a/stacks/container-apps/remix.yml
+++ b/stacks/container-apps/remix.yml
@@ -206,16 +206,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsStaging, "3306", "5432"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -303,16 +297,10 @@ Resources:
               Value: !Ref SecretsVersion
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_ADDR
-                  Value: !Ref SharedAuroraPostgresqlEndpoint
-                - !Ref AWS::NoValue
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_5432_TCP_PORT
-                  Value: "3306" # TODO Make this a root stack parameter
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_5432_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+            - Name: DB_PORT_5432_TCP_PORT
+              Value: !If [IsStaging, "3306", "5432"]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/sphinx-nlb.yml
+++ b/stacks/container-apps/sphinx-nlb.yml
@@ -430,11 +430,10 @@ Resources:
               Value: !Ref SharedMemcachedEndpointAddress
             - Name: MEMCACHED_PORT_11211_TCP_PORT
               Value: !Ref SharedMemcachedEndpointPort
-            - Fn::If:
-                - IsStaging
-                - Name: DB_PORT_3306_TCP_ADDR
-                  Value: !Ref SharedAuroraMysqlEndpoint
-                - !Ref AWS::NoValue
+            - Name: DB_PORT_3306_TCP_ADDR
+              Value: !If [IsStaging, !Ref SharedAuroraMysqlEndpoint, !Ref SharedRdsMysqlEndpoint]
+            - Name: DB_PORT_3306_TCP_PORT
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:


### PR DESCRIPTION
Consistently use stack params for setting the db hosts/ports, instead of AWS secrets.  Note that prod is still pointed at non-Aurora at this point.

Deploying this:

- [x] Ensure the prod zipfile contains the shared mysql/postgres host variables.
- [ ] Deploy this (aws-secrets hosts/ports in prod will continue to override this)
- [ ] Update every app's aws-secrets, removing the host/port ENVs