### PR TITLE
Analytics kinesis streams

### DIFF
--- a/stacks/apps-100A.yml
+++ b/stacks/apps-100A.yml
@@ -53,9 +53,9 @@ Parameters:
   MediajointS3BucketArn: { Type: String }
   NetworksS3BucketArn: { Type: String }
   WfmtServicesS3BucketArn: { Type: String }
-  CountsBytesKinesisStreamArn: { Type: String }
-  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
-  AnalyticsMetricsKinesisStreamArn: { Type: String }
+  DovetailCdnLogsKinesisStreamArn: { Type: String }
+  DovetailCountedKinesisStreamArn: { Type: String }
+  DovetailVerifiedMetricsKinesisStreamArn: { Type: String }
 
   CmsEcrImageTag: { Type: String }
   CmsSecretsVersion: { Type: String }
@@ -206,8 +206,8 @@ Resources:
         DovetailS3Bucket: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/S3_BUCKET
         DovetailS3ObjectStitchPrefix: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/S3_PREFIX
         DovetailCdnLogsKinesisArn: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/KINESIS_IN # TODO: remove
-        CountsBytesKinesisStreamArn: !Ref CountsBytesKinesisStreamArn
-        AnalyticsDynamoDBKinesisStreamArn: !Ref AnalyticsDynamoDBKinesisStreamArn
+        DovetailCdnLogsKinesisStreamArn: !Ref DovetailCdnLogsKinesisStreamArn
+        DovetailCountedKinesisStreamArn: !Ref DovetailCountedKinesisStreamArn
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         SharedRedisClientSecurityGroupId: !Ref SharedRedisClientSecurityGroupId
@@ -238,7 +238,7 @@ Resources:
         CloudWatchLogGroupTaggerServiceToken: !Ref CloudWatchLogGroupTaggerServiceToken
         CodeS3Bucket: !Ref DeploymentPackageBucketName
         CodeS3ObjectKey: !Ref DovetailTrafficLambdaCodeS3ObjectKey
-        MetricsKinesisStreamArn: !Ref AnalyticsMetricsKinesisStreamArn
+        DovetailVerifiedMetricsKinesisStreamArn: !Ref DovetailVerifiedMetricsKinesisStreamArn
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/apps-100A.yml
+++ b/stacks/apps-100A.yml
@@ -205,7 +205,7 @@ Resources:
         ArrangementsDynamodbAccessRoleArn: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-cdn-arranger/ARRANGEMENTS_DDB_ACCESS_ROLE
         DovetailS3Bucket: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/S3_BUCKET
         DovetailS3ObjectStitchPrefix: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/S3_PREFIX
-        DovetailCdnLogsKinesisArn: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/KINESIS_IN
+        DovetailCdnLogsKinesisArn: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/KINESIS_IN # TODO: remove
         CountsBytesKinesisStreamArn: !Ref CountsBytesKinesisStreamArn
         AnalyticsDynamoDBKinesisStreamArn: !Ref AnalyticsDynamoDBKinesisStreamArn
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress

--- a/stacks/apps-100A.yml
+++ b/stacks/apps-100A.yml
@@ -53,6 +53,9 @@ Parameters:
   MediajointS3BucketArn: { Type: String }
   NetworksS3BucketArn: { Type: String }
   WfmtServicesS3BucketArn: { Type: String }
+  CountsBytesKinesisStreamArn: { Type: String }
+  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
+  AnalyticsMetricsKinesisStreamArn: { Type: String }
 
   CmsEcrImageTag: { Type: String }
   CmsSecretsVersion: { Type: String }
@@ -203,7 +206,8 @@ Resources:
         DovetailS3Bucket: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/S3_BUCKET
         DovetailS3ObjectStitchPrefix: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/S3_PREFIX
         DovetailCdnLogsKinesisArn: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/KINESIS_IN
-        DovetailCountedBytesKinesisArn: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-counts-lambda/KINESIS_OUT
+        CountsBytesKinesisStreamArn: !Ref CountsBytesKinesisStreamArn
+        AnalyticsDynamoDBKinesisStreamArn: !Ref AnalyticsDynamoDBKinesisStreamArn
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         SharedRedisClientSecurityGroupId: !Ref SharedRedisClientSecurityGroupId
@@ -234,7 +238,7 @@ Resources:
         CloudWatchLogGroupTaggerServiceToken: !Ref CloudWatchLogGroupTaggerServiceToken
         CodeS3Bucket: !Ref DeploymentPackageBucketName
         CodeS3ObjectKey: !Ref DovetailTrafficLambdaCodeS3ObjectKey
-        MetricsKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/dovetail-traffic-lambda/METRICS_KINESIS_STREAM
+        MetricsKinesisStreamArn: !Ref AnalyticsMetricsKinesisStreamArn
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -59,10 +59,10 @@ Parameters:
   SharedGlueDatabaseName: { Type: String }
   AdFilesS3BucketArn: { Type: String }
   FeedsS3BucketArn: { Type: String }
-  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
-  AnalyticsDynamoDBKinesisStreamName: { Type: String }
-  AnalyticsMetricsKinesisStreamArn: { Type: String }
-  AnalyticsMetricsKinesisStreamName: { Type: String }
+  DovetailCountedKinesisStreamArn: { Type: String }
+  DovetailCountedKinesisStreamName: { Type: String }
+  DovetailVerifiedMetricsKinesisStreamArn: { Type: String }
+  DovetailVerifiedMetricsKinesisStreamName: { Type: String }
 
   AuguryEcrImageTag: { Type: String }
   AugurySecretsVersion: { Type: String }
@@ -156,14 +156,14 @@ Resources:
         VpcPrivateSubnet2Id: !Ref VpcPrivateSubnet2Id
         VpcPrivateSubnet3Id: !Ref VpcPrivateSubnet3Id
         MetricsKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM # TODO: remove
-        AnalyticsMetricsKinesisStreamArn: !Ref AnalyticsMetricsKinesisStreamArn
-        AnalyticsMetricsKinesisStreamName: !Ref AnalyticsMetricsKinesisStreamName
+        DovetailVerifiedMetricsKinesisStreamArn: !Ref DovetailVerifiedMetricsKinesisStreamArn
+        DovetailVerifiedMetricsKinesisStreamName: !Ref DovetailVerifiedMetricsKinesisStreamName
         SharedRedisClientSecurityGroupId: !Ref SharedRedisClientSecurityGroupId
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         DynamoDbKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM # TODO: remove
-        AnalyticsDynamoDBKinesisStreamArn: !Ref AnalyticsDynamoDBKinesisStreamArn
-        AnalyticsDynamoDBKinesisStreamName: !Ref AnalyticsDynamoDBKinesisStreamName
+        DovetailCountedKinesisStreamArn: !Ref DovetailCountedKinesisStreamArn
+        DovetailCountedKinesisStreamName: !Ref DovetailCountedKinesisStreamName
         DynamoDbTableName: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME
         DynamoDbTtl: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TTL
         DynamoDbAccessRoleArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_ACCESS_ROLE
@@ -204,7 +204,7 @@ Resources:
         VpcPublicSubnet2Id: !Ref VpcPublicSubnet2Id
         VpcPublicSubnet3Id: !Ref VpcPublicSubnet3Id
         SharedEcsAsgInstanceSecurityGroupId: !Ref SharedEcsAsgInstanceSecurityGroupId
-        DynamoDbKinesisStreamArn: !Ref AnalyticsDynamoDBKinesisStreamArn
+        DovetailCountedKinesisStreamArn: !Ref DovetailCountedKinesisStreamArn
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         SharedGlueDatabaseName: !Ref SharedGlueDatabaseName

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -59,6 +59,10 @@ Parameters:
   SharedGlueDatabaseName: { Type: String }
   AdFilesS3BucketArn: { Type: String }
   FeedsS3BucketArn: { Type: String }
+  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
+  AnalyticsDynamoDBKinesisStreamName: { Type: String }
+  AnalyticsMetricsKinesisStreamArn: { Type: String }
+  AnalyticsMetricsKinesisStreamName: { Type: String }
 
   AuguryEcrImageTag: { Type: String }
   AugurySecretsVersion: { Type: String }
@@ -151,11 +155,15 @@ Resources:
         VpcPrivateSubnet1Id: !Ref VpcPrivateSubnet1Id
         VpcPrivateSubnet2Id: !Ref VpcPrivateSubnet2Id
         VpcPrivateSubnet3Id: !Ref VpcPrivateSubnet3Id
-        MetricsKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM
+        MetricsKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/METRICS_KINESIS_STREAM # TODO: remove
+        AnalyticsMetricsKinesisStreamArn: !Ref AnalyticsMetricsKinesisStreamArn
+        AnalyticsMetricsKinesisStreamName: !Ref AnalyticsMetricsKinesisStreamName
         SharedRedisClientSecurityGroupId: !Ref SharedRedisClientSecurityGroupId
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
-        DynamoDbKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM
+        DynamoDbKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM # TODO: remove
+        AnalyticsDynamoDBKinesisStreamArn: !Ref AnalyticsDynamoDBKinesisStreamArn
+        AnalyticsDynamoDBKinesisStreamName: !Ref AnalyticsDynamoDBKinesisStreamName
         DynamoDbTableName: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TABLE_NAME
         DynamoDbTtl: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_TTL
         DynamoDbAccessRoleArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_ACCESS_ROLE
@@ -196,7 +204,7 @@ Resources:
         VpcPublicSubnet2Id: !Ref VpcPublicSubnet2Id
         VpcPublicSubnet3Id: !Ref VpcPublicSubnet3Id
         SharedEcsAsgInstanceSecurityGroupId: !Ref SharedEcsAsgInstanceSecurityGroupId
-        DynamoDbKinesisStreamArn: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-ingest-lambda/DYNAMODB_KINESIS_STREAM
+        DynamoDbKinesisStreamArn: !Ref AnalyticsDynamoDBKinesisStreamArn
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         SharedGlueDatabaseName: !Ref SharedGlueDatabaseName

--- a/stacks/apps/dovetail-analytics.yml
+++ b/stacks/apps/dovetail-analytics.yml
@@ -26,10 +26,14 @@ Parameters:
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   MetricsKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
+  AnalyticsMetricsKinesisStreamArn: { Type: String }
+  AnalyticsMetricsKinesisStreamName: { Type: String }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
   DynamoDbKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
+  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
+  AnalyticsDynamoDBKinesisStreamName: { Type: String }
   DynamoDbTableName: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbTtl: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbAccessRoleArn: { Type: AWS::SSM::Parameter::Value<String> }
@@ -38,39 +42,6 @@ Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
 
 Resources:
-  AnalyticsDynamoDBKinesisStream:
-    Type: AWS::Kinesis::Stream
-    Properties:
-      RetentionPeriodHours: 24
-      ShardCount: 2
-      StreamModeDetails:
-        StreamMode: PROVISIONED
-      Tags:
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Analytics }
-  AnalyticsMetricsKinesisStream:
-    Type: AWS::Kinesis::Stream
-    Properties:
-      RetentionPeriodHours: 24
-      ShardCount: 2
-      StreamModeDetails:
-        StreamMode: PROVISIONED
-      Tags:
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Analytics }
-
   ParameterStoreReadPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -111,7 +82,7 @@ Resources:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
-            Stream: !GetAtt AnalyticsMetricsKinesisStream.Arn
+            Stream: !Ref AnalyticsMetricsKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -413,7 +384,7 @@ Resources:
             BatchSize: 50
             Enabled: true
             StartingPosition: LATEST
-            Stream: !GetAtt AnalyticsDynamoDBKinesisStream.Arn
+            Stream: !Ref AnalyticsDynamoDBKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -509,7 +480,7 @@ Resources:
                   - kinesis:DescribeStream
                   - kinesis:PutRecord
                   - kinesis:PutRecords
-                Resource: !GetAtt AnalyticsMetricsKinesisStream.Arn
+                Resource: !Ref AnalyticsMetricsKinesisStreamArn
             Version: "2012-10-17"
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -524,7 +495,7 @@ Resources:
     # Send impression data from DynamoDB Lambda function's logs to Kinesis
     Type: AWS::Logs::SubscriptionFilter
     Properties:
-      DestinationArn: !GetAtt AnalyticsMetricsKinesisStream.Arn
+      DestinationArn: !Ref AnalyticsMetricsKinesisStreamArn
       FilterPattern: "{$.msg = impression}"
       LogGroupName: !Ref AnalyticsDynamoDbFunctionLogGroup
       RoleArn: !GetAtt AnalyticsDynamoDbFunctionLogGroupToKinesisSubscriptionFilterRole.Arn
@@ -700,7 +671,7 @@ Resources:
             BatchSize: 25
             Enabled: true
             StartingPosition: LATEST
-            Stream: !GetAtt AnalyticsMetricsKinesisStream.Arn
+            Stream: !Ref AnalyticsMetricsKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 2048
@@ -1002,7 +973,7 @@ Resources:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
-            Stream: !GetAtt AnalyticsMetricsKinesisStream.Arn
+            Stream: !Ref AnalyticsMetricsKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -1449,6 +1420,6 @@ Resources:
               }
             ]
           }
-        - DdbStreamName: !Ref AnalyticsDynamoDBKinesisStream
-          MetricsStreamName: !Ref AnalyticsMetricsKinesisStream
+        - DdbStreamName: !Ref AnalyticsDynamoDBKinesisStreamName
+          MetricsStreamName: !Ref AnalyticsMetricsKinesisStreamName
       DashboardName: !Sub ${RootStackName}-${AWS::Region}-Dovetail-Analytics

--- a/stacks/apps/dovetail-analytics.yml
+++ b/stacks/apps/dovetail-analytics.yml
@@ -25,11 +25,11 @@ Parameters:
   VpcPrivateSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
-  MetricsKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
+  MetricsKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
-  DynamoDbKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
+  DynamoDbKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
   DynamoDbTableName: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbTtl: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbAccessRoleArn: { Type: AWS::SSM::Parameter::Value<String> }
@@ -38,6 +38,39 @@ Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
 
 Resources:
+  AnalyticsDynamoDBKinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      RetentionPeriodHours: 24
+      ShardCount: 2
+      StreamModeDetails:
+        StreamMode: PROVISIONED
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Analytics }
+  AnalyticsMetricsKinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      RetentionPeriodHours: 24
+      ShardCount: 2
+      StreamModeDetails:
+        StreamMode: PROVISIONED
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Analytics }
+
   ParameterStoreReadPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -66,12 +99,19 @@ Resources:
           # TODO: get these out of the code and into CFN somehow
           PARAMSTORE_PREFIX: !Sub /prx/${EnvironmentTypeAbbreviation}/analytics-bigquery
       Events:
-        KinesisTrigger:
+        KinesisTrigger: # TODO: remove
           Properties:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
             Stream: !Ref MetricsKinesisStreamArn
+          Type: Kinesis
+        MetricsKinesisTrigger:
+          Properties:
+            BatchSize: 100
+            Enabled: true
+            StartingPosition: LATEST
+            Stream: !GetAtt AnalyticsMetricsKinesisStream.Arn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -361,12 +401,19 @@ Resources:
           DDB_ROLE: !Ref DynamoDbAccessRoleArn
           DDB_TTL: !Ref DynamoDbTtl
       Events:
-        KinesisTrigger:
+        KinesisTrigger: # TODO: remove
           Properties:
             BatchSize: 50
             Enabled: true
             StartingPosition: LATEST
             Stream: !Ref DynamoDbKinesisStreamArn
+          Type: Kinesis
+        DynamodbKinesisTrigger:
+          Properties:
+            BatchSize: 50
+            Enabled: true
+            StartingPosition: LATEST
+            Stream: !GetAtt AnalyticsDynamoDBKinesisStream.Arn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -462,7 +509,7 @@ Resources:
                   - kinesis:DescribeStream
                   - kinesis:PutRecord
                   - kinesis:PutRecords
-                Resource: !Ref MetricsKinesisStreamArn
+                Resource: !GetAtt AnalyticsMetricsKinesisStream.Arn
             Version: "2012-10-17"
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -477,7 +524,7 @@ Resources:
     # Send impression data from DynamoDB Lambda function's logs to Kinesis
     Type: AWS::Logs::SubscriptionFilter
     Properties:
-      DestinationArn: !Ref MetricsKinesisStreamArn
+      DestinationArn: !GetAtt AnalyticsMetricsKinesisStream.Arn
       FilterPattern: "{$.msg = impression}"
       LogGroupName: !Ref AnalyticsDynamoDbFunctionLogGroup
       RoleArn: !GetAtt AnalyticsDynamoDbFunctionLogGroupToKinesisSubscriptionFilterRole.Arn
@@ -606,7 +653,8 @@ Resources:
           MetricValue: $.rows
 
   AnalyticsDynamoDbFunctionLookupsMetricFilter:
-    # I don't know what this one does
+    # Count the number of redirect-datas we've looked up and shuffeld along to
+    # the metrics-kinesis stream
     Type: AWS::Logs::MetricFilter
     Properties:
       FilterPattern: '{ $.dest = "kinesis*" }'
@@ -640,12 +688,19 @@ Resources:
         Variables:
           PINGBACKS: "true"
       Events:
-        KinesisTrigger:
+        KinesisTrigger: # TODO: remove
           Properties:
             BatchSize: 25
             Enabled: true
             StartingPosition: LATEST
             Stream: !Ref MetricsKinesisStreamArn
+          Type: Kinesis
+        MetricsKinesisTrigger:
+          Properties:
+            BatchSize: 25
+            Enabled: true
+            StartingPosition: LATEST
+            Stream: !GetAtt AnalyticsMetricsKinesisStream.Arn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 2048
@@ -935,12 +990,19 @@ Resources:
           REDIS_IMPRESSIONS_HOST: !Sub cluster://${SharedRedisReplicationGroupEndpointAddress}:${SharedRedisReplicationGroupEndpointPort}
           REDIS_IMPRESSIONS_TTL: "90000"
       Events:
-        KinesisTrigger:
+        KinesisTrigger: # TODO: remove
           Properties:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
             Stream: !Ref MetricsKinesisStreamArn
+          Type: Kinesis
+        MetricsKinesisTrigger:
+          Properties:
+            BatchSize: 100
+            Enabled: true
+            StartingPosition: LATEST
+            Stream: !GetAtt AnalyticsMetricsKinesisStream.Arn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -1387,6 +1449,6 @@ Resources:
               }
             ]
           }
-        - DdbStreamName: !Select [1, !Split [":stream/", !Ref DynamoDbKinesisStreamArn]]
-          MetricsStreamName: !Select [1, !Split [":stream/", !Ref MetricsKinesisStreamArn]]
+        - DdbStreamName: !Ref AnalyticsDynamoDBKinesisStream
+          MetricsStreamName: !Ref AnalyticsMetricsKinesisStream
       DashboardName: !Sub ${RootStackName}-${AWS::Region}-Dovetail-Analytics

--- a/stacks/apps/dovetail-analytics.yml
+++ b/stacks/apps/dovetail-analytics.yml
@@ -26,14 +26,14 @@ Parameters:
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   MetricsKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
-  AnalyticsMetricsKinesisStreamArn: { Type: String }
-  AnalyticsMetricsKinesisStreamName: { Type: String }
+  DovetailVerifiedMetricsKinesisStreamArn: { Type: String }
+  DovetailVerifiedMetricsKinesisStreamName: { Type: String }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
   DynamoDbKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
-  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
-  AnalyticsDynamoDBKinesisStreamName: { Type: String }
+  DovetailCountedKinesisStreamArn: { Type: String }
+  DovetailCountedKinesisStreamName: { Type: String }
   DynamoDbTableName: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbTtl: { Type: AWS::SSM::Parameter::Value<String> }
   DynamoDbAccessRoleArn: { Type: AWS::SSM::Parameter::Value<String> }
@@ -82,7 +82,7 @@ Resources:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
-            Stream: !Ref AnalyticsMetricsKinesisStreamArn
+            Stream: !Ref DovetailVerifiedMetricsKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -384,7 +384,7 @@ Resources:
             BatchSize: 50
             Enabled: true
             StartingPosition: LATEST
-            Stream: !Ref AnalyticsDynamoDBKinesisStreamArn
+            Stream: !Ref DovetailCountedKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -480,7 +480,7 @@ Resources:
                   - kinesis:DescribeStream
                   - kinesis:PutRecord
                   - kinesis:PutRecords
-                Resource: !Ref AnalyticsMetricsKinesisStreamArn
+                Resource: !Ref DovetailVerifiedMetricsKinesisStreamArn
             Version: "2012-10-17"
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -495,7 +495,7 @@ Resources:
     # Send impression data from DynamoDB Lambda function's logs to Kinesis
     Type: AWS::Logs::SubscriptionFilter
     Properties:
-      DestinationArn: !Ref AnalyticsMetricsKinesisStreamArn
+      DestinationArn: !Ref DovetailVerifiedMetricsKinesisStreamArn
       FilterPattern: "{$.msg = impression}"
       LogGroupName: !Ref AnalyticsDynamoDbFunctionLogGroup
       RoleArn: !GetAtt AnalyticsDynamoDbFunctionLogGroupToKinesisSubscriptionFilterRole.Arn
@@ -671,7 +671,7 @@ Resources:
             BatchSize: 25
             Enabled: true
             StartingPosition: LATEST
-            Stream: !Ref AnalyticsMetricsKinesisStreamArn
+            Stream: !Ref DovetailVerifiedMetricsKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 2048
@@ -973,7 +973,7 @@ Resources:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
-            Stream: !Ref AnalyticsMetricsKinesisStreamArn
+            Stream: !Ref DovetailVerifiedMetricsKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       MemorySize: 512
@@ -1420,6 +1420,6 @@ Resources:
               }
             ]
           }
-        - DdbStreamName: !Ref AnalyticsDynamoDBKinesisStreamName
-          MetricsStreamName: !Ref AnalyticsMetricsKinesisStreamName
+        - DdbStreamName: !Ref DovetailCountedKinesisStreamName
+          MetricsStreamName: !Ref DovetailVerifiedMetricsKinesisStreamName
       DashboardName: !Sub ${RootStackName}-${AWS::Region}-Dovetail-Analytics

--- a/stacks/apps/dovetail-counts.yml
+++ b/stacks/apps/dovetail-counts.yml
@@ -33,8 +33,8 @@ Parameters:
   ArrangementsDynamodbAccessRoleArn: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailS3Bucket: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailS3ObjectStitchPrefix: { Type: AWS::SSM::Parameter::Value<String> }
-  DovetailCdnLogsKinesisArn: { Type: AWS::SSM::Parameter::Value<String> }
-  DovetailCountedBytesKinesisArn: { Type: AWS::SSM::Parameter::Value<String> }
+  DovetailCdnLogsKinesisArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
+  DovetailCountedBytesKinesisArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: route from analytics-ingest stack
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
@@ -43,6 +43,23 @@ Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
 
 Resources:
+  CountsBytesKinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      RetentionPeriodHours: 24
+      ShardCount: 1
+      StreamModeDetails:
+        StreamMode: PROVISIONED
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Counts }
+
   CountsFunctionSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -91,6 +108,13 @@ Resources:
             Enabled: true
             StartingPosition: LATEST
             Stream: !Ref DovetailCdnLogsKinesisArn
+          Type: Kinesis
+        CountsBytesKinesisTrigger:
+          Properties:
+            BatchSize: 100
+            Enabled: true
+            StartingPosition: LATEST
+            Stream: !GetAtt CountsBytesKinesisStream.Arn
           Type: Kinesis
       Handler: index.handler
       Layers:

--- a/stacks/apps/dovetail-counts.yml
+++ b/stacks/apps/dovetail-counts.yml
@@ -34,7 +34,8 @@ Parameters:
   DovetailS3Bucket: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailS3ObjectStitchPrefix: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailCdnLogsKinesisArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
-  DovetailCountedBytesKinesisArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: route from analytics-ingest stack
+  CountsBytesKinesisStreamArn: { Type: String }
+  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
@@ -43,23 +44,6 @@ Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
 
 Resources:
-  CountsBytesKinesisStream:
-    Type: AWS::Kinesis::Stream
-    Properties:
-      RetentionPeriodHours: 24
-      ShardCount: 1
-      StreamModeDetails:
-        StreamMode: PROVISIONED
-      Tags:
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Counts }
-
   CountsFunctionSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -97,7 +81,7 @@ Resources:
           ARRANGEMENTS_DDB_ACCESS_ROLE: !Ref ArrangementsDynamodbAccessRoleArn
           ARRANGEMENTS_DDB_REGION: !Ref ArrangementsDynamodbRegion
           ARRANGEMENTS_DDB_TABLE: !Ref ArrangementsDynamodbTableName
-          KINESIS_IMPRESSION_STREAM: !Ref DovetailCountedBytesKinesisArn
+          KINESIS_IMPRESSION_STREAM: !Ref AnalyticsDynamoDBKinesisStreamArn
           REDIS_URL: !Sub cluster://${SharedRedisReplicationGroupEndpointAddress}:${SharedRedisReplicationGroupEndpointPort}
           S3_BUCKET: !Ref DovetailS3Bucket
           S3_PREFIX: !Ref DovetailS3ObjectStitchPrefix
@@ -114,7 +98,7 @@ Resources:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
-            Stream: !GetAtt CountsBytesKinesisStream.Arn
+            Stream: !Ref CountsBytesKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       Layers:
@@ -140,7 +124,7 @@ Resources:
                 - kinesis:PutRecord
                 - kinesis:PutRecords
               Effect: Allow
-              Resource: !Ref DovetailCountedBytesKinesisArn
+              Resource: !Ref AnalyticsDynamoDBKinesisStreamArn
           Version: "2012-10-17"
       Tags:
         prx:meta:tagging-version: "2021-04-07"

--- a/stacks/apps/dovetail-counts.yml
+++ b/stacks/apps/dovetail-counts.yml
@@ -34,8 +34,8 @@ Parameters:
   DovetailS3Bucket: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailS3ObjectStitchPrefix: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailCdnLogsKinesisArn: { Type: AWS::SSM::Parameter::Value<String> } # TODO: remove
-  CountsBytesKinesisStreamArn: { Type: String }
-  AnalyticsDynamoDBKinesisStreamArn: { Type: String }
+  DovetailCdnLogsKinesisStreamArn: { Type: String }
+  DovetailCountedKinesisStreamArn: { Type: String }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
@@ -81,7 +81,7 @@ Resources:
           ARRANGEMENTS_DDB_ACCESS_ROLE: !Ref ArrangementsDynamodbAccessRoleArn
           ARRANGEMENTS_DDB_REGION: !Ref ArrangementsDynamodbRegion
           ARRANGEMENTS_DDB_TABLE: !Ref ArrangementsDynamodbTableName
-          KINESIS_IMPRESSION_STREAM: !Ref AnalyticsDynamoDBKinesisStreamArn
+          KINESIS_IMPRESSION_STREAM: !Ref DovetailCountedKinesisStreamArn
           REDIS_URL: !Sub cluster://${SharedRedisReplicationGroupEndpointAddress}:${SharedRedisReplicationGroupEndpointPort}
           S3_BUCKET: !Ref DovetailS3Bucket
           S3_PREFIX: !Ref DovetailS3ObjectStitchPrefix
@@ -98,7 +98,7 @@ Resources:
             BatchSize: 100
             Enabled: true
             StartingPosition: LATEST
-            Stream: !Ref CountsBytesKinesisStreamArn
+            Stream: !Ref DovetailCdnLogsKinesisStreamArn
           Type: Kinesis
       Handler: index.handler
       Layers:
@@ -124,7 +124,7 @@ Resources:
                 - kinesis:PutRecord
                 - kinesis:PutRecords
               Effect: Allow
-              Resource: !Ref AnalyticsDynamoDBKinesisStreamArn
+              Resource: !Ref DovetailCountedKinesisStreamArn
           Version: "2012-10-17"
       Tags:
         prx:meta:tagging-version: "2021-04-07"

--- a/stacks/apps/dovetail-router.yml
+++ b/stacks/apps/dovetail-router.yml
@@ -86,7 +86,7 @@ Parameters:
   VpcPublicSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   VpcPublicSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPublicSubnet3Id: { Type: AWS::EC2::Subnet::Id }
-  DynamoDbKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
+  DovetailCountedKinesisStreamArn: { Type: String }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
   SharedGlueDatabaseName: { Type: String }
@@ -1158,7 +1158,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Router }
 
-  # Subscription filter (send logged impression data to Kinesis)
+  # Subscription filter (send logged redirect data to Kinesis)
   SubscriptionFilterRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1178,7 +1178,7 @@ Resources:
                   - kinesis:PutRecord
                   - kinesis:PutRecords
                 Effect: Allow
-                Resource: !Ref DynamoDbKinesisStreamArn
+                Resource: !Ref DovetailCountedKinesisStreamArn
             Version: "2012-10-17"
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -1192,7 +1192,7 @@ Resources:
   SubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Properties:
-      DestinationArn: !Ref DynamoDbKinesisStreamArn
+      DestinationArn: !Ref DovetailCountedKinesisStreamArn
       FilterPattern: '{ $.msg = "impression" }'
       LogGroupName: !Ref TaskLogGroup
       RoleArn: !GetAtt SubscriptionFilterRole.Arn

--- a/stacks/apps/dovetail-traffic.yml
+++ b/stacks/apps/dovetail-traffic.yml
@@ -22,7 +22,7 @@ Parameters:
   CloudWatchLogGroupTaggerServiceToken: { Type: String }
   CodeS3Bucket: { Type: String }
   CodeS3ObjectKey: { Type: String }
-  MetricsKinesisStreamArn: { Type: AWS::SSM::Parameter::Value<String> }
+  DovetailVerifiedMetricsKinesisStreamArn: { Type: String }
 
 Resources:
   TrafficSqsQueue:
@@ -59,7 +59,7 @@ Resources:
             BatchSize: 1000
             Enabled: true
             StartingPosition: LATEST
-            Stream: !Ref MetricsKinesisStreamArn
+            Stream: !Ref DovetailVerifiedMetricsKinesisStreamArn
           Type: Kinesis
         SqsTrigger:
           Properties:

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -310,7 +310,7 @@ Resources:
       TemplateURL: !Sub ${Constants.TemplateUrlBase}/stacks/shared-announce.yml
       TimeoutInMinutes: 10
 
-  SharedKinesisStack:
+  SharedDovetailKinesisStack:
     Type: AWS::CloudFormation::Stack
     Properties:
       NotificationARNs:
@@ -327,8 +327,8 @@ Resources:
         - { Key: prx:cloudformation:root-stack-id, Value: !GetAtt Constants.RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
-      TemplateURL: !Sub ${Constants.TemplateUrlBase}/stacks/shared-kinesis.yml
-      TimeoutInMinutes: 10
+      TemplateURL: !Sub ${Constants.TemplateUrlBase}/stacks/shared-dovetail-kinesis.yml
+      TimeoutInMinutes: 60
 
   SharedEcsClusterStack:
     Type: AWS::CloudFormation::Stack
@@ -648,9 +648,9 @@ Resources:
         MediajointS3BucketArn: !Ref MediajointS3BucketArn
         NetworksS3BucketArn: !Ref NetworksS3BucketArn
         WfmtServicesS3BucketArn: !Ref WfmtServicesS3BucketArn
-        CountsBytesKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.CountsBytesKinesisStreamArn
-        AnalyticsDynamoDBKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsDynamoDBKinesisStreamArn
-        AnalyticsMetricsKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsMetricsKinesisStreamArn
+        DovetailCdnLogsKinesisStreamArn: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailCdnLogsKinesisStreamArn
+        DovetailCountedKinesisStreamArn: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailCountedKinesisStreamArn
+        DovetailVerifiedMetricsKinesisStreamArn: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailVerifiedMetricsKinesisStreamArn
 
         # App-specific parameters
 
@@ -880,10 +880,10 @@ Resources:
         SharedGlueDatabaseName: !GetAtt SharedGlueDatabaseStack.Outputs.SharedGlueDatabaseName
         AdFilesS3BucketArn: !Ref AdFilesS3BucketArn
         FeedsS3BucketArn: !Ref FeedsS3BucketArn
-        AnalyticsDynamoDBKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsDynamoDBKinesisStreamArn
-        AnalyticsDynamoDBKinesisStreamName: !GetAtt SharedKinesisStack.Outputs.AnalyticsDynamoDBKinesisStreamName
-        AnalyticsMetricsKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsMetricsKinesisStreamArn
-        AnalyticsMetricsKinesisStreamName: !GetAtt SharedKinesisStack.Outputs.AnalyticsMetricsKinesisStreamName
+        DovetailCountedKinesisStreamArn: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailCountedKinesisStreamArn
+        DovetailCountedKinesisStreamName: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailCountedKinesisStreamName
+        DovetailVerifiedMetricsKinesisStreamArn: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailVerifiedMetricsKinesisStreamArn
+        DovetailVerifiedMetricsKinesisStreamName: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailVerifiedMetricsKinesisStreamName
 
         # App-specific parameters
 

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -648,6 +648,9 @@ Resources:
         MediajointS3BucketArn: !Ref MediajointS3BucketArn
         NetworksS3BucketArn: !Ref NetworksS3BucketArn
         WfmtServicesS3BucketArn: !Ref WfmtServicesS3BucketArn
+        CountsBytesKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.CountsBytesKinesisStreamArn
+        AnalyticsDynamoDBKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsDynamoDBKinesisStreamArn
+        AnalyticsMetricsKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsMetricsKinesisStreamArn
 
         # App-specific parameters
 
@@ -877,6 +880,10 @@ Resources:
         SharedGlueDatabaseName: !GetAtt SharedGlueDatabaseStack.Outputs.SharedGlueDatabaseName
         AdFilesS3BucketArn: !Ref AdFilesS3BucketArn
         FeedsS3BucketArn: !Ref FeedsS3BucketArn
+        AnalyticsDynamoDBKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsDynamoDBKinesisStreamArn
+        AnalyticsDynamoDBKinesisStreamName: !GetAtt SharedKinesisStack.Outputs.AnalyticsDynamoDBKinesisStreamName
+        AnalyticsMetricsKinesisStreamArn: !GetAtt SharedKinesisStack.Outputs.AnalyticsMetricsKinesisStreamArn
+        AnalyticsMetricsKinesisStreamName: !GetAtt SharedKinesisStack.Outputs.AnalyticsMetricsKinesisStreamName
 
         # App-specific parameters
 

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -310,6 +310,26 @@ Resources:
       TemplateURL: !Sub ${Constants.TemplateUrlBase}/stacks/shared-announce.yml
       TimeoutInMinutes: 10
 
+  SharedKinesisStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      NotificationARNs:
+        - !Ref CloudFormationNotificationsSnsTopicArn
+      Parameters:
+        RootStackName: !GetAtt Constants.RootStackName
+        RootStackId: !GetAtt Constants.RootStackId
+        EnvironmentType: !Ref EnvironmentType
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !GetAtt Constants.RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !GetAtt Constants.RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+      TemplateURL: !Sub ${Constants.TemplateUrlBase}/stacks/shared-kinesis.yml
+      TimeoutInMinutes: 10
+
   SharedEcsClusterStack:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/stacks/shared-dovetail-kinesis.yml
+++ b/stacks/shared-dovetail-kinesis.yml
@@ -1,8 +1,9 @@
-# stacks/shared-kinesis.yml
+# stacks/shared-dovetail-kinesis.yml
 AWSTemplateFormatVersion: "2010-09-09"
 
 Description: >-
-  Creates kinesis streams intended to be used by several applications.
+  Creates kinesis streams used across multiple dovetail apps to enable processing
+  download and impression metrics.
 
 Parameters:
   EnvironmentType: { Type: String }
@@ -10,8 +11,10 @@ Parameters:
   RootStackId: { Type: String }
 
 Resources:
+  # realtime cloudfront logs, including bytes-downloaded by listeners
+  #
   # dovetail3-cdn realtime logs --> dovetail-counts
-  CountsBytesKinesisStream:
+  DovetailCdnLogsKinesisStream:
     Type: AWS::Kinesis::Stream
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -30,9 +33,12 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Counts }
 
+  # IAB2 counted segment-numbers
+  # but ALSO dovetail-router redirect data TODO: move this
+  #
   # dovetail-counts --> analytics-dynamodb
   # dovetail-router --> analytics-dynamodb
-  AnalyticsDynamoDBKinesisStream:
+  DovetailCountedKinesisStream:
     Type: AWS::Kinesis::Stream
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -51,11 +57,13 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Analytics }
 
+  # IAB2 verified episode downloads and ad-impressions
+  #
   # analytics-dynamodb --> analytics-bigquery
   # analytics-dynamodb --> analytics-pingbacks
   # analytics-dynamodb --> analytics-redis
   # analytics-dynamodb --> dovetail-traffic (TEMP)
-  AnalyticsMetricsKinesisStream:
+  DovetailVerifiedMetricsKinesisStream:
     Type: AWS::Kinesis::Stream
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -75,15 +83,17 @@ Resources:
         - { Key: prx:dev:application, Value: Analytics }
 
 Outputs:
-  CountsBytesKinesisStreamName:
-    Value: !Ref CountsBytesKinesisStream
-  CountsBytesKinesisStreamArn:
-    Value: !GetAtt CountsBytesKinesisStream.Arn
-  AnalyticsDynamoDBKinesisStreamName:
-    Value: !Ref AnalyticsDynamoDBKinesisStream
-  AnalyticsDynamoDBKinesisStreamArn:
-    Value: !GetAtt AnalyticsDynamoDBKinesisStream.Arn
-  AnalyticsMetricsKinesisStreamName:
-    Value: !Ref AnalyticsMetricsKinesisStream
-  AnalyticsMetricsKinesisStreamArn:
-    Value: !GetAtt AnalyticsMetricsKinesisStream.Arn
+  DovetailCdnLogsKinesisStreamName:
+    Value: !Ref DovetailCdnLogsKinesisStream
+  DovetailCdnLogsKinesisStreamArn:
+    Value: !GetAtt DovetailCdnLogsKinesisStream.Arn
+
+  DovetailCountedKinesisStreamName:
+    Value: !Ref DovetailCountedKinesisStream
+  DovetailCountedKinesisStreamArn:
+    Value: !GetAtt DovetailCountedKinesisStream.Arn
+
+  DovetailVerifiedMetricsKinesisStreamName:
+    Value: !Ref DovetailVerifiedMetricsKinesisStream
+  DovetailVerifiedMetricsKinesisStreamArn:
+    Value: !GetAtt DovetailVerifiedMetricsKinesisStream.Arn

--- a/stacks/shared-kinesis.yml
+++ b/stacks/shared-kinesis.yml
@@ -30,7 +30,6 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Counts }
 
-
   # dovetail-counts --> analytics-dynamodb
   # dovetail-router --> analytics-dynamodb
   AnalyticsDynamoDBKinesisStream:

--- a/stacks/shared-kinesis.yml
+++ b/stacks/shared-kinesis.yml
@@ -1,0 +1,90 @@
+# stacks/shared-kinesis.yml
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Creates kinesis streams intended to be used by several applications.
+
+Parameters:
+  EnvironmentType: { Type: String }
+  RootStackName: { Type: String }
+  RootStackId: { Type: String }
+
+Resources:
+  # dovetail3-cdn realtime logs --> dovetail-counts
+  CountsBytesKinesisStream:
+    Type: AWS::Kinesis::Stream
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      RetentionPeriodHours: 24
+      ShardCount: 1
+      StreamModeDetails:
+        StreamMode: PROVISIONED
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Counts }
+
+
+  # dovetail-counts --> analytics-dynamodb
+  # dovetail-router --> analytics-dynamodb
+  AnalyticsDynamoDBKinesisStream:
+    Type: AWS::Kinesis::Stream
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      RetentionPeriodHours: 24
+      ShardCount: 2
+      StreamModeDetails:
+        StreamMode: PROVISIONED
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Analytics }
+
+  # analytics-dynamodb --> analytics-bigquery
+  # analytics-dynamodb --> analytics-pingbacks
+  # analytics-dynamodb --> analytics-redis
+  # analytics-dynamodb --> dovetail-traffic (TEMP)
+  AnalyticsMetricsKinesisStream:
+    Type: AWS::Kinesis::Stream
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      RetentionPeriodHours: 24
+      ShardCount: 2
+      StreamModeDetails:
+        StreamMode: PROVISIONED
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Analytics }
+
+Outputs:
+  CountsBytesKinesisStreamName:
+    Value: !Ref CountsBytesKinesisStream
+  CountsBytesKinesisStreamArn:
+    Value: !GetAtt CountsBytesKinesisStream.Arn
+  AnalyticsDynamoDBKinesisStreamName:
+    Value: !Ref AnalyticsDynamoDBKinesisStream
+  AnalyticsDynamoDBKinesisStreamArn:
+    Value: !GetAtt AnalyticsDynamoDBKinesisStream.Arn
+  AnalyticsMetricsKinesisStreamName:
+    Value: !Ref AnalyticsMetricsKinesisStream
+  AnalyticsMetricsKinesisStreamArn:
+    Value: !GetAtt AnalyticsMetricsKinesisStream.Arn


### PR DESCRIPTION
Merge carefully!

We've been using 3 kinesis streams not in CFN:

- `dovetail-bytes-production` the output of CloudFront; input to dovetail-counts
- `dovetail-ddb-production` the output of both DTR logs and dovetail-counts; input to analytics-dynamodb
- `dovetail-metrics-production-6s` the output of analytics-dynamodb, input to analytics-bigquery/redis/pingbacks

Move these into CFN, so we can deploy them in another region!  This keeps the old streams as deprecated-triggers for now, until they empty.  And we update CloudFront.