### PR TITLE
Bump the memory and reservable memory for augury (workers)

### DIFF
--- a/stacks/container-apps/root.yml
+++ b/stacks/container-apps/root.yml
@@ -278,8 +278,8 @@ Resources:
         EnvironmentType: !Ref EnvironmentType
         EnvironmentTypeAbbreviation: !Ref EnvironmentTypeAbbreviation
         SecretsBase: !Ref SecretsBase
-        ContainerMemory: !If [IsProduction, 3000, 2000]
-        ContainerMemoryReservation: !Ref ContainerMemoryReservation
+        ContainerMemory: !If [IsProduction, 3944, 2000]
+        ContainerMemoryReservation:  !If [IsProduction, 3944, !Ref ContainerMemoryReservation]
         ContainerCpu: !Ref ContainerCpu
         PlatformALBListenerPriorityPrefix: !Ref AuguryPlatformALBListenerPriorityPrefix
         EcrImageTag: !Ref AuguryEcrImageTag


### PR DESCRIPTION
Bumps the ECS task's hard/soft memory to some max value (given the predominant instance type).