### PR TITLE
Add some ENVs to jump servers

### DIFF
--- a/stacks/jump-server.yml
+++ b/stacks/jump-server.yml
@@ -106,7 +106,6 @@ Resources:
                 [main]
                 stack=${AWS::StackId}
                 region=${AWS::Region}
-              mode: "000400"
               owner: root
               group: root
             /etc/cfn/hooks.d/cfn-auto-reloader.conf:
@@ -132,6 +131,9 @@ Resources:
                 export PRX_SHARED_REDIS_PORT=${SharedRedisReplicationGroupEndpointPort}
                 export PRX_CASTLE_POSTGRES_HOST=${CastlePostgresInstanceEndpointAddress}
                 export PRX_CASTLE_POSTGRES_PORT=${CastlePostgresInstanceEndpointPort}
+              group: ec2-user
+              mode: "000644"
+              owner: ec2-user
           packages:
             yum:
               jq: []

--- a/stacks/jump-server.yml
+++ b/stacks/jump-server.yml
@@ -97,7 +97,8 @@ Resources:
                   echo "${developer_keys}" >> /home/ec2-user/.ssh/authorized_keys
                 - developer_keys: !Join ["\n", !Ref AuthorizedKeys]
             02_load_prx_env:
-              command: "printf \"\n# Load PRX environment variables\nif [ -f ~/.prxenv ]; then\n  . ~/.prxenv\nfi\n\" >> .bash_profile"
+              command: |-
+                printf "\n# Load PRX environment variables\nif [ -f ~/.prxenv ]; then\n  . ~/.prxenv\nfi\n" >> .bash_profile
           files:
             /etc/cfn/cfn-hup.conf:
               # Create a configuration file for cfn-hup

--- a/stacks/jump-server.yml
+++ b/stacks/jump-server.yml
@@ -15,9 +15,18 @@ Parameters:
   RootStackName: { Type: String }
   RootStackId: { Type: String }
   CastlePostgresClientSecurityGroupId: { Type: String }
+  CastlePostgresInstanceEndpointAddress: { Type: String }
+  CastlePostgresInstanceEndpointPort: { Type: String }
+  SharedAuroraMysqlEndpoint: { Type: String }
+  SharedAuroraMysqlPort: { Type: String }
+  SharedAuroraPostgresqlEndpoint: { Type: String }
+  SharedAuroraPostgresqlPort: { Type: String }
+  SharedEcsClusterName: { Type: String }
   SharedMysqlClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedPostgresqlClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
+  SharedRedisReplicationGroupEndpointAddress: { Type: String }
+  SharedRedisReplicationGroupEndpointPort: { Type: String }
   VpcId: { Type: AWS::EC2::VPC::Id }
   VpcPublicSubnet1Id: { Type: AWS::EC2::Subnet::Id }
 
@@ -87,6 +96,8 @@ Resources:
                   echo "Adding developer public keys to authorized_keys"
                   echo "${developer_keys}" >> /home/ec2-user/.ssh/authorized_keys
                 - developer_keys: !Join ["\n", !Ref AuthorizedKeys]
+            02_load_prx_env:
+              command: "printf \"\n# Load PRX environment variables\nif [ -f ~/.bashrc ]; then\n  . ~/.prxenv\nfi\n\" >> .bash_profile"
           files:
             /etc/cfn/cfn-hup.conf:
               # Create a configuration file for cfn-hup
@@ -108,6 +119,19 @@ Resources:
                 path=Resources.JumpServer.Metadata.AWS::CloudFormation::Init
                 action=/opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource JumpServer
                 runas=root
+            /home/ec2-user/.prxenv:
+              content: !Sub |
+                export PRX_REGION=${AWS::Region}
+                export PRX_ENVIRONMENT=${EnvironmentType}
+                export PRX_ECS_CLUSTER_NAME=${SharedEcsClusterName}
+                export PRX_SHARED_MYSQL_HOST=${SharedAuroraMysqlEndpoint}
+                export PRX_SHARED_MYSQL_PORT=${SharedAuroraMysqlPort}
+                export PRX_SHARED_POSTGRES_HOST=${SharedAuroraPostgresqlEndpoint}
+                export PRX_SHARED_POSTGRES_PORT=${SharedAuroraPostgresqlPort}
+                export PRX_SHARED_REDIS_HOST=${SharedRedisReplicationGroupEndpointAddress}
+                export PRX_SHARED_REDIS_PORT=${SharedRedisReplicationGroupEndpointPort}
+                export PRX_CASTLE_POSTGRES_HOST=${CastlePostgresInstanceEndpointAddress}
+                export PRX_CASTLE_POSTGRES_PORT=${CastlePostgresInstanceEndpointPort}
           packages:
             yum:
               jq: []

--- a/stacks/jump-server.yml
+++ b/stacks/jump-server.yml
@@ -97,7 +97,7 @@ Resources:
                   echo "${developer_keys}" >> /home/ec2-user/.ssh/authorized_keys
                 - developer_keys: !Join ["\n", !Ref AuthorizedKeys]
             02_load_prx_env:
-              command: "printf \"\n# Load PRX environment variables\nif [ -f ~/.bashrc ]; then\n  . ~/.prxenv\nfi\n\" >> .bash_profile"
+              command: "printf \"\n# Load PRX environment variables\nif [ -f ~/.prxenv ]; then\n  . ~/.prxenv\nfi\n\" >> .bash_profile"
           files:
             /etc/cfn/cfn-hup.conf:
               # Create a configuration file for cfn-hup

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -1050,9 +1050,18 @@ Resources:
         RootStackName: !GetAtt Constants.RootStackName
         RootStackId: !GetAtt Constants.RootStackId
         CastlePostgresClientSecurityGroupId: !If [CreateApplicationStacks, !GetAtt Apps200AStack.Outputs.CastlePostgresClientSecurityGroupId, ""]
+        CastlePostgresInstanceEndpointAddress: !If [CreateApplicationStacks, !GetAtt Apps200AStack.Outputs.CastlePostgresInstanceEndpointAddress, ""]
+        CastlePostgresInstanceEndpointPort: !If [CreateApplicationStacks, !GetAtt Apps200AStack.Outputs.CastlePostgresInstanceEndpointPort, ""]
+        SharedAuroraMysqlEndpoint: !Ref SharedAuroraMysqlEndpoint
+        SharedAuroraMysqlPort: !Ref SharedAuroraMysqlPort
+        SharedAuroraPostgresqlEndpoint: !Ref SharedAuroraPostgresqlEndpoint
+        SharedAuroraPostgresqlPort: !Ref SharedAuroraPostgresqlPort
+        SharedEcsClusterName: !GetAtt SharedEcsClusterStack.Outputs.EcsClusterName
         SharedMysqlClientSecurityGroupId: !GetAtt SharedDatabaseSecurityGroupsStack.Outputs.SharedMysqlClientSecurityGroupId
         SharedPostgresqlClientSecurityGroupId: !GetAtt SharedDatabaseSecurityGroupsStack.Outputs.SharedPostgresqlClientSecurityGroupId
         SharedRedisClientSecurityGroupId: !GetAtt SharedRedisSecurityGroupStack.Outputs.ClientSecurityGroupId
+        SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
+        SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
         VpcId: !GetAtt SharedVpcStack.Outputs.VpcId
         VpcPublicSubnet1Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet1Id
       Tags:


### PR DESCRIPTION
Add some envs to un-hardcode things in the `awssh` and `awstunnel` scripting.  Given a region and environment-type, they should be able to ssh you into the jump server and pull the configs you need.

I'd also like to get all `awssh` traffic going _through_ the jump server instead of having port 22 open on every ECS instance.  Someday...