### PR TITLE
Feat/bump augury webs

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -95,7 +95,7 @@ Resources:
     Properties:
       HealthCheckIntervalSeconds: 15
       HealthCheckPath: /health_check
-      HealthCheckTimeoutSeconds: 5
+      HealthCheckTimeoutSeconds: 30
       HealthyThresholdCount: 2
       Port: 80
       Protocol: HTTP
@@ -113,7 +113,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Augury }
       TargetType: instance
-      UnhealthyThresholdCount: 12
+      UnhealthyThresholdCount: 10
       VpcId: !Ref VpcId
   TargetGroupHttp5xxAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -113,7 +113,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Augury }
       TargetType: instance
-      UnhealthyThresholdCount: 6
+      UnhealthyThresholdCount: 12
       VpcId: !Ref VpcId
   TargetGroupHttp5xxAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -214,7 +214,7 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
-      DesiredCount: !If [IsProduction, 4, 2]
+      DesiredCount: !If [IsProduction, 12, 2]
       EnableECSManagedTags: true
       LoadBalancers:
         - ContainerName: !Ref kWebContainerName


### PR DESCRIPTION
Since most of the Augury activity is clustered around "bursts" late in the day UTC,  Let the auto scaler increment the number of web nodes to handle the "open in tabs and modify" behavior.

The flip side is that when more if the performance enhancements land on Augury we can tune this back down. 