### PR TITLE
Create SSM VPC Endpoint

### DIFF
--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -30,6 +30,7 @@ Parameters:
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   EcsLaunchEndpointsAccessSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
+  SystemManagerEndpointAccessSecurityGroup: { Type: AWS::EC2::SecurityGroup::Id }
   KmsEndpointAccessSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   DeploymentPackageBucketName: { Type: String }
   EchoServiceToken: { Type: String }

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -157,6 +157,7 @@ Resources:
         VpcPrivateSubnet1Id: !Ref VpcPrivateSubnet1Id
         VpcPrivateSubnet2Id: !Ref VpcPrivateSubnet2Id
         VpcPrivateSubnet3Id: !Ref VpcPrivateSubnet3Id
+        SystemManagerEndpointAccessSecurityGroup: !Ref SystemManagerEndpointAccessSecurityGroup
         DovetailVerifiedMetricsKinesisStreamArn: !Ref DovetailVerifiedMetricsKinesisStreamArn
         DovetailVerifiedMetricsKinesisStreamName: !Ref DovetailVerifiedMetricsKinesisStreamName
         SharedRedisClientSecurityGroupId: !Ref SharedRedisClientSecurityGroupId

--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -113,6 +113,7 @@ Resources:
         VpcPublicSubnet3Id: !Ref VpcPublicSubnet3Id
         EcsLaunchEndpointsAccessSecurityGroupId: !Ref EcsLaunchEndpointsAccessSecurityGroupId
         KmsEndpointAccessSecurityGroupId: !Ref KmsEndpointAccessSecurityGroupId
+        SystemManagerEndpointAccessSecurityGroup: !Ref SystemManagerEndpointAccessSecurityGroup
         SharedAuroraPostgresqlEndpoint: !Ref SharedAuroraPostgresqlEndpoint
         SharedAuroraPostgresqlPort: !Ref SharedAuroraPostgresqlPort
         SharedPostgresqlClientSecurityGroupId: !Ref SharedPostgresqlClientSecurityGroupId

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -49,6 +49,7 @@ Parameters:
   VpcPublicSubnet3Id: { Type: AWS::EC2::Subnet::Id }
   EcsLaunchEndpointsAccessSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   KmsEndpointAccessSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
+  SystemManagerEndpointAccessSecurityGroup: { Type: AWS::EC2::SecurityGroup::Id }
   SharedAuroraPostgresqlEndpoint: { Type: String }
   SharedAuroraPostgresqlPort: { Type: String }
   SharedPostgresqlClientSecurityGroupId: { Type: String }
@@ -842,6 +843,7 @@ Resources:
           SECURITY_GROUP_3: !Ref KmsEndpointAccessSecurityGroupId
           SECURITY_GROUP_4: !Ref CastlePostgresClientSecurityGroupId
           SECURITY_GROUP_5: !Ref SharedPostgresqlClientSecurityGroupId
+          SECURITY_GROUP_6: !Ref SystemManagerEndpointAccessSecurityGroup
           STARTED_BY: !Ref AWS::StackName
           ENVIRONMENT_TYPE: !Ref EnvironmentType
           ROOT_STACK_ID: !Ref RootStackId
@@ -890,6 +892,7 @@ Resources:
                   process.env.SECURITY_GROUP_3,
                   process.env.SECURITY_GROUP_4,
                   process.env.SECURITY_GROUP_5,
+                  process.env.SECURITY_GROUP_6,
                 ],
               },
             },

--- a/stacks/apps/dovetail-analytics.yml
+++ b/stacks/apps/dovetail-analytics.yml
@@ -28,6 +28,7 @@ Parameters:
   VpcPrivateSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet3Id: { Type: AWS::EC2::Subnet::Id }
+  SystemManagerEndpointAccessSecurityGroup: { Type: AWS::EC2::SecurityGroup::Id }
   DovetailVerifiedMetricsKinesisStreamArn: { Type: String }
   DovetailVerifiedMetricsKinesisStreamName: { Type: String }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
@@ -1138,6 +1139,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt AnalyticsRedisFunctionSecurityGroup.GroupId
           - !Ref SharedRedisClientSecurityGroupId
+          - !Ref SystemManagerEndpointAccessSecurityGroup
         SubnetIds:
           - !Ref VpcPrivateSubnet1Id
           - !Ref VpcPrivateSubnet2Id

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -860,6 +860,7 @@ Resources:
         VpcPrivateSubnet2Id: !GetAtt SharedVpcStack.Outputs.PrivateSubnet2Id
         VpcPrivateSubnet3Id: !GetAtt SharedVpcStack.Outputs.PrivateSubnet3Id
         EcsLaunchEndpointsAccessSecurityGroupId: !GetAtt SharedVpcStack.Outputs.EcsLaunchEndpointsAccessSecurityGroupId
+        SystemManagerEndpointAccessSecurityGroup: !GetAtt SharedVpcStack.Outputs.SystemManagerEndpointAccessSecurityGroup
         KmsEndpointAccessSecurityGroupId: !GetAtt SharedVpcStack.Outputs.KmsEndpointAccessSecurityGroupId
         DeploymentPackageBucketName: !GetAtt Constants.DeploymentPackageBucketName
         EchoServiceToken: !GetAtt CustomResourcesStack.Outputs.EchoServiceToken

--- a/stacks/shared-vpc/interface-endpoints.yml
+++ b/stacks/shared-vpc/interface-endpoints.yml
@@ -143,6 +143,27 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
       VpcId: !Ref VpcId
+  SystemManagerEndpointAccessSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub >-
+        Allows outbound HTTPS traffic to flow to System Manager VPC Endpoints
+        in ${EnvironmentType}
+      SecurityGroupEgress:
+        - DestinationSecurityGroupId: !GetAtt SystemManagerEndpointInboundTrafficSecurityGroup.GroupId
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+      Tags:
+        - { Key: Name, Value: !Sub "${RootStackName}_shared-vpc_kinesis-streams-interface-access" }
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+      VpcId: !Ref VpcId
   EcsLaunchEndpointsAccessSecurityGroup:
     # This security group is intented to be used by EC2 instances, ECS
     # services, etc. Resources that belong to this group will be able to send
@@ -489,7 +510,7 @@ Resources:
 
   KinesisStreamsEndpointInboundTrafficSecurityGroup:
     # This security group is associated with the Kinesis Streams VPC Endpoint.
-    # Other security group that have egress rules to this group will have
+    # Other security groups that have egress rules to this group will have
     # Kinesis Streams access.
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -543,6 +564,63 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
 
+  SystemManagerEndpointInboundTrafficSecurityGroup:
+    # This security group is associated with the System Manager VPC Endpoint.
+    # Other security groups that have egress rules to this group will have
+    # System Manager access.
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub >-
+        Allows HTTPS traffic from the SystemManagerEndpointAccessSecurityGroup
+        to flow into the STS VPC Endpoint in ${EnvironmentType}
+      Tags:
+        - { Key: Name, Value: !Sub "${RootStackName}_shared-vpc_system-manager-interface-inbound" }
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+      VpcId: !Ref VpcId
+  SystemManagerEndpointInboundTrafficSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      FromPort: 443
+      GroupId: !GetAtt SystemManagerEndpointInboundTrafficSecurityGroup.GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId: !GetAtt SystemManagerEndpointAccessSecurityGroup.GroupId
+      ToPort: 443
+  SystemManagerVpcEndpoint:
+    # https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      PrivateDnsEnabled: true
+      SecurityGroupIds:
+        - !Ref EcsLaunchEndpointsInboundTrafficSecurityGroup
+        - !Ref SystemManagerEndpointInboundTrafficSecurityGroup
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
+      SubnetIds:
+        - !Ref PublicSubnet1Id
+        - !Ref PublicSubnet2Id
+        - !Ref PublicSubnet3Id
+      VpcEndpointType: Interface
+      VpcId: !Ref VpcId
+  SystemManagerVpcEndpointTags:
+    Type: Custom::Ec2ResourceTags
+    Properties:
+      ServiceToken: !Ref Ec2ResourceTaggerServiceToken
+      ResourceId: !Ref SystemManagerVpcEndpoint
+      Tags:
+        - { Key: Name, Value: !Sub "${RootStackName}_shared_system-manager" }
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+
 Outputs:
   EcsLaunchEndpointsAccessSecurityGroupId:
     Value: !GetAtt EcsLaunchEndpointsAccessSecurityGroup.GroupId
@@ -554,3 +632,5 @@ Outputs:
     Value: !GetAtt CloudWatchLogsEndpointAccessSecurityGroup.GroupId
   KinesisStreamsEndpointAccessSecurityGroupId:
     Value: !GetAtt KinesisStreamsEndpointAccessSecurityGroup.GroupId
+  SystemManagerEndpointAccessSecurityGroup:
+    Value: !GetAtt SystemManagerEndpointAccessSecurityGroup.GroupId


### PR DESCRIPTION
Adds a VPC Endpoint for SSM.

Also gives the shared ECS security group access to the endpoint.

Also gives explicit access to Augury slow worker and Dovetail Analytics Redis