### PR TITLE
ECS draining

### DIFF
--- a/stacks/shared-ecs/asg.yml
+++ b/stacks/shared-ecs/asg.yml
@@ -103,7 +103,7 @@ Resources:
   # this lambda handles draining ECS tasks from instances in this ASG before they
   # terminate. Should keep an eye on the github issue for less-DIY support of this
   # functionality: https://github.com/aws/containers-roadmap/issues/256
-  ECSDrainSNSTopic:
+  EcsDrainSnsTopic:
     Condition: IsStaging
     Type: AWS::SNS::Topic
     Properties:
@@ -114,23 +114,20 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:application, Value: Common }
-  ECSDrainSNSRole:
+        - { Key: prx:dev:application, Value: Infrastructure }
+  EcsDrainSnsRole:
     Condition: IsStaging
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Statement:
-          - Action:
-              - sts:AssumeRole
+          - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service:
-                - autoscaling.amazonaws.com
+              Service: autoscaling.amazonaws.com
         Version: "2012-10-17"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AutoScalingNotificationAccessRole
-      Path: /
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -138,8 +135,8 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:application, Value: Common }
-  ECSDrainHook:
+        - { Key: prx:dev:application, Value: Infrastructure }
+  EcsDrainHook:
     Condition: IsStaging
     Type: AWS::AutoScaling::LifecycleHook
     Properties:
@@ -147,9 +144,9 @@ Resources:
       DefaultResult: ABANDON
       HeartbeatTimeout: 900
       LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
-      NotificationTargetARN: !Ref ECSDrainSNSTopic
-      RoleARN: !GetAtt ECSDrainSNSRole.Arn
-  ECSDrainFunction:
+      NotificationTargetARN: !Ref EcsDrainSnsTopic
+      RoleARN: !GetAtt EcsDrainSnsRole.Arn
+  EcsDrainFunction:
     Condition: IsStaging
     Type: AWS::Serverless::Function
     Properties:
@@ -160,7 +157,7 @@ Resources:
       Events:
         SnsMessages:
           Properties:
-            Topic: !Ref ECSDrainSNSTopic
+            Topic: !Ref EcsDrainSnsTopic
           Type: SNS
       Handler: index.handler
       InlineCode: |
@@ -389,11 +386,9 @@ Resources:
                 - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/*
           Version: "2012-10-17"
         - Statement:
-            - Action:
-                - sns:Publish
+            - Action: sns:Publish
               Effect: Allow
-              Resource:
-                - !Ref ECSDrainSNSTopic
+              Resource: !Ref EcsDrainSnsTopic
           Version: "2012-10-17"
       Runtime: python3.9
       Tags:
@@ -403,20 +398,20 @@ Resources:
         prx:cloudformation:root-stack-name: !Ref RootStackName
         prx:cloudformation:root-stack-id: !Ref RootStackId
         prx:ops:environment: !Ref EnvironmentType
-        prx:dev:application: Common
+        prx:dev:application: Infrastructure
       Timeout: 300
-  ECSDrainLogGroup:
+  EcsDrainLogGroup:
     Condition: IsStaging
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${ECSDrainFunction}
+      LogGroupName: !Sub /aws/lambda/${EcsDrainFunction}
       RetentionInDays: 30
-  ECSDrainLogGroupTags:
+  EcsDrainLogGroupTags:
     Condition: IsStaging
     Type: Custom::CloudWatchLogGroupTags
     Properties:
       ServiceToken: !Ref CloudWatchLogGroupTaggerServiceToken
-      LogGroupName: !Ref ECSDrainLogGroup
+      LogGroupName: !Ref EcsDrainLogGroup
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -424,7 +419,7 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:application, Value: Common }
+        - { Key: prx:dev:application, Value: Infrastructure }
 
   # This adds a rule to the load balancer security group defined in
   # shared-alb.yml. It allows all TCP egress traffic from the load balancer

--- a/stacks/shared-ecs/asg.yml
+++ b/stacks/shared-ecs/asg.yml
@@ -368,10 +368,9 @@ Resources:
               Resource: "*"
           Version: "2012-10-17"
         - Statement:
-            - Action:
-                - autoscaling:CompleteLifecycleAction
+            - Action: autoscaling:CompleteLifecycleAction
               Effect: Allow
-              Resource: "*" # TODO: how to get an ASG ARN?
+              Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${Asg}
           Version: "2012-10-17"
         - Statement:
             - Action:
@@ -380,10 +379,10 @@ Resources:
                 - ecs:UpdateContainerInstancesState
               Effect: Allow
               Resource:
-                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${EcsClusterName}
-                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:container-instance/*
-                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:container/*
-                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/*
+                - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${EcsClusterName}
+                - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:container-instance/*
+                - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:container/*
+                - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:task/*
           Version: "2012-10-17"
         - Statement:
             - Action: sns:Publish

--- a/stacks/shared-ecs/asg.yml
+++ b/stacks/shared-ecs/asg.yml
@@ -99,6 +99,327 @@ Resources:
       Roles:
         - !Ref InstanceRole
 
+  # Based on https://aws.amazon.com/ru/blogs/compute/how-to-automate-container-instance-draining-in-amazon-ecs
+  # this lambda handles draining ECS tasks from instances in this ASG before they
+  # terminate. Should keep an eye on the github issue for less-DIY support of this
+  # functionality: https://github.com/aws/containers-roadmap/issues/256
+  ECSDrainSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+  ECSDrainSNSRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - autoscaling.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AutoScalingNotificationAccessRole
+      Path: /
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+  ECSDrainHook:
+    Type: AWS::AutoScaling::LifecycleHook
+    Properties:
+      AutoScalingGroupName: !Ref Asg
+      DefaultResult: ABANDON
+      HeartbeatTimeout: 900
+      LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
+      NotificationTargetARN: !Ref ECSDrainSNSTopic
+      RoleARN: !GetAtt ECSDrainSNSRole.Arn
+  ECSDrainFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: Drain tasks off ECS instances before allowing them to terminate
+      Environment:
+        Variables:
+          ECS_CLUSTER: !Ref EcsClusterName
+      Events:
+        SnsMessages:
+          Properties:
+            Topic: !Ref ECSDrainSNSTopic
+          Type: SNS
+      Handler: index.handler
+      InlineCode: |
+        from __future__ import print_function
+        import boto3
+        import json
+        import datetime
+        import time
+        import logging
+        import os
+
+        logging.basicConfig()
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+
+        # Establish boto3 session
+        session = boto3.session.Session()
+        logger.debug("Session is in region %s ", session.region_name)
+
+        ec2Client = session.client(service_name="ec2")
+        ecsClient = session.client(service_name="ecs")
+        asgClient = session.client("autoscaling")
+        snsClient = session.client("sns")
+        lambdaClient = session.client("lambda")
+
+        """Publish SNS message to trigger lambda again.
+            :param message: To repost the complete original message received when ASG
+                terminating event was received.
+            :param topicARN: SNS topic to publish the message to.
+        """
+
+
+        def publishToSNS(message, topicARN):
+            logger.info("Publish to SNS topic %s", topicARN)
+            snsClient.publish(
+                TopicArn=topicARN,
+                Message=json.dumps(message),
+                Subject="Publishing SNS message to invoke lambda again..",
+            )
+            return "published"
+
+
+        """Check task status on the ECS container instance ID.
+            :param Ec2InstanceId: The EC2 instance ID is used to identify the cluster,
+                container instances in cluster
+        """
+
+
+        def checkContainerInstanceTaskStatus(Ec2InstanceId):
+            containerInstanceId = None
+            clusterName = os.environ["ECS_CLUSTER"]
+            tmpMsgAppend = None
+
+            # Get list of container instance IDs from the clusterName
+            clusterListResp = ecsClient.list_container_instances(cluster=clusterName)
+            containerDetResp = ecsClient.describe_container_instances(
+                cluster=clusterName, containerInstances=clusterListResp["containerInstanceArns"]
+            )
+            logger.debug("describe container instances response %s", containerDetResp)
+
+            for containerInstances in containerDetResp["containerInstances"]:
+                logger.debug(
+                    "Container Instance ARN: %s and ec2 Instance ID %s",
+                    containerInstances["containerInstanceArn"],
+                    containerInstances["ec2InstanceId"],
+                )
+                if containerInstances["ec2InstanceId"] == Ec2InstanceId:
+                    logger.info(
+                        "Container instance ID of interest : %s",
+                        containerInstances["containerInstanceArn"],
+                    )
+                    containerInstanceId = containerInstances["containerInstanceArn"]
+
+                    # Check if the instance state is set to DRAINING. If not, set it, so the
+                    # ECS Cluster will handle de-registering instance, draining tasks and
+                    # draining them
+                    containerStatus = containerInstances["status"]
+                    if containerStatus == "DRAINING":
+                        logger.info(
+                            "Container ID %s with EC2 instance-id %s is draining tasks",
+                            containerInstanceId,
+                            Ec2InstanceId,
+                        )
+                        tmpMsgAppend = {"containerInstanceId": containerInstanceId}
+                    else:
+                        # Make ECS API call to set the container status to DRAINING
+                        logger.info(
+                            "Make ECS API call to set the container status to DRAINING..."
+                        )
+                        ecsClient.update_container_instances_state(
+                            cluster=clusterName,
+                            containerInstances=[containerInstanceId],
+                            status="DRAINING",
+                        )
+                        # When you set instance state to draining, append the
+                        # containerInstanceID to the message as well
+                        tmpMsgAppend = {"containerInstanceId": containerInstanceId}
+
+            # Using container Instance ID, get the task list, and task running on that instance.
+            if containerInstanceId is not None:
+                # List tasks on the container instance ID, to get task Arns
+                listTaskResp = ecsClient.list_tasks(
+                    cluster=clusterName, containerInstance=containerInstanceId
+                )
+                logger.debug("Container instance task list %s", listTaskResp["taskArns"])
+
+                # If the chosen instance has tasks
+                if len(listTaskResp["taskArns"]) > 0:
+                    logger.info("Tasks are on this instance...%s", Ec2InstanceId)
+                    return 1, tmpMsgAppend
+                else:
+                    logger.info("NO tasks are on this instance...%s", Ec2InstanceId)
+                    return 0, tmpMsgAppend
+            else:
+                logger.info("NO tasks are on this instance....%s", Ec2InstanceId)
+                return 0, tmpMsgAppend
+
+
+        def lambda_handler(event, context):
+
+            line = event["Records"][0]["Sns"]["Message"]
+            message = json.loads(line)
+            Ec2InstanceId = message["EC2InstanceId"]
+            asgGroupName = message["AutoScalingGroupName"]
+            snsArn = event["Records"][0]["EventSubscriptionArn"]
+            TopicArn = event["Records"][0]["Sns"]["TopicArn"]
+
+            # lifecyclehookname = None
+            clusterName = os.environ["ECS_CLUSTER"]
+            tmpMsgAppend = None
+            # completeHook = 0
+
+            logger.info("Lambda received the event %s", event)
+            logger.debug("records: %s", event["Records"][0])
+            logger.debug("sns: %s", event["Records"][0]["Sns"])
+            logger.debug("Message: %s", message)
+            logger.debug("Ec2 Instance Id %s ,%s", Ec2InstanceId, asgGroupName)
+            logger.debug("Ecs Cluster Name %s", clusterName)
+            logger.debug("SNS ARN %s", snsArn)
+
+            # Get list of container instance IDs from the clusterName
+            clusterListResp = ecsClient.list_container_instances(cluster=clusterName)
+            logger.debug("list container instances response %s", clusterListResp)
+
+            # If the event received is instance terminating...
+            if "LifecycleTransition" in message.keys():
+                logger.debug("message autoscaling %s", message["LifecycleTransition"])
+                if (
+                    message["LifecycleTransition"].find("autoscaling:EC2_INSTANCE_TERMINATING")
+                    > -1
+                ):
+
+                    # Get lifecycle hook name
+                    lifecycleHookName = message["LifecycleHookName"]
+                    logger.debug("Setting lifecycle hook name %s ", lifecycleHookName)
+
+                    # Check if there are any tasks running on the instance
+                    tasksRunning, tmpMsgAppend = checkContainerInstanceTaskStatus(Ec2InstanceId)
+                    logger.debug("Returned values received: %s ", tasksRunning)
+                    if tmpMsgAppend is not None:
+                        message.update(tmpMsgAppend)
+
+                    # If tasks are still running...
+                    if tasksRunning == 1:
+                        logger.info("SQS delayed callback to %s...", TopicArn)
+                        time.sleep(5)
+                        msgResponse = publishToSNS(message, TopicArn)
+                        logger.debug(
+                            "msgResponse %s and time is %s", msgResponse, datetime.datetime
+                        )
+                    # If tasks are NOT running...
+                    elif tasksRunning == 0:
+                        # completeHook = 1
+                        logger.debug(
+                            (
+                                "Setting lifecycle to complete;No tasks are running "
+                                "on instance, completing lifecycle action...."
+                            )
+                        )
+
+                        try:
+                            response = asgClient.complete_lifecycle_action(
+                                LifecycleHookName=lifecycleHookName,
+                                AutoScalingGroupName=asgGroupName,
+                                LifecycleActionResult="CONTINUE",
+                                InstanceId=Ec2InstanceId,
+                            )
+                            logger.info(
+                                "Response received from complete_lifecycle_action %s", response
+                            )
+                            logger.info("Completedlifecycle hook action")
+                        except Exception as e:
+                            print(str(e))
+      MemorySize: 256
+      Policies:
+        - Statement:
+            - Action:
+                - ec2:DescribeInstances
+                - ec2:DescribeInstanceAttribute
+                - ec2:DescribeInstanceStatus
+                - ec2:DescribeHosts
+                - ecs:DescribeContainerInstances
+                - ecs:DescribeTasks
+                - ecs:ListContainerInstances
+                - ecs:ListTasks
+                - sns:ListSubscriptions
+              Effect: Allow
+              Resource: "*"
+          Version: "2012-10-17"
+        - Statement:
+            - Action:
+                - autoscaling:CompleteLifecycleAction
+              Effect: Allow
+              Resource: "*" # TODO: how to get an ASG ARN?
+          Version: "2012-10-17"
+        - Statement:
+            - Action:
+                - ecs:SubmitContainerStateChange
+                - ecs:SubmitTaskStateChange
+                - ecs:UpdateContainerInstancesState
+              Effect: Allow
+              Resource:
+                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${EcsClusterName}
+                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:container-instance/*
+                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:container/*
+                - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/*
+          Version: "2012-10-17"
+        - Statement:
+            - Action:
+                - sns:Publish
+              Effect: Allow
+              Resource:
+                - !Ref ECSDrainSNSTopic
+          Version: "2012-10-17"
+      Runtime: python3.9
+      Tags:
+        prx:meta:tagging-version: "2021-04-07"
+        prx:cloudformation:stack-name: !Ref AWS::StackName
+        prx:cloudformation:stack-id: !Ref AWS::StackId
+        prx:cloudformation:root-stack-name: !Ref RootStackName
+        prx:cloudformation:root-stack-id: !Ref RootStackId
+        prx:ops:environment: !Ref EnvironmentType
+        prx:dev:application: Common
+      Timeout: 300
+  ECSDrainLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${ECSDrainFunction}
+      RetentionInDays: 30
+  ECSDrainLogGroupTags:
+    Type: Custom::CloudWatchLogGroupTags
+    Properties:
+      ServiceToken: !Ref CloudWatchLogGroupTaggerServiceToken
+      LogGroupName: !Ref ECSDrainLogGroup
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+
   # This adds a rule to the load balancer security group defined in
   # shared-alb.yml. It allows all TCP egress traffic from the load balancer
   # security group to the instance security group (i.e., allows traffic from

--- a/stacks/shared-ecs/asg.yml
+++ b/stacks/shared-ecs/asg.yml
@@ -104,6 +104,7 @@ Resources:
   # terminate. Should keep an eye on the github issue for less-DIY support of this
   # functionality: https://github.com/aws/containers-roadmap/issues/256
   ECSDrainSNSTopic:
+    Condition: IsStaging
     Type: AWS::SNS::Topic
     Properties:
       Tags:
@@ -115,6 +116,7 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
   ECSDrainSNSRole:
+    Condition: IsStaging
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -138,6 +140,7 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
   ECSDrainHook:
+    Condition: IsStaging
     Type: AWS::AutoScaling::LifecycleHook
     Properties:
       AutoScalingGroupName: !Ref Asg
@@ -147,6 +150,7 @@ Resources:
       NotificationTargetARN: !Ref ECSDrainSNSTopic
       RoleARN: !GetAtt ECSDrainSNSRole.Arn
   ECSDrainFunction:
+    Condition: IsStaging
     Type: AWS::Serverless::Function
     Properties:
       Description: Drain tasks off ECS instances before allowing them to terminate
@@ -402,11 +406,13 @@ Resources:
         prx:dev:application: Common
       Timeout: 300
   ECSDrainLogGroup:
+    Condition: IsStaging
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${ECSDrainFunction}
       RetentionInDays: 30
   ECSDrainLogGroupTags:
+    Condition: IsStaging
     Type: Custom::CloudWatchLogGroupTags
     Properties:
       ServiceToken: !Ref CloudWatchLogGroupTaggerServiceToken


### PR DESCRIPTION
Bring back the [ECS task draining](https://github.com/PRX/Infrastructure/blob/bcdbefed9ad2cddf5bc8d1112b254918789e06c1/stacks/ecs.yml#L653) lambda/SQS.  Attempts to convert to `AWS::Serverless::Function` - we'll see if that works!

Just staging for now.