### PR TITLE
Migrate from Castle-specific Redis to shared Redis

### DIFF
--- a/stacks/apps-200A.yml
+++ b/stacks/apps-200A.yml
@@ -31,6 +31,8 @@ Parameters:
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   SharedMemcachedEndpointAddress: { Type: String }
   SharedMemcachedEndpointPort: { Type: String }
+  SharedRedisReplicationGroupEndpointAddress: { Type: String }
+  SharedRedisReplicationGroupEndpointPort: { Type: String }
   AmazonSesSmtpCredentialsGeneratorServiceToken: { Type: String }
   EchoServiceToken: { Type: String }
   CloudWatchAlarmTaggerServiceToken: { Type: String }

--- a/stacks/apps-200A.yml
+++ b/stacks/apps-200A.yml
@@ -171,6 +171,8 @@ Resources:
         VpcPrivateSubnet1Id: !Ref VpcPrivateSubnet1Id
         VpcPrivateSubnet2Id: !Ref VpcPrivateSubnet2Id
         VpcPrivateSubnet3Id: !Ref VpcPrivateSubnet3Id
+        SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
+        SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         SecretsBase: !Ref SecretsBase
         EcrImageTag: !Ref CastleEcrImageTag
         SecretsVersion: !Ref CastleSecretsVersion

--- a/stacks/apps-200A.yml
+++ b/stacks/apps-200A.yml
@@ -428,7 +428,5 @@ Outputs:
     Value: !GetAtt FeederStack.Outputs.AlbName
   CastleRedisCacheName:
     Value: !GetAtt CastleStack.Outputs.RedisCacheName
-  CastleRedisCachePrimaryEndPointAddress:
-    Value: !GetAtt CastleStack.Outputs.RedisCachePrimaryEndPointAddress
   BetaDeployBucketRegionalDomainName:
     Value: !GetAtt BetaStack.Outputs.DeployBucketRegionalDomainName

--- a/stacks/apps-200A.yml
+++ b/stacks/apps-200A.yml
@@ -168,9 +168,6 @@ Resources:
         AlbHttpsListenerArn: !Ref AlbHttpsListenerArn
         EcsClusterArn: !Ref EcsClusterArn
         VpcId: !Ref VpcId
-        VpcPrivateSubnet1Id: !Ref VpcPrivateSubnet1Id
-        VpcPrivateSubnet2Id: !Ref VpcPrivateSubnet2Id
-        VpcPrivateSubnet3Id: !Ref VpcPrivateSubnet3Id
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         SecretsBase: !Ref SecretsBase
@@ -183,7 +180,6 @@ Resources:
         RootStackName: !Ref RootStackName
         RootStackId: !Ref RootStackId
         CloudWatchAlarmTaggerServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
-        SharedEcsAsgInstanceSecurityGroupId: !Ref SharedEcsAsgInstanceSecurityGroupId
         CastleRdsPostgresqlEndpoint: !Ref CastleRdsPostgresqlEndpoint
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -30,6 +30,8 @@ Parameters:
   EchoServiceToken: { Type: String }
   CloudWatchAlarmTaggerServiceToken: { Type: String }
   SharedEcsAsgInstanceSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
+  SharedRedisReplicationGroupEndpointAddress: { Type: String }
+  SharedRedisReplicationGroupEndpointPort: { Type: String }
   CastleRedisCachePrimaryEndPointAddress: { Type: String }
   CastleHostname: { Type: String }
   CorporateHostname: { Type: String }

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -71,6 +71,8 @@ Resources:
         VpcPrivateSubnet2Id: !Ref VpcPrivateSubnet2Id
         VpcPrivateSubnet3Id: !Ref VpcPrivateSubnet3Id
         MetricsKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM
+        SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
+        SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         CastleRedisCachePrimaryEndPointAddress: !Ref CastleRedisCachePrimaryEndPointAddress
         DynamoDbKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM
         DynamoDbTableName: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -73,7 +73,6 @@ Resources:
         MetricsKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
-        CastleRedisCachePrimaryEndPointAddress: !Ref CastleRedisCachePrimaryEndPointAddress
         DynamoDbKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM
         DynamoDbTableName: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME
         DynamoDbTtl: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TTL

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -31,8 +31,6 @@ Parameters:
   CloudWatchAlarmTaggerServiceToken: { Type: String }
   SharedEcsAsgInstanceSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
-  SharedRedisReplicationGroupEndpointPort: { Type: String }
-  CastleRedisCachePrimaryEndPointAddress: { Type: String }
   CastleHostname: { Type: String }
   CorporateHostname: { Type: String }
   ExchangeHostname: { Type: String }
@@ -72,7 +70,6 @@ Resources:
         VpcPrivateSubnet3Id: !Ref VpcPrivateSubnet3Id
         MetricsKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
-        SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         DynamoDbKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM
         DynamoDbTableName: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME
         DynamoDbTtl: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TTL

--- a/stacks/apps/castle.yml
+++ b/stacks/apps/castle.yml
@@ -25,6 +25,8 @@ Parameters:
   VpcPrivateSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
+  SharedRedisReplicationGroupEndpointAddress: { Type: String }
+  SharedRedisReplicationGroupEndpointPort: { Type: String }
   SecretsBase: { Type: String }
   EcrImageTag: { Type: String }
   SecretsVersion: { Type: String }

--- a/stacks/apps/castle.yml
+++ b/stacks/apps/castle.yml
@@ -22,9 +22,6 @@ Parameters:
   RootStackId: { Type: String }
   CloudWatchAlarmTaggerServiceToken: { Type: String }
   VpcId: { Type: AWS::EC2::VPC::Id }
-  VpcPrivateSubnet1Id: { Type: AWS::EC2::Subnet::Id }
-  VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
-  VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
   SecretsBase: { Type: String }
@@ -32,7 +29,6 @@ Parameters:
   SecretsVersion: { Type: String }
   AlbListenerRulePriorityPrefix: { Type: String }
   SecretsStackName: { Type: String }
-  SharedEcsAsgInstanceSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   CastleRdsPostgresqlEndpoint: { Type: String }
 
 Conditions:
@@ -210,9 +206,9 @@ Resources:
             - Name: PG_HOST
               Value: !Ref CastleRdsPostgresqlEndpoint
             - Name: REDIS_HOST
-              Value: !GetAtt RedisReplicationGroup.PrimaryEndPoint.Address
+              Value: !Ref SharedRedisReplicationGroupEndpointAddress
             - Name: REDIS_PORT
-              Value: !GetAtt RedisReplicationGroup.PrimaryEndPoint.Port
+              Value: !Ref SharedRedisReplicationGroupEndpointPort
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -239,114 +235,3 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Castle }
       TaskRoleArn: !GetAtt TaskRole.Arn
-
-  RedisSubnetGroup:
-    Type: AWS::ElastiCache::SubnetGroup
-    Properties:
-      Description: !Sub Castle ${EnvironmentType} Redis subnet group
-      SubnetIds:
-        - !Ref VpcPrivateSubnet1Id
-        - !Ref VpcPrivateSubnet2Id
-        - !Ref VpcPrivateSubnet3Id
-      Tags:
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Castle }
-  RedisSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      VpcId: !Ref VpcId
-      GroupDescription: !Sub Castle ${EnvironmentType} Redis security group
-      SecurityGroupIngress:
-        - FromPort: 6379
-          IpProtocol: tcp
-          SourceSecurityGroupId: !Ref SharedEcsAsgInstanceSecurityGroupId
-          ToPort: 6379
-      Tags:
-        - { Key: Name, Value: !Sub "${RootStackName}_castle_redis" }
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Castle }
-  RedisReplicationGroup:
-    Type: AWS::ElastiCache::ReplicationGroup
-    Properties:
-      AtRestEncryptionEnabled: false
-      AutomaticFailoverEnabled: true
-      AutoMinorVersionUpgrade: false
-      CacheNodeType: !If
-        - IsProduction
-        - cache.t3.medium
-        - cache.t3.micro
-      CacheSubnetGroupName: !Ref RedisSubnetGroup
-      Engine: Redis
-      EngineVersion: 6.x
-      MultiAZEnabled: true
-      NumNodeGroups: 1 # 1 = cluster mode disabled, NodeGroups are Shards
-      ReplicasPerNodeGroup: 1 # Replicas are nodes. N replicas will result in N+1 Nodes Per Shard
-      ReplicationGroupDescription: !Sub Castle ${EnvironmentType} Redis
-      SecurityGroupIds:
-        - !GetAtt RedisSecurityGroup.GroupId
-      SnapshotRetentionLimit: 0 # 0 = automatic backups are disabled
-      Tags:
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Castle }
-  RedisMemoryLowAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: IsProduction
-    Properties:
-      AlarmName: !Sub WARN [Castle] Redis <${EnvironmentTypeAbbreviation}> HIGH MEMORY USAGE
-      AlarmDescription: !Sub >-
-        ${EnvironmentType} Castle Redis's database memory usage has exceeded
-        the recommended safe level
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: CacheClusterId
-          Value: !Ref RedisReplicationGroup
-      EvaluationPeriods: 2
-      MetricName: DatabaseMemoryUsagePercentage
-      Namespace: AWS/ElastiCache
-      Period: 120
-      Statistic: Maximum
-      Threshold: 0.85
-      TreatMissingData: notBreaching
-  RedisMemoryVeryLowAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: IsProduction
-    Properties:
-      AlarmName: !Sub ERROR [Castle] Redis <${EnvironmentTypeAbbreviation}> VERY HIGH MEMORY USAGE
-      AlarmDescription: !Sub >-
-        ${EnvironmentType} Castle Redis's database memory usage has reached a
-        critically high level
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: CacheClusterId
-          Value: !Ref RedisReplicationGroup
-      EvaluationPeriods: 2
-      MetricName: DatabaseMemoryUsagePercentage
-      Namespace: AWS/ElastiCache
-      Period: 120
-      Statistic: Maximum
-      Threshold: 0.93
-      TreatMissingData: notBreaching
-
-Outputs:
-  RedisCacheName:
-    Value: !Ref RedisReplicationGroup
-  RedisCachePrimaryEndPointAddress:
-    Value: !GetAtt RedisReplicationGroup.PrimaryEndPoint.Address

--- a/stacks/apps/dovetail-analytics.yml
+++ b/stacks/apps/dovetail-analytics.yml
@@ -646,7 +646,7 @@ Resources:
         ${EnvironmentType} Dovetail Analytics sending INCRs to Redis
       Environment:
         Variables:
-          REDIS_HOST: !Ref CastleRedisCachePrimaryEndPointAddress
+          REDIS_HOST: !Ref SharedRedisReplicationGroupEndpointAddress
           REDIS_TTL: "7200"
           REDIS_IMPRESSIONS_HOST: !Sub cluster://${DovetailRedisHostname}:6379
           REDIS_IMPRESSIONS_TTL: "90000"

--- a/stacks/apps/dovetail-analytics.yml
+++ b/stacks/apps/dovetail-analytics.yml
@@ -22,6 +22,8 @@ Parameters:
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   MetricsKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
+  SharedRedisReplicationGroupEndpointAddress: { Type: String }
+  SharedRedisReplicationGroupEndpointPort: { Type: String }
   CastleRedisCachePrimaryEndPointAddress: { Type: String }
   DynamoDbKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbTableName: { Type: AWS::SSM::Parameter::Value<String> }

--- a/stacks/apps/dovetail-analytics.yml
+++ b/stacks/apps/dovetail-analytics.yml
@@ -23,8 +23,6 @@ Parameters:
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   MetricsKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
-  SharedRedisReplicationGroupEndpointPort: { Type: String }
-  CastleRedisCachePrimaryEndPointAddress: { Type: String }
   DynamoDbKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbTableName: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbTtl: { Type: AWS::SSM::Parameter::Value<String> }

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -1179,6 +1179,8 @@ Resources:
         EchoServiceToken: !GetAtt CustomResourcesStack.Outputs.EchoServiceToken
         CloudWatchAlarmTaggerServiceToken: !GetAtt CustomResourcesStack.Outputs.CloudWatchAlarmTaggerServiceToken
         SharedEcsAsgInstanceSecurityGroupId: !GetAtt SharedEcsAsgStack.Outputs.InstanceSecurityGroupId
+        SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
+        SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
         CastleRedisCachePrimaryEndPointAddress: !GetAtt Apps200AStack.Outputs.CastleRedisCachePrimaryEndPointAddress
         CastleHostname: !GetAtt Constants.CastleHostname
         CorporateHostname: !GetAtt Constants.CorporateHostname

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -1078,6 +1078,8 @@ Resources:
         VpcPrivateSubnet3Id: !GetAtt SharedVpcStack.Outputs.PrivateSubnet3Id
         SharedMemcachedEndpointAddress: !GetAtt PrivateSharedMemcachedStack.Outputs.CacheEndpointAddress
         SharedMemcachedEndpointPort: !GetAtt PrivateSharedMemcachedStack.Outputs.CacheEndpointPort
+        SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
+        SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
         AmazonSesSmtpCredentialsGeneratorServiceToken: !GetAtt CustomResourcesStack.Outputs.AmazonSesSmtpCredentialsGeneratorServiceToken
         EchoServiceToken: !GetAtt CustomResourcesStack.Outputs.EchoServiceToken
         CloudWatchAlarmTaggerServiceToken: !GetAtt CustomResourcesStack.Outputs.CloudWatchAlarmTaggerServiceToken

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -1180,8 +1180,6 @@ Resources:
         CloudWatchAlarmTaggerServiceToken: !GetAtt CustomResourcesStack.Outputs.CloudWatchAlarmTaggerServiceToken
         SharedEcsAsgInstanceSecurityGroupId: !GetAtt SharedEcsAsgStack.Outputs.InstanceSecurityGroupId
         SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
-        SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
-        CastleRedisCachePrimaryEndPointAddress: !GetAtt Apps200AStack.Outputs.CastleRedisCachePrimaryEndPointAddress
         CastleHostname: !GetAtt Constants.CastleHostname
         CorporateHostname: !GetAtt Constants.CorporateHostname
         ExchangeHostname: !GetAtt Constants.ExchangeHostname


### PR DESCRIPTION
Blocked by https://github.com/PRX/castle.prx.org/issues/130

In the new cluster/apps, uses the shared Redis for Castle and Analytics Lambda instead of the Castle-specific Redis