### PR TITLE
Multi-behavior dovetail cdn

### DIFF
--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -17,6 +17,7 @@ Metadata:
           - ExpiredRedirectPrefix
           - OriginRequestFunctionArn
           - EnvironmentType
+          - RealtimeLogFields
       - Label:
           default: Primary Region
         Parameters:
@@ -62,6 +63,8 @@ Metadata:
         default: Secondary region's kinesis stream for realtime logs
       RealtimeLogKinesisStreamArn3:
         default: Tertiary region's kinesis stream for realtime logs
+      RealtimeLogFields:
+        default: Fields to include in realtime logs
 
 Parameters:
   OriginBucket:
@@ -106,6 +109,9 @@ Parameters:
   RealtimeLogKinesisStreamArn3:
     Type: String
     Description: eg. arn:aws:kinesis:<region>:<account>:stream/<name>
+  RealtimeLogFields:
+    Type: String
+    Default: timestamp,c-ip,sc-status,cs-method,cs-uri-stem,cs-user-agent,cs-referer,x-forwarded-for,sc-content-len,sc-range-start,sc-range-end
 
 Conditions:
   HasSecondaryRegion: !Not [!Equals [!Ref RealtimeLogKinesisStreamArn2, ""]]
@@ -409,18 +415,7 @@ Resources:
             RoleArn: !GetAtt RealtimeLogRole.Arn
             StreamArn: !Ref RealtimeLogKinesisStreamArn
           StreamType: Kinesis
-      Fields:
-        - timestamp
-        - c-ip
-        - sc-status
-        - cs-method
-        - cs-uri-stem
-        - cs-user-agent
-        - cs-referer
-        - x-forwarded-for
-        - sc-content-len
-        - sc-range-start
-        - sc-range-end
+      Fields: !Split [",", !Ref RealtimeLogFields]
       Name: !Sub ${AWS::StackName}-RealtimeLogConfig
       SamplingRate: 100
   RealtimeLogConfig2:
@@ -432,18 +427,7 @@ Resources:
             RoleArn: !GetAtt RealtimeLogRole.Arn
             StreamArn: !Ref RealtimeLogKinesisStreamArn2
           StreamType: Kinesis
-      Fields:
-        - timestamp
-        - c-ip
-        - sc-status
-        - cs-method
-        - cs-uri-stem
-        - cs-user-agent
-        - cs-referer
-        - x-forwarded-for
-        - sc-content-len
-        - sc-range-start
-        - sc-range-end
+      Fields: !Split [",", !Ref RealtimeLogFields]
       Name: !Sub ${AWS::StackName}-RealtimeLogConfig2
       SamplingRate: 100
   RealtimeLogConfig3:
@@ -455,18 +439,7 @@ Resources:
             RoleArn: !GetAtt RealtimeLogRole.Arn
             StreamArn: !Ref RealtimeLogKinesisStreamArn3
           StreamType: Kinesis
-      Fields:
-        - timestamp
-        - c-ip
-        - sc-status
-        - cs-method
-        - cs-uri-stem
-        - cs-user-agent
-        - cs-referer
-        - x-forwarded-for
-        - sc-content-len
-        - sc-range-start
-        - sc-range-end
+      Fields: !Split [",", !Ref RealtimeLogFields]
       Name: !Sub ${AWS::StackName}-RealtimeLogConfig3
       SamplingRate: 100
 

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -66,13 +66,13 @@ Metadata:
 Parameters:
   OriginBucket:
     Type: String
-    Description: eg. some-bucket-name.s3.amazonaws.com
+    Description: eg. some-bucket-name.s3.region-name.amazonaws.com
   OriginBucket2:
     Type: String
-    Description: eg. some-bucket-name.s3.amazonaws.com
+    Description: eg. some-bucket-name.s3.region-name.amazonaws.com
   OriginBucket3:
     Type: String
-    Description: eg. some-bucket-name.s3.amazonaws.com
+    Description: eg. some-bucket-name.s3.region-name.amazonaws.com
   DistributionDomain:
     Type: String
     Description: eg. dovetail3-cdn.prxu.org
@@ -84,7 +84,6 @@ Parameters:
     Description: eg. arn:aws:lambda:<region>:<account>:function:<name>:<version>
   EnvironmentType:
     Type: String
-    Description: Only deploy this stack once per environment
     AllowedValues:
       - Testing
       - Staging

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -17,7 +17,6 @@ Metadata:
           - ExpiredRedirectPrefix
           - OriginRequestFunctionArn
           - EnvironmentType
-          - EnvironmentTypeAbbreviation
       - Label:
           default: Primary Region
         Parameters:
@@ -51,8 +50,6 @@ Metadata:
         default: Dovetail origin request lambda
       EnvironmentType:
         default: Environment Type
-      EnvironmentTypeAbbreviation:
-        default: Environment Type Abbreviation
       CacheBehaviorPrefix:
         default: Primary region's path prefix
       CacheBehaviorPrefix2:
@@ -92,13 +89,6 @@ Parameters:
       - Testing
       - Staging
       - Production
-  EnvironmentTypeAbbreviation:
-    Type: String
-    Description: Must match above
-    AllowedValues:
-      - test
-      - stag
-      - prod
   CacheBehaviorPrefix:
     Type: String
     Description: eg. use1/, us-west-2/
@@ -211,7 +201,7 @@ Resources:
       FunctionConfig:
         Comment: Handle viewer-requests for Dovetail 3 CDN
         Runtime: cloudfront-js-1.0
-      Name: !Sub "dt3-viewer-request-${EnvironmentTypeAbbreviation}"
+      Name: !Sub ${AWS::StackName}-viewer-request
 
   CloudFrontCachePolicy:
     Type: AWS::CloudFront::CachePolicy
@@ -257,7 +247,7 @@ Resources:
             Compress: false
             FunctionAssociations:
               - EventType: viewer-request
-                FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/dt3-viewer-request-${EnvironmentTypeAbbreviation}
+                FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
             LambdaFunctionAssociations:
               - EventType: origin-request
                 LambdaFunctionARN: !Ref OriginRequestFunctionArn
@@ -274,7 +264,7 @@ Resources:
               Compress: false
               FunctionAssociations:
                 - EventType: viewer-request
-                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/dt3-viewer-request-${EnvironmentTypeAbbreviation}
+                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
               LambdaFunctionAssociations:
                 - EventType: origin-request
                   LambdaFunctionARN: !Ref OriginRequestFunctionArn
@@ -292,7 +282,7 @@ Resources:
               Compress: false
               FunctionAssociations:
                 - EventType: viewer-request
-                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/dt3-viewer-request-${EnvironmentTypeAbbreviation}
+                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
               LambdaFunctionAssociations:
                 - EventType: origin-request
                   LambdaFunctionARN: !Ref OriginRequestFunctionArn
@@ -329,7 +319,7 @@ Resources:
           Compress: false
           FunctionAssociations:
             - EventType: viewer-request
-              FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/dt3-viewer-request-${EnvironmentTypeAbbreviation}
+              FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
               # TODO: this is stalling CFN updates for like ... no reason.
               # FunctionARN: !GetAtt ViewerRequestFunction.FunctionMetadata.FunctionARN
           LambdaFunctionAssociations:
@@ -346,7 +336,7 @@ Resources:
         Logging:
           Bucket: prx-dovetail.s3.amazonaws.com
           IncludeCookies: false
-          Prefix: !Sub "dt3-logs-${EnvironmentTypeAbbreviation}"
+          Prefix: !Sub "${AWS::StackName}-logs"
         Origins:
           - DomainName: !Ref OriginBucket
             Id: dovetail3-stitch-s3

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -91,13 +91,13 @@ Parameters:
       - Production
   CacheBehaviorPrefix:
     Type: String
-    Description: eg. use1/, us-west-2/
+    Description: eg. /use1/*, /us-west-2/*
   CacheBehaviorPrefix2:
     Type: String
-    Description: eg. use1/, us-west-2/
+    Description: eg. /use1/*, /us-west-2/*
   CacheBehaviorPrefix3:
     Type: String
-    Description: eg. use1/, us-west-2/
+    Description: eg. /use1/*, /us-west-2/*
   RealtimeLogKinesisStreamArn:
     Type: String
     Description: eg. arn:aws:kinesis:<region>:<account>:stream/<name>
@@ -193,7 +193,7 @@ Resources:
       ServiceToken: !GetAtt CloudFrontFunctionCodeFetcherFunction.Arn
       Cycle: 2 # Change this when the code in GitHub changes
 
-  ViewerRequestFunction:
+  ViewerRequestFunction1:
     Type: AWS::CloudFront::Function
     Properties:
       AutoPublish: true # TODO
@@ -235,7 +235,7 @@ Resources:
           QueryStringBehavior: none
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
-    DependsOn: ViewerRequestFunction
+    DependsOn: ViewerRequestFunction1
     Properties:
       DistributionConfig:
         Aliases:
@@ -321,7 +321,7 @@ Resources:
             - EventType: viewer-request
               FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
               # TODO: this is stalling CFN updates for like ... no reason.
-              # FunctionARN: !GetAtt ViewerRequestFunction.FunctionMetadata.FunctionARN
+              # FunctionARN: !GetAtt ViewerRequestFunction1.FunctionMetadata.FunctionARN
           LambdaFunctionAssociations:
             - EventType: origin-request
               LambdaFunctionARN: !Ref OriginRequestFunctionArn

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -13,15 +13,32 @@ Metadata:
       - Label:
           default: Distribution Parameters
         Parameters:
-          - OriginBucket
           - DistributionDomain
           - ExpiredRedirectPrefix
           - OriginRequestFunctionArn
           - EnvironmentTypeAbbreviation
+      - Label:
+          default: Primary Region
+        Parameters:
+          - OriginBucket
           - RealtimeLogKinesisStreamArn
+      - Label:
+          default: Secondary Region (optional)
+        Parameters:
+          - OriginBucket2
+          - RealtimeLogKinesisStreamArn2
+      - Label:
+          default: Tertiary Region (optional)
+        Parameters:
+          - OriginBucket3
+          - RealtimeLogKinesisStreamArn3
     ParameterLabels:
       OriginBucket:
-        default: Primary dovetail-cdn-arranger S3 Bucket
+        default: Primary region's dovetail-cdn-arranger S3 Bucket
+      OriginBucket2:
+        default: Secondary region's dovetail-cdn-arranger S3 Bucket
+      OriginBucket3:
+        default: Tertiary region's dovetail-cdn-arranger S3 Bucket
       DistributionDomain:
         default: Domain Name
       ExpiredRedirectPrefix:
@@ -31,10 +48,20 @@ Metadata:
       EnvironmentTypeAbbreviation:
         default: Environment type used in naming things
       RealtimeLogKinesisStreamArn:
-        default: Kinesis stream for realtime logs
+        default: Primary region's kinesis stream for realtime logs
+      RealtimeLogKinesisStreamArn2:
+        default: Secondary region's kinesis stream for realtime logs
+      RealtimeLogKinesisStreamArn3:
+        default: Tertiary region's kinesis stream for realtime logs
 
 Parameters:
   OriginBucket:
+    Type: String
+    Description: eg. some-bucket-name.s3.amazonaws.com
+  OriginBucket2:
+    Type: String
+    Description: eg. some-bucket-name.s3.amazonaws.com
+  OriginBucket3:
     Type: String
     Description: eg. some-bucket-name.s3.amazonaws.com
   DistributionDomain:
@@ -60,6 +87,16 @@ Parameters:
   RealtimeLogKinesisStreamArn:
     Type: String
     Description: eg. arn:aws:kinesis:<region>:<account>:stream/<name>
+  RealtimeLogKinesisStreamArn2:
+    Type: String
+    Description: eg. arn:aws:kinesis:<region>:<account>:stream/<name>
+  RealtimeLogKinesisStreamArn3:
+    Type: String
+    Description: eg. arn:aws:kinesis:<region>:<account>:stream/<name>
+
+Conditions:
+  HasSecondaryRegion: !Not [!Equals [!Ref RealtimeLogKinesisStreamArn2, ""]]
+  HasTertiaryRegion: !Not [!Equals [!Ref RealtimeLogKinesisStreamArn3, ""]]
 
 Resources:
   Certificate:
@@ -188,6 +225,58 @@ Resources:
       DistributionConfig:
         Aliases:
           - !Ref DistributionDomain
+        CacheBehaviors:
+          - AllowedMethods: [HEAD, GET]
+            CachedMethods: [HEAD, GET]
+            CachePolicyId: !Ref CloudFrontCachePolicy
+            Compress: false
+            FunctionAssociations:
+              - EventType: viewer-request
+                FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/dt3-viewer-request-${EnvironmentTypeAbbreviation}
+            LambdaFunctionAssociations:
+              - EventType: origin-request
+                LambdaFunctionARN: !Ref OriginRequestFunctionArn
+            OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
+            PathPattern: !Join ["", [!Select [3, !Split [":", !Ref RealtimeLogKinesisStreamArn]], "/"]]
+            RealtimeLogConfigArn: !Ref RealtimeLogConfig
+            TargetOriginId: dovetail3-stitch-s3
+            ViewerProtocolPolicy: allow-all
+          - !If
+            - HasSecondaryRegion
+            - AllowedMethods: [HEAD, GET]
+              CachedMethods: [HEAD, GET]
+              CachePolicyId: !Ref CloudFrontCachePolicy
+              Compress: false
+              FunctionAssociations:
+                - EventType: viewer-request
+                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/dt3-viewer-request-${EnvironmentTypeAbbreviation}
+              LambdaFunctionAssociations:
+                - EventType: origin-request
+                  LambdaFunctionARN: !Ref OriginRequestFunctionArn
+              OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
+              PathPattern: !Join ["", [!Select [3, !Split [":", !Ref RealtimeLogKinesisStreamArn2]], "/"]]
+              RealtimeLogConfigArn: !Ref RealtimeLogConfig2
+              TargetOriginId: dovetail3-stitch-s3-2
+              ViewerProtocolPolicy: allow-all
+            - !Ref AWS::NoValue
+          - !If
+            - HasTertiaryRegion
+            - AllowedMethods: [HEAD, GET]
+              CachedMethods: [HEAD, GET]
+              CachePolicyId: !Ref CloudFrontCachePolicy
+              Compress: false
+              FunctionAssociations:
+                - EventType: viewer-request
+                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/dt3-viewer-request-${EnvironmentTypeAbbreviation}
+              LambdaFunctionAssociations:
+                - EventType: origin-request
+                  LambdaFunctionARN: !Ref OriginRequestFunctionArn
+              OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
+              PathPattern: !Join ["", [!Select [3, !Split [":", !Ref RealtimeLogKinesisStreamArn3]], "/"]]
+              RealtimeLogConfigArn: !Ref RealtimeLogConfig3
+              TargetOriginId: dovetail3-stitch-s3-3
+              ViewerProtocolPolicy: allow-all
+            - !Ref AWS::NoValue
         Comment: !Ref DistributionDomain
         CustomErrorResponses:
           # dovetail uploaded, but file wasn't there!
@@ -230,17 +319,28 @@ Resources:
         HttpVersion: http2
         IPV6Enabled: true
         Logging:
-          # TODO: non us-east-1 bucket
           Bucket: prx-dovetail.s3.amazonaws.com
           IncludeCookies: false
           Prefix: !Sub "dt3-logs-${EnvironmentTypeAbbreviation}"
         Origins:
-          # TODO: multiple dovetail-cdn-arranger S3 bucket origins, in case
-          # lambda executions fail for some reason
           - DomainName: !Ref OriginBucket
             Id: dovetail3-stitch-s3
             S3OriginConfig:
               OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
+          - !If
+            - HasSecondaryRegion
+            - DomainName: !Ref OriginBucket2
+              Id: dovetail3-stitch-s3-2
+              S3OriginConfig:
+                OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
+            - !Ref AWS::NoValue
+          - !If
+            - HasTertiaryRegion
+            - DomainName: !Ref OriginBucket3
+              Id: dovetail3-stitch-s3-3
+              S3OriginConfig:
+                OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
+            - !Ref AWS::NoValue
         PriceClass: PriceClass_200
         ViewerCertificate:
           AcmCertificateArn: !Ref Certificate
@@ -275,7 +375,10 @@ Resources:
                   - kinesis:PutRecord
                   - kinesis:PutRecords
                 Effect: Allow
-                Resource: !Ref RealtimeLogKinesisStreamArn
+                Resource:
+                  - !Ref RealtimeLogKinesisStreamArn
+                  - !If [HasSecondaryRegion, !Ref RealtimeLogKinesisStreamArn2, AWS::NoValue]
+                  - !If [HasTertiaryRegion, !Ref RealtimeLogKinesisStreamArn3, AWS::NoValue]
       Tags:
         - { Key: Name, Value: !Sub "${AWS::StackName}" }
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -305,6 +408,52 @@ Resources:
         - sc-range-start
         - sc-range-end
       Name: !Sub dt3-realtime-logs-${EnvironmentTypeAbbreviation}
+      SamplingRate: 100
+  RealtimeLogConfig2:
+    Condition: HasSecondaryRegion
+    Type: AWS::CloudFront::RealtimeLogConfig
+    Properties:
+      EndPoints:
+        - KinesisStreamConfig:
+            RoleArn: !GetAtt RealtimeLogRole.Arn
+            StreamArn: !Ref RealtimeLogKinesisStreamArn2
+          StreamType: Kinesis
+      Fields:
+        - timestamp
+        - c-ip
+        - sc-status
+        - cs-method
+        - cs-uri-stem
+        - cs-user-agent
+        - cs-referer
+        - x-forwarded-for
+        - sc-content-len
+        - sc-range-start
+        - sc-range-end
+      Name: !Sub dt3-realtime-logs-${EnvironmentTypeAbbreviation}-2
+      SamplingRate: 100
+  RealtimeLogConfig3:
+    Condition: HasTertiaryRegion
+    Type: AWS::CloudFront::RealtimeLogConfig
+    Properties:
+      EndPoints:
+        - KinesisStreamConfig:
+            RoleArn: !GetAtt RealtimeLogRole.Arn
+            StreamArn: !Ref RealtimeLogKinesisStreamArn3
+          StreamType: Kinesis
+      Fields:
+        - timestamp
+        - c-ip
+        - sc-status
+        - cs-method
+        - cs-uri-stem
+        - cs-user-agent
+        - cs-referer
+        - x-forwarded-for
+        - sc-content-len
+        - sc-range-start
+        - sc-range-end
+      Name: !Sub dt3-realtime-logs-${EnvironmentTypeAbbreviation}-3
       SamplingRate: 100
 
   CloudFrontOriginAccessIdentity:

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -491,9 +491,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateAlarms
     Properties:
-      AlarmName: !Sub WARN [Dovetail-CDN] CDN <${EnvironmentTypeAbbreviation}> RETURNING 4XX ERRORS (${AWS::StackName})
+      AlarmName: !Sub WARN [Dovetail-CDN] CDN <${EnvironmentType}> RETURNING 4XX ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-
-        The ${EnvironmentTypeAbbreviation} Dovetail CDN is returning an
+        The ${EnvironmentType} Dovetail CDN is returning an
         unusually high rate of 4XX errors to end users. The usually doesn't
         indicate any operational problems with any components of Dovetail.
       ComparisonOperator: GreaterThanThreshold
@@ -514,9 +514,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateAlarms
     Properties:
-      AlarmName: !Sub WARN [Dovetail-CDN] CDN <${EnvironmentTypeAbbreviation}> RETURNING 5XX ERRORS (${AWS::StackName})
+      AlarmName: !Sub WARN [Dovetail-CDN] CDN <${EnvironmentType}> RETURNING 5XX ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-
-        The ${EnvironmentTypeAbbreviation} Dovetail CDN 5XX error rate is
+        The ${EnvironmentType} Dovetail CDN 5XX error rate is
         higher than the baseline background noise rate, which could indicate a
         problem with audio stitching or the CDN's origin.
       ComparisonOperator: GreaterThanThreshold
@@ -537,9 +537,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateAlarms
     Properties:
-      AlarmName: !Sub FATAL [Dovetail-CDN] CDN <${EnvironmentTypeAbbreviation}> RETURNING 5XX ERRORS (${AWS::StackName})
+      AlarmName: !Sub FATAL [Dovetail-CDN] CDN <${EnvironmentType}> RETURNING 5XX ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-
-        The ${EnvironmentTypeAbbreviation} Dovetail CDN 5XX error rate is
+        The ${EnvironmentType} Dovetail CDN 5XX error rate is
         very high. This likely means a significant number of end users are not
         able to download audio.
       ComparisonOperator: GreaterThanThreshold
@@ -560,9 +560,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateAlarms
     Properties:
-      AlarmName: !Sub WARN [Dovetail-CDN] Edge Lambda <${EnvironmentTypeAbbreviation}> EXECUTION ERRORS (${AWS::StackName})
+      AlarmName: !Sub WARN [Dovetail-CDN] Edge Lambda <${EnvironmentType}> EXECUTION ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-
-        The ${EnvironmentTypeAbbreviation} Dovetail CDN Lambda@Edge functions
+        The ${EnvironmentType} Dovetail CDN Lambda@Edge functions
         are failing. This could mean the stitching functions they call are also
         failing, or working too slowly. Some audio downloads may be failing.
       ComparisonOperator: GreaterThanThreshold

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -16,6 +16,7 @@ Metadata:
           - DistributionDomain
           - ExpiredRedirectPrefix
           - OriginRequestFunctionArn
+          - EnvironmentType
           - EnvironmentTypeAbbreviation
       - Label:
           default: Primary Region
@@ -45,8 +46,10 @@ Metadata:
         default: Prefix for redirecting back to Dovetail
       OriginRequestFunctionArn:
         default: Dovetail origin request lambda
+      EnvironmentType:
+        default: Environment Type
       EnvironmentTypeAbbreviation:
-        default: Environment type used in naming things
+        default: Environment Type Abbreviation
       RealtimeLogKinesisStreamArn:
         default: Primary region's kinesis stream for realtime logs
       RealtimeLogKinesisStreamArn2:
@@ -75,11 +78,14 @@ Parameters:
     Description: eg. arn:aws:lambda:<region>:<account>:function:<name>:<version>
   EnvironmentType:
     Type: String
+    Description: Only deploy this stack once per environment
     AllowedValues:
+      - Testing
       - Staging
       - Production
   EnvironmentTypeAbbreviation:
     Type: String
+    Description: Must match above
     AllowedValues:
       - test
       - stag
@@ -97,6 +103,7 @@ Parameters:
 Conditions:
   HasSecondaryRegion: !Not [!Equals [!Ref RealtimeLogKinesisStreamArn2, ""]]
   HasTertiaryRegion: !Not [!Equals [!Ref RealtimeLogKinesisStreamArn3, ""]]
+  CreateAlarms: !Not [!Equals [!Ref EnvironmentType, Testing]]
 
 Resources:
   Certificate:
@@ -377,8 +384,8 @@ Resources:
                 Effect: Allow
                 Resource:
                   - !Ref RealtimeLogKinesisStreamArn
-                  - !If [HasSecondaryRegion, !Ref RealtimeLogKinesisStreamArn2, AWS::NoValue]
-                  - !If [HasTertiaryRegion, !Ref RealtimeLogKinesisStreamArn3, AWS::NoValue]
+                  - !If [HasSecondaryRegion, !Ref RealtimeLogKinesisStreamArn2, !Ref AWS::NoValue]
+                  - !If [HasTertiaryRegion, !Ref RealtimeLogKinesisStreamArn3, !Ref AWS::NoValue]
       Tags:
         - { Key: Name, Value: !Sub "${AWS::StackName}" }
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -464,6 +471,7 @@ Resources:
 
   CloudFrontDistribution400Alarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: CreateAlarms
     Properties:
       AlarmName: !Sub WARN [Dovetail-CDN] CDN <${EnvironmentTypeAbbreviation}> RETURNING 4XX ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-
@@ -486,6 +494,7 @@ Resources:
       Unit: Percent
   CloudFrontDistribution500Alarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: CreateAlarms
     Properties:
       AlarmName: !Sub WARN [Dovetail-CDN] CDN <${EnvironmentTypeAbbreviation}> RETURNING 5XX ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-
@@ -508,6 +517,7 @@ Resources:
       Unit: Percent
   CloudFrontDistributionFatal500Alarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: CreateAlarms
     Properties:
       AlarmName: !Sub FATAL [Dovetail-CDN] CDN <${EnvironmentTypeAbbreviation}> RETURNING 5XX ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-
@@ -530,6 +540,7 @@ Resources:
       Unit: Percent
   CloudFrontDistributionLambdaExecutionErrorAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: CreateAlarms
     Properties:
       AlarmName: !Sub WARN [Dovetail-CDN] Edge Lambda <${EnvironmentTypeAbbreviation}> EXECUTION ERRORS (${AWS::StackName})
       AlarmDescription: !Sub >-

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -432,7 +432,7 @@ Resources:
         - sc-content-len
         - sc-range-start
         - sc-range-end
-      Name: !Sub dt3-realtime-logs-${EnvironmentTypeAbbreviation}
+      Name: !Sub ${AWS::StackName}-RealtimeLogConfig
       SamplingRate: 100
   RealtimeLogConfig2:
     Condition: HasSecondaryRegion
@@ -455,7 +455,7 @@ Resources:
         - sc-content-len
         - sc-range-start
         - sc-range-end
-      Name: !Sub dt3-realtime-logs-${EnvironmentTypeAbbreviation}-2
+      Name: !Sub ${AWS::StackName}-RealtimeLogConfig2
       SamplingRate: 100
   RealtimeLogConfig3:
     Condition: HasTertiaryRegion
@@ -478,7 +478,7 @@ Resources:
         - sc-content-len
         - sc-range-start
         - sc-range-end
-      Name: !Sub dt3-realtime-logs-${EnvironmentTypeAbbreviation}-3
+      Name: !Sub ${AWS::StackName}-RealtimeLogConfig3
       SamplingRate: 100
 
   CloudFrontOriginAccessIdentity:

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -255,42 +255,42 @@ Resources:
             RealtimeLogConfigArn: !Ref RealtimeLogConfig
             TargetOriginId: dovetail3-stitch-s3
             ViewerProtocolPolicy: allow-all
-          - !If
-            - HasSecondaryRegion
-            - AllowedMethods: [HEAD, GET]
-              CachedMethods: [HEAD, GET]
-              CachePolicyId: !Ref CloudFrontCachePolicy
-              Compress: false
-              FunctionAssociations:
-                - EventType: viewer-request
-                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
-              LambdaFunctionAssociations:
-                - EventType: origin-request
-                  LambdaFunctionARN: !Ref OriginRequestFunctionArn
-              OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
-              PathPattern: !Ref CacheBehaviorPrefix2
-              RealtimeLogConfigArn: !Ref RealtimeLogConfig2
-              TargetOriginId: dovetail3-stitch-s3-2
-              ViewerProtocolPolicy: allow-all
-            - !Ref AWS::NoValue
-          - !If
-            - HasTertiaryRegion
-            - AllowedMethods: [HEAD, GET]
-              CachedMethods: [HEAD, GET]
-              CachePolicyId: !Ref CloudFrontCachePolicy
-              Compress: false
-              FunctionAssociations:
-                - EventType: viewer-request
-                  FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
-              LambdaFunctionAssociations:
-                - EventType: origin-request
-                  LambdaFunctionARN: !Ref OriginRequestFunctionArn
-              OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
-              PathPattern: !Ref CacheBehaviorPrefix3
-              RealtimeLogConfigArn: !Ref RealtimeLogConfig3
-              TargetOriginId: dovetail3-stitch-s3-3
-              ViewerProtocolPolicy: allow-all
-            - !Ref AWS::NoValue
+          - Fn::If:
+              - HasSecondaryRegion
+              - AllowedMethods: [HEAD, GET]
+                CachedMethods: [HEAD, GET]
+                CachePolicyId: !Ref CloudFrontCachePolicy
+                Compress: false
+                FunctionAssociations:
+                  - EventType: viewer-request
+                    FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
+                LambdaFunctionAssociations:
+                  - EventType: origin-request
+                    LambdaFunctionARN: !Ref OriginRequestFunctionArn
+                OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
+                PathPattern: !Ref CacheBehaviorPrefix2
+                RealtimeLogConfigArn: !Ref RealtimeLogConfig2
+                TargetOriginId: dovetail3-stitch-s3-2
+                ViewerProtocolPolicy: allow-all
+              - !Ref AWS::NoValue
+          - Fn::If:
+              - HasTertiaryRegion
+              - AllowedMethods: [HEAD, GET]
+                CachedMethods: [HEAD, GET]
+                CachePolicyId: !Ref CloudFrontCachePolicy
+                Compress: false
+                FunctionAssociations:
+                  - EventType: viewer-request
+                    FunctionARN: !Sub arn:aws:cloudfront::${AWS::AccountId}:function/${AWS::StackName}-viewer-request
+                LambdaFunctionAssociations:
+                  - EventType: origin-request
+                    LambdaFunctionARN: !Ref OriginRequestFunctionArn
+                OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
+                PathPattern: !Ref CacheBehaviorPrefix3
+                RealtimeLogConfigArn: !Ref RealtimeLogConfig3
+                TargetOriginId: dovetail3-stitch-s3-3
+                ViewerProtocolPolicy: allow-all
+              - !Ref AWS::NoValue
         Comment: !Ref DistributionDomain
         CustomErrorResponses:
           # dovetail uploaded, but file wasn't there!
@@ -341,20 +341,20 @@ Resources:
             Id: dovetail3-stitch-s3
             S3OriginConfig:
               OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
-          - !If
-            - HasSecondaryRegion
-            - DomainName: !Ref OriginBucket2
-              Id: dovetail3-stitch-s3-2
-              S3OriginConfig:
-                OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
-            - !Ref AWS::NoValue
-          - !If
-            - HasTertiaryRegion
-            - DomainName: !Ref OriginBucket3
-              Id: dovetail3-stitch-s3-3
-              S3OriginConfig:
-                OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
-            - !Ref AWS::NoValue
+          - Fn::If:
+              - HasSecondaryRegion
+              - DomainName: !Ref OriginBucket2
+                Id: dovetail3-stitch-s3-2
+                S3OriginConfig:
+                  OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
+              - !Ref AWS::NoValue
+          - Fn::If:
+              - HasTertiaryRegion
+              - DomainName: !Ref OriginBucket3
+                Id: dovetail3-stitch-s3-3
+                S3OriginConfig:
+                  OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
+              - !Ref AWS::NoValue
         PriceClass: PriceClass_200
         ViewerCertificate:
           AcmCertificateArn: !Ref Certificate

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -110,7 +110,7 @@ Parameters:
     Type: String
     Description: eg. arn:aws:kinesis:<region>:<account>:stream/<name>
   RealtimeLogFields:
-    Type: String
+    Type: CommaDelimitedList
     Default: timestamp,c-ip,sc-status,cs-method,cs-uri-stem,cs-user-agent,cs-referer,x-forwarded-for,sc-content-len,sc-range-start,sc-range-end
 
 Conditions:
@@ -415,7 +415,7 @@ Resources:
             RoleArn: !GetAtt RealtimeLogRole.Arn
             StreamArn: !Ref RealtimeLogKinesisStreamArn
           StreamType: Kinesis
-      Fields: !Split [",", !Ref RealtimeLogFields]
+      Fields: !Ref RealtimeLogFields
       Name: !Sub ${AWS::StackName}-RealtimeLogConfig
       SamplingRate: 100
   RealtimeLogConfig2:
@@ -427,7 +427,7 @@ Resources:
             RoleArn: !GetAtt RealtimeLogRole.Arn
             StreamArn: !Ref RealtimeLogKinesisStreamArn2
           StreamType: Kinesis
-      Fields: !Split [",", !Ref RealtimeLogFields]
+      Fields: !Ref RealtimeLogFields
       Name: !Sub ${AWS::StackName}-RealtimeLogConfig2
       SamplingRate: 100
   RealtimeLogConfig3:
@@ -439,7 +439,7 @@ Resources:
             RoleArn: !GetAtt RealtimeLogRole.Arn
             StreamArn: !Ref RealtimeLogKinesisStreamArn3
           StreamType: Kinesis
-      Fields: !Split [",", !Ref RealtimeLogFields]
+      Fields: !Ref RealtimeLogFields
       Name: !Sub ${AWS::StackName}-RealtimeLogConfig3
       SamplingRate: 100
 

--- a/cdn/dovetail-cdn.yml
+++ b/cdn/dovetail-cdn.yml
@@ -21,16 +21,19 @@ Metadata:
       - Label:
           default: Primary Region
         Parameters:
+          - CacheBehaviorPrefix
           - OriginBucket
           - RealtimeLogKinesisStreamArn
       - Label:
           default: Secondary Region (optional)
         Parameters:
+          - CacheBehaviorPrefix2
           - OriginBucket2
           - RealtimeLogKinesisStreamArn2
       - Label:
           default: Tertiary Region (optional)
         Parameters:
+          - CacheBehaviorPrefix3
           - OriginBucket3
           - RealtimeLogKinesisStreamArn3
     ParameterLabels:
@@ -50,6 +53,12 @@ Metadata:
         default: Environment Type
       EnvironmentTypeAbbreviation:
         default: Environment Type Abbreviation
+      CacheBehaviorPrefix:
+        default: Primary region's path prefix
+      CacheBehaviorPrefix2:
+        default: Secondary region's path prefix
+      CacheBehaviorPrefix3:
+        default: Tertiary region's path prefix
       RealtimeLogKinesisStreamArn:
         default: Primary region's kinesis stream for realtime logs
       RealtimeLogKinesisStreamArn2:
@@ -72,7 +81,7 @@ Parameters:
     Description: eg. dovetail3-cdn.prxu.org
   ExpiredRedirectPrefix:
     Type: String
-    Description: eg. https://dovetail.prxu.org/_
+    Description: eg. https://dovetail.prxu.org
   OriginRequestFunctionArn:
     Type: String
     Description: eg. arn:aws:lambda:<region>:<account>:function:<name>:<version>
@@ -90,6 +99,15 @@ Parameters:
       - test
       - stag
       - prod
+  CacheBehaviorPrefix:
+    Type: String
+    Description: eg. use1/, us-west-2/
+  CacheBehaviorPrefix2:
+    Type: String
+    Description: eg. use1/, us-west-2/
+  CacheBehaviorPrefix3:
+    Type: String
+    Description: eg. use1/, us-west-2/
   RealtimeLogKinesisStreamArn:
     Type: String
     Description: eg. arn:aws:kinesis:<region>:<account>:stream/<name>
@@ -244,7 +262,7 @@ Resources:
               - EventType: origin-request
                 LambdaFunctionARN: !Ref OriginRequestFunctionArn
             OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
-            PathPattern: !Join ["", [!Select [3, !Split [":", !Ref RealtimeLogKinesisStreamArn]], "/"]]
+            PathPattern: !Ref CacheBehaviorPrefix
             RealtimeLogConfigArn: !Ref RealtimeLogConfig
             TargetOriginId: dovetail3-stitch-s3
             ViewerProtocolPolicy: allow-all
@@ -261,7 +279,7 @@ Resources:
                 - EventType: origin-request
                   LambdaFunctionARN: !Ref OriginRequestFunctionArn
               OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
-              PathPattern: !Join ["", [!Select [3, !Split [":", !Ref RealtimeLogKinesisStreamArn2]], "/"]]
+              PathPattern: !Ref CacheBehaviorPrefix2
               RealtimeLogConfigArn: !Ref RealtimeLogConfig2
               TargetOriginId: dovetail3-stitch-s3-2
               ViewerProtocolPolicy: allow-all
@@ -279,7 +297,7 @@ Resources:
                 - EventType: origin-request
                   LambdaFunctionARN: !Ref OriginRequestFunctionArn
               OriginRequestPolicyId: !Ref CloudFrontOriginRequestPolicy
-              PathPattern: !Join ["", [!Select [3, !Split [":", !Ref RealtimeLogKinesisStreamArn3]], "/"]]
+              PathPattern: !Ref CacheBehaviorPrefix3
               RealtimeLogConfigArn: !Ref RealtimeLogConfig3
               TargetOriginId: dovetail3-stitch-s3-3
               ViewerProtocolPolicy: allow-all

--- a/dns/prxu.org-hosted_zone.yml
+++ b/dns/prxu.org-hosted_zone.yml
@@ -253,6 +253,7 @@ Resources:
             - _05fd9745b2d8eadd458ddd56e359a9d6.jddtvkljgg.acm-validations.aws.
           TTL: "3600"
           Type: CNAME
+        # dovetail-cdn-test.prxu.org
         - Name: !Sub _4fff80fd20e8e1edf61d0a3593c909d6.dovetail3-cdn-test.${Domain}
           ResourceRecords:
             - _107faa09af9e0eb79f73b6ae0055452f.snfqtctrdh.acm-validations.aws.

--- a/dns/prxu.org-hosted_zone.yml
+++ b/dns/prxu.org-hosted_zone.yml
@@ -253,6 +253,11 @@ Resources:
             - _05fd9745b2d8eadd458ddd56e359a9d6.jddtvkljgg.acm-validations.aws.
           TTL: "3600"
           Type: CNAME
+        - Name: !Sub _4fff80fd20e8e1edf61d0a3593c909d6.dovetail3-cdn-test.${Domain}
+          ResourceRecords:
+            - _107faa09af9e0eb79f73b6ae0055452f.snfqtctrdh.acm-validations.aws.
+          TTL: "3600"
+          Type: CNAME
         # a.prxu.org
         - Name: !Sub _b8dd66197d6cc156051d931a5f7ecdd9.a.${Domain}
           ResourceRecords:


### PR DESCRIPTION
- Adds optional secondary and tertiary regions (behaviors) to the dovetail-cdn stack.
- You can configure those behaviors to log to different kinesis streams

Not exactly a no-op, as it cycles some of the live-log configs.  So expect a bit of a blip in metrics - definitely deploy after hours.  But will initially deploy with just the us-east-1 region set (probably prefix `use1` or something).

But should allow processing analytics in a 2nd or 3rd region.