### PR TITLE
Bump to 3 periods of 15 minutes

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -562,7 +562,7 @@ Resources:
       EvaluationPeriods: 3
       MetricName: !Sub ForecastJobElapsed${EnvironmentType}
       Namespace: PRX/Augury
-      Period: !If [IsProduction, 300, 5400]
+      Period: !If [IsProduction, 900, 5400]
       Statistic: SampleCount
       Threshold: 1
       TreatMissingData: breaching


### PR DESCRIPTION
Expands the sampling interval to three 15 minute periods.

I forgot there was a 30 minute 'buffer' in the schedule at the [end of the day](https://github.com/PRX/augury.prx.org/blob/ed1c30e496dae6106f847973b234faa2ef374759/app/jobs/schedule_forecasts_cron_job.rb#L20), so that the forecasts don't run over the next day's forecasts.  