### PR TITLE
Bump the evaluation periods to silence EOD alarm

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -559,7 +559,7 @@ Resources:
         ${EnvironmentType} Augury's worker task has not logged any forecast
         actvitiy for an unusually long time. Inventory is slowly becoming stale.
       ComparisonOperator: LessThanThreshold
-      EvaluationPeriods: 3
+      EvaluationPeriods: 4
       MetricName: !Sub ForecastJobElapsed${EnvironmentType}
       Namespace: PRX/Augury
       Period: !If [IsProduction, 900, 5400]


### PR DESCRIPTION
Every day, in the forecasting quiescence of UTC evening, the forecast alarm goes off.  This PR adds another evaluation period, to make sure we are sampling slowly enough that a false positive is not triggered in the lull.
