### PR TITLE
Cleanup Feeder and CMS SNS and SQS policies

### DIFF
--- a/stacks/apps/cms.yml
+++ b/stacks/apps/cms.yml
@@ -158,11 +158,18 @@ Resources:
               - Action: sns:Publish
                 Effect: Allow
                 Resource: !Ref PorterJobExecutionSnsTopicArn
+                Sid: AllowPublish
             Version: "2012-10-17"
-          PolicyName: PorterSnsPublish
+          PolicyName: Porter
         - PolicyDocument:
             Statement:
-              - Action: sqs:*
+              - Action:
+                  - sqs:ChangeMessageVisibility
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                  - sqs:GetQueueUrl
+                  - sqs:ReceiveMessage
+                  - sqs:SendMessage
                 Effect: Allow
                 Resource:
                   - !GetAtt AudioCallbackQueue.Arn
@@ -170,16 +177,15 @@ Resources:
                   - !GetAtt PodcastImportQueue.Arn
                   - !GetAtt SearchIndexerQueue.Arn
                   - !GetAtt DefaultJobQueue.Arn
+                Sid: AllowShoryuken
             Version: "2012-10-17"
-          PolicyName: JobQueues
+          PolicyName: AppQueueus
         - PolicyDocument:
             Statement:
-              - Action: sqs:* # TODO Seems very permissive
-                Effect: Allow
-                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${AnnounceResourcePrefix}*
-              - Action: sns:* # TODO Seems very permissive
+              - Action: sns:Publish
                 Effect: Allow
                 Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${AnnounceResourcePrefix}*
+                Sid: AllowPublish
             Version: "2012-10-17"
           PolicyName: Announce
         - PolicyDocument:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -262,9 +262,23 @@ Resources:
                 Resource:
                   - !GetAtt DefaultJobQueue.Arn
                   - !GetAtt FixerCallbackQueue.Arn
-                Sid: AllowSendAndReceive
+                Sid: AllowShoryuken
             Version: "2012-10-17"
-          PolicyName: Queues
+          PolicyName: AppQueues
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - sqs:ChangeMessageVisibility
+                  - sqs:DeleteMessage
+                  - sqs:Get*
+                  - sqs:List*
+                  - sqs:ReceiveMessage
+                  - sqs:SendMessage
+                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${AnnounceResourcePrefix}_announce_feeder_*
+                Sid: AllowShoryuken
+            Version: "2012-10-17"
+          PolicyName: Announce
         - PolicyDocument:
             Statement:
               - Action: sns:Publish
@@ -272,7 +286,7 @@ Resources:
                 Resource: "*" # TODO permissive
                 Sid: AllowGlobalPublish
             Version: "2012-10-17"
-          PolicyName: SnsFullApplicationAccess
+          PolicyName: SNS
         - PolicyDocument:
             Statement:
               - Action:


### PR DESCRIPTION
These should be much closer to the least privilege requirements of both apps. Hopefully not removing any necessary permissions?