### PR TITLE
Set up an alarm for missing forecasts

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -559,7 +559,6 @@ Resources:
       TreatMissingData: breaching
   AuguryForecastsAreBehindAlarmTags:
     Type: Custom::CloudWatchAlarmTags
-    Condition: IsProduction
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
       AlarmArn: !GetAtt AuguryActualsAreBehindAlarm.Arn

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -553,7 +553,7 @@ Resources:
       EvaluationPeriods: 3
       MetricName: !Sub ForecastJobElapsed${EnvironmentType}
       Namespace: PRX/Augury
-      Period: If [IsProduction, 300, 5400]
+      Period: !If [IsProduction, 300, 5400]
       Statistic: SampleCount
       Threshold: 1
       TreatMissingData: breaching

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -551,7 +551,7 @@ Resources:
         actvitiy for an unusually long time. Inventory is slowly becoming stale.
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 3
-      MetricName: ForecastDownloadsMetricFilter
+      MetricName: !Sub ForecastJobElapsed${EnvironmentType}
       Namespace: PRX/Augury
       Period: If [IsProduction, 300, 5400]
       Statistic: SampleCount

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -553,7 +553,7 @@ Resources:
       EvaluationPeriods: 3
       MetricName: ForecastDownloadsMetricFilter
       Namespace: PRX/Augury
-      Period: If [IsProduction, 300, 3600]
+      Period: If [IsProduction, 300, 5400]
       Statistic: SampleCount
       Threshold: 1
       TreatMissingData: breaching

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -542,6 +542,38 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Augury }
 
+  AuguryForecastsAreBehindAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> NOT FORECASTING INVENTORY (${RootStackName})
+      AlarmDescription: !Sub >-
+        ${EnvironmentType} Augury's worker task has not logged any forecast
+        actvitiy for an unusually long time. Inventory is slowly becoming stale.
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 3
+      MetricName: ForecastDownloadsMetricFilter
+      Namespace: PRX/Augury
+      Period: If [IsProduction, 300, 3600]
+      Statistic: SampleCount
+      Threshold: 1
+      TreatMissingData: breaching
+  AuguryForecastsAreBehindAlarmTags:
+    Type: Custom::CloudWatchAlarmTags
+    Condition: IsProduction
+    Properties:
+      ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
+      AlarmArn: !GetAtt AuguryActualsAreBehindAlarm.Arn
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Augury }
+
   # Some Augury jobs are marked as "slow", which indicates they should not be
   # completed in the standard ECS service instance. These jobs are added to a
   # queue, and run in isolated Fargate tasks. In order to limit concurrency,


### PR DESCRIPTION
Sets up a new alarm to make sure the forecasts are running, uses the forecasts metrics filter.