### PR TITLE
Fixup queue names

### DIFF
--- a/stacks/apps/cms.yml
+++ b/stacks/apps/cms.yml
@@ -424,6 +424,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_audio_callback
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt AudioCallbackDeadletterQueue.Arn
@@ -442,6 +443,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_audio_callback_failures
       ReceiveMessageWaitTimeSeconds: 0
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -493,6 +495,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_image_callback
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt ImageCallbackDeadletterQueue.Arn
@@ -511,6 +514,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_image_callback_failures
       ReceiveMessageWaitTimeSeconds: 0
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -562,6 +566,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_podcast_import
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt PodcastImportDeadletterQueue.Arn
@@ -580,6 +585,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_podcast_import_failures
       ReceiveMessageWaitTimeSeconds: 0
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -631,6 +637,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_search_indexer
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt SearchIndexerDeadletterQueue.Arn
@@ -649,6 +656,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_search_indexer_failures
       ReceiveMessageWaitTimeSeconds: 0
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -699,6 +707,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_default
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DefaultJobDeadletterQueue.Arn
@@ -717,6 +726,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_cms_default_failures
       ReceiveMessageWaitTimeSeconds: 0
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/stacks/apps/cms.yml
+++ b/stacks/apps/cms.yml
@@ -325,16 +325,8 @@ Resources:
               Value: !Ref SharedAuroraMysqlEndpoint
             - Name: DB_PORT_3306_TCP_PORT
               Value: !Ref SharedAuroraMysqlPort
-            - Name: SQS_AUDIO_CALLBACK_QUEUE_NAME
-              Value: !GetAtt AudioCallbackQueue.QueueName
-            - Name: SQS_IMAGE_CALLBACK_QUEUE_NAME
-              Value: !GetAtt ImageCallbackQueue.QueueName
-            - Name: SQS_PODCAST_IMPORT_QUEUE_NAME
-              Value: !GetAtt PodcastImportQueue.QueueName
-            - Name: SQS_SEARCH_INDEXER_QUEUE_NAME
-              Value: !GetAtt SearchIndexerQueue.QueueName
-            - Name: SQS_DEFAULT_JOB_QUEUE_NAME
-              Value: !GetAtt DefaultJobQueue.QueueName
+            - Name: ANNOUNCE_RESOURCE_PREFIX
+              Value: !Ref AnnounceResourcePrefix
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -868,6 +868,8 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
               Value: !Ref SharedAuroraPostgresqlPort
+            - Name: FIXER_CALLBACK_QUEUE_NAME
+              Value: !GetAtt FixerCallbackQueue.QueueName
             - Name: ANNOUNCE_RESOURCE_PREFIX
               Value: !Ref AnnounceResourcePrefix
           Essential: true
@@ -962,10 +964,10 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
               Value: !Ref SharedAuroraPostgresqlPort
-            - Name: DEFAULT_JOB_QUEUE_NAME
-              Value: !GetAtt DefaultJobQueue.QueueName
             - Name: FIXER_CALLBACK_QUEUE_NAME
               Value: !GetAtt FixerCallbackQueue.QueueName
+            - Name: ANNOUNCE_RESOURCE_PREFIX
+              Value: !Ref AnnounceResourcePrefix
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -502,6 +502,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_feeder_default
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DefaultJobDeadletterQueue.Arn
@@ -521,6 +522,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_feeder_default_failures
       ReceiveMessageWaitTimeSeconds: 0
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -574,6 +576,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_feeder_fixer_callback
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt FixerCallbackDeadletterQueue.Arn
@@ -593,6 +596,7 @@ Resources:
     Properties:
       DelaySeconds: 0
       MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_feeder_fixer_callback_failures
       ReceiveMessageWaitTimeSeconds: 0
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DefaultJobDeadletterQueue.Arn

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -193,16 +193,8 @@ Resources:
               Value: !Ref SharedAuroraMysqlEndpoint
             - Name: DB_PORT_3306_TCP_PORT
               Value: "3306"
-            - Name: SQS_AUDIO_CALLBACK_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_audio_callback, production_cms_audio_callback]
-            - Name: SQS_IMAGE_CALLBACK_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_image_callback, production_cms_image_callback]
-            - Name: SQS_PODCAST_IMPORT_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_podcast_import, production_cms_podcast_import]
-            - Name: SQS_SEARCH_INDEXER_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_search_indexer, production_cms_search_indexer]
-            - Name: SQS_DEFAULT_JOB_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_default, production_cms_default]
+            - Name: AnnounceResourcePrefix
+              Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -294,16 +286,8 @@ Resources:
               Value: !Ref SharedAuroraMysqlEndpoint
             - Name: DB_PORT_3306_TCP_PORT
               Value: "3306"
-            - Name: SQS_AUDIO_CALLBACK_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_audio_callback, production_cms_audio_callback]
-            - Name: SQS_IMAGE_CALLBACK_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_image_callback, production_cms_image_callback]
-            - Name: SQS_PODCAST_IMPORT_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_podcast_import, production_cms_podcast_import]
-            - Name: SQS_SEARCH_INDEXER_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_search_indexer, production_cms_search_indexer]
-            - Name: SQS_DEFAULT_JOB_QUEUE_NAME
-              Value: !If [IsStaging, staging_cms_default, production_cms_default]
+            - Name: AnnounceResourcePrefix
+              Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/container-apps/cms.prx.org.yml
+++ b/stacks/container-apps/cms.prx.org.yml
@@ -193,7 +193,7 @@ Resources:
               Value: !Ref SharedAuroraMysqlEndpoint
             - Name: DB_PORT_3306_TCP_PORT
               Value: "3306"
-            - Name: AnnounceResourcePrefix
+            - Name: ANNOUNCE_RESOURCE_PREFIX
               Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag
@@ -286,7 +286,7 @@ Resources:
               Value: !Ref SharedAuroraMysqlEndpoint
             - Name: DB_PORT_3306_TCP_PORT
               Value: "3306"
-            - Name: AnnounceResourcePrefix
+            - Name: ANNOUNCE_RESOURCE_PREFIX
               Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag

--- a/stacks/container-apps/feeder.prx.org.yml
+++ b/stacks/container-apps/feeder.prx.org.yml
@@ -381,7 +381,7 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
               Value: "3306"
-            - Name: AnnounceResourcePrefix
+            - Name: ANNOUNCE_RESOURCE_PREFIX
               Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag
@@ -466,7 +466,7 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
               Value: "3306"
-            - Name: AnnounceResourcePrefix
+            - Name: ANNOUNCE_RESOURCE_PREFIX
               Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag

--- a/stacks/container-apps/feeder.prx.org.yml
+++ b/stacks/container-apps/feeder.prx.org.yml
@@ -7,6 +7,7 @@ Conditions:
   CreateWorkerResources: !Equals [!Ref CreateWorker, true]
   CreateProductionResources: !Equals [!Ref EnvironmentType, Production]
   HasMemoryReservation: !Not [!Equals [!Ref ContainerMemoryReservation, ""]]
+  IsStaging: !Equals [!Ref EnvironmentType, Staging]
 
 Parameters:
   # VPC ########################################################################
@@ -380,6 +381,8 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
               Value: "3306"
+            - Name: AnnounceResourcePrefix
+              Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:
@@ -463,6 +466,8 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: DB_PORT_5432_TCP_PORT
               Value: "3306"
+            - Name: AnnounceResourcePrefix
+              Value: !If [IsStaging, staging, production]
           Essential: true
           Image: !Ref EcrImageTag
           LogConfiguration:

--- a/stacks/shared-announce.yml
+++ b/stacks/shared-announce.yml
@@ -791,4 +791,4 @@ Resources:
 
 Outputs:
   ResourcePrefix:
-    Value: !GetAtt Hash.Hash
+    Value: !Sub ${Hash.Hash}_${EnvironmentTypeAbbreviation}


### PR DESCRIPTION
- [x] Standardize ENVs for CMS and Feeder.  All they actually need is the `ANNOUNCE_RESOURCE_PREFIX`.
- [x] Hardcode `ANNOUNCE_RESOURCE_PREFIX` in old stacks, to match the current Rails.env usage
- [x] Interpolate all QueueNames for CMS/Feeder shoryuken.  Using something like `!Sub ${AnnounceResourcePrefix}_cms_audio_callback`
- [x] Fix shared-announce.yml to export the full prefix, including env abbreviation