### PR TITLE
Jump server in every region

### DIFF
--- a/stacks/apps/dovetail-router.yml
+++ b/stacks/apps/dovetail-router.yml
@@ -116,6 +116,7 @@ Resources:
       # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy.html#routing-policy-latency
       # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-latency-alias.html
       ServiceDomain: !Sub dovetail-router-alb-latency-group.${EnvironmentTypeAbbreviation}.prx.tech
+      VanityDomain: !If [IsProduction, !Sub "dovetail-router.${AWS::Region}.prx.tech", !Sub "dovetail-router.staging.${AWS::Region}.prx.tech"]
 
   Certificate:
     # This certificate does not include an entry for the service domain, since
@@ -170,6 +171,25 @@ Resources:
           Name: !GetAtt Constants.ServiceDomain
           Region: !Ref AWS::Region
           SetIdentifier: !Ref AWS::StackName
+          Type: A
+
+  VanityRecordSetGroup:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      Comment: Record sets for regional Dovetail Router ALBs
+      HostedZoneName: prx.tech.
+      RecordSets:
+        - AliasTarget:
+            DNSName: !GetAtt Alb.DNSName
+            EvaluateTargetHealth: true
+            HostedZoneId: !GetAtt Alb.CanonicalHostedZoneID
+          Name: !GetAtt Constants.VanityDomain
+          Type: AAAA
+        - AliasTarget:
+            DNSName: !GetAtt Alb.DNSName
+            EvaluateTargetHealth: true
+            HostedZoneId: !GetAtt Alb.CanonicalHostedZoneID
+          Name: !GetAtt Constants.VanityDomain
           Type: A
 
   AccessLogsBucket:

--- a/stacks/jump-server.yml
+++ b/stacks/jump-server.yml
@@ -20,6 +20,7 @@ Parameters:
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
+  HasCastleSecurityGroup: !Not [!Equals [!Ref CastlePostgresClientSecurityGroupId, ""]]
 
 Resources:
   InstanceProfile:
@@ -138,7 +139,7 @@ Resources:
           DeviceIndex: 0
           GroupSet:
             - !GetAtt SecurityGroup.GroupId
-            - !Ref CastlePostgresClientSecurityGroupId
+            - !If [HasCastleSecurityGroup, !Ref CastlePostgresClientSecurityGroupId, !Ref AWS::NoValue]
             - !Ref SharedMysqlClientSecurityGroupId
             - !Ref SharedPostgresqlClientSecurityGroupId
             - !Ref SharedRedisClientSecurityGroupId

--- a/stacks/jump-server.yml
+++ b/stacks/jump-server.yml
@@ -195,6 +195,18 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
 
+  VanityJumpRecordSetGroup:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      Comment: Record sets for regional EC2 jump servers
+      HostedZoneName: prx.tech.
+      RecordSets:
+        - Type: CNAME
+          Name: !If [IsProduction, !Sub "jump.${AWS::Region}.prx.tech", !Sub "jump.staging.${AWS::Region}.prx.tech"]
+          ResourceRecords:
+            - !Ref ElasticIP
+          TTL: "3600"
+
 Outputs:
   ElasticIP:
     Description: The Elastic IP address of the jump server

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -122,8 +122,6 @@ Conditions:
   CreateDatabaseDependentResources: !Condition HasAllSharedAuroraEndpoints
   # Application stacks require external MySQL/PostgreSQL databases
   CreateApplicationStacks: !Condition CreateDatabaseDependentResources
-  # Jump server requires that application stacks have been created
-  CreateJumpServerStack: !Condition CreateApplicationStacks
   # Dashboard requires that application stacks have been created
   CreateDashboardsStack: !Condition CreateApplicationStacks
 
@@ -935,10 +933,9 @@ Resources:
       TemplateURL: !Sub ${Constants.TemplateUrlBase}/stacks/apps-400A.yml
       TimeoutInMinutes: 40
 
-  # Requires VPC, Redis and DB SGs, and Castle
+  # Requires VPC, Redis and DB SGs
   JumpServerStack:
     Type: AWS::CloudFormation::Stack
-    Condition: CreateJumpServerStack
     Properties:
       NotificationARNs:
         - !Ref CloudFormationNotificationsSnsTopicArn
@@ -948,7 +945,7 @@ Resources:
         KeyPairName: !Ref AsgKeyPairName
         RootStackName: !GetAtt Constants.RootStackName
         RootStackId: !GetAtt Constants.RootStackId
-        CastlePostgresClientSecurityGroupId: !GetAtt Apps200AStack.Outputs.CastlePostgresClientSecurityGroupId
+        CastlePostgresClientSecurityGroupId: !If [CreateApplicationStacks, !GetAtt Apps200AStack.Outputs.CastlePostgresClientSecurityGroupId, ""]
         SharedMysqlClientSecurityGroupId: !GetAtt SharedDatabaseSecurityGroupsStack.Outputs.SharedMysqlClientSecurityGroupId
         SharedPostgresqlClientSecurityGroupId: !GetAtt SharedDatabaseSecurityGroupsStack.Outputs.SharedPostgresqlClientSecurityGroupId
         SharedRedisClientSecurityGroupId: !GetAtt SharedRedisSecurityGroupStack.Outputs.ClientSecurityGroupId


### PR DESCRIPTION
Adds some regional DNS entries for the jump servers and dovetail-router:

```
jump.us-east-1.prx.tech
jump.staging.us-east-1.prx.tech

dovetail-router.us-east-1.prx.tech
dovetail-router.staging.us-east-1.prx.tech
```

Also makes the castle dependency on the jump servers optional.