### PR TITLE
Feeder to Aurora

### DIFF
--- a/stacks/apps-200A.yml
+++ b/stacks/apps-200A.yml
@@ -283,7 +283,6 @@ Resources:
         VpcPublicSubnet2Id: !Ref VpcPublicSubnet2Id
         VpcPublicSubnet3Id: !Ref VpcPublicSubnet3Id
         SharedEcsAsgInstanceSecurityGroupId: !Ref SharedEcsAsgInstanceSecurityGroupId
-        SharedRdsPostgresqlEndpoint: !Ref SharedRdsPostgresqlEndpoint
         SharedAuroraPostgresqlEndpoint: !Ref SharedAuroraPostgresqlEndpoint
         SharedGlueDatabaseName: !Ref SharedGlueDatabaseName
       Tags:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -79,14 +79,12 @@ Parameters:
   VpcPublicSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPublicSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   SharedEcsAsgInstanceSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
-  SharedRdsPostgresqlEndpoint: { Type: String }
   SharedAuroraPostgresqlEndpoint: { Type: String }
   SharedGlueDatabaseName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
-  HasRdsEndpoint: !Not [!Equals [!Ref SharedRdsPostgresqlEndpoint, ""]]
   HasAuroraEndpoint: !Not [!Equals [!Ref SharedAuroraPostgresqlEndpoint, ""]]
   EnableWorkers: !And [!Condition HasAuroraEndpoint, !Condition IsPrimaryRegion]
 
@@ -739,9 +737,9 @@ Resources:
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
             - Name: DB_PORT_5432_TCP_ADDR
-              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+              Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
-              Value: !If [IsProduction, "5432", "3306"]
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -818,9 +816,9 @@ Resources:
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
             - Name: DB_PORT_5432_TCP_ADDR
-              Value: !If [IsProduction, !Ref SharedRdsPostgresqlEndpoint, !Ref SharedAuroraPostgresqlEndpoint]
+              Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
-              Value: !If [IsProduction, "5432", "3306"]
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/feeder.prx.org.yml
+++ b/stacks/container-apps/feeder.prx.org.yml
@@ -7,7 +7,6 @@ Conditions:
   CreateWorkerResources: !Equals [!Ref CreateWorker, true]
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
   HasMemoryReservation: !Not [!Equals [!Ref ContainerMemoryReservation, ""]]
-  IsStaging: !Equals [!Ref EnvironmentType, Staging]
 
 Parameters:
   # VPC ########################################################################
@@ -36,8 +35,6 @@ Parameters:
   EnvironmentTypeAbbreviation:
     Type: String
   SecretsBase:
-    Type: String
-  EcrRegion:
     Type: String
   EcrImageTag:
     Type: String
@@ -79,8 +76,6 @@ Parameters:
   HealthCheckPath:
     Type: String
     Default: /api/v1
-  SharedRdsPostgresqlEndpoint:
-    Type: String
   SharedAuroraPostgresqlEndpoint:
     Type: String
 Resources:
@@ -382,9 +377,9 @@ Resources:
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
             - Name: DB_PORT_5432_TCP_ADDR
-              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+              Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
-              Value: !If [IsStaging, "3306", "5432"]
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -465,9 +460,9 @@ Resources:
             - Name: AWS_ACCOUNT_ID
               Value: !Ref AWS::AccountId
             - Name: DB_PORT_5432_TCP_ADDR
-              Value: !If [IsStaging, !Ref SharedAuroraPostgresqlEndpoint, !Ref SharedRdsPostgresqlEndpoint]
+              Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
-              Value: !If [IsStaging, "3306", "5432"]
+              Value: "3306"
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -587,7 +587,6 @@ Resources:
         EnvironmentTypeAbbreviation: !FindInMap [EnvironmentTypeMap, !Ref EnvironmentType, abbreviation]
         SecretsBase:
           Fn::ImportValue: !Sub ${SecretsStackName}-SecretsBaseRegion
-        EcrRegion: !Ref EcrRegion
         EcrImageTag: !Ref FeederEcrImageTag
         SecretsVersion: !Ref FeederSecretsVersion
         AppName: feeder
@@ -603,7 +602,6 @@ Resources:
         ContainerMemoryReservation: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendMemoryReservation]
         ContainerCpu: !FindInMap [ECSReservationMap, !Ref EnvironmentType, BackendCpu]
         HealthCheckPath: "/api/v1"
-        SharedRdsPostgresqlEndpoint: !Ref SharedRdsPostgresqlEndpoint
         SharedAuroraPostgresqlEndpoint: !Ref SharedAuroraPostgresqlEndpoint
       Tags:
         - Key: prx:cloudformation:stack-name


### PR DESCRIPTION
🚧  DO NOT MERGE until ready to move the DB.

Use Aurora for all Feeder DBs, all the time.