### PR TITLE
Lower augury fargate memory

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -622,7 +622,7 @@ Resources:
           Name: augury-workslow
       Cpu: "4096"
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
-      Memory: "30720"
+      Memory: "16384"
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
Looks like fargate memory usage is peaking at around 10gigs, so lower the bound on memory usage
<img width="1170" alt="Screen Shot 2022-01-27 at 10 15 54 AM" src="https://user-images.githubusercontent.com/329012/151398973-3499ba74-36de-481a-ae57-7f569b70ff8f.png">
.