### PR TITLE
Use only new hostname for The Count

### DIFF
--- a/stacks/apps/exchange.yml
+++ b/stacks/apps/exchange.yml
@@ -473,8 +473,6 @@ Resources:
               Value: mem_cache_store
             - Name: PAYPAL_ACTION_URL
               Value: !If [IsProduction, https://www.paypal.com/cgi-bin/webscr, https://www.sandbox.paypal.com/cgi-bin/webscr]
-            - Name: COUNT_HOST_NEW # TODO
-              Value: thecount.prx.org
           Essential: true
           Image: !Ref EcrImageTag
           LinuxParameters:
@@ -726,8 +724,6 @@ Resources:
               Value: mem_cache_store
             - Name: PAYPAL_ACTION_URL
               Value: !If [IsProduction, https://www.paypal.com/cgi-bin/webscr, https://www.sandbox.paypal.com/cgi-bin/webscr]
-            - Name: COUNT_HOST_NEW # TODO
-              Value: thecount.prx.org
           Essential: true
           Image: !Ref EcrImageTag
           LinuxParameters:
@@ -1092,8 +1088,6 @@ Resources:
               Value: mem_cache_store
             - Name: PAYPAL_ACTION_URL
               Value: !If [IsProduction, https://www.paypal.com/cgi-bin/webscr, https://www.sandbox.paypal.com/cgi-bin/webscr]
-            - Name: COUNT_HOST_NEW # TODO
-              Value: thecount.prx.org
           Essential: true
           Image: !Ref EcrImageTag
           LinuxParameters:

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -225,7 +225,7 @@ Resources:
       PublishHostname: !If [IsProduction, publish.prx.org, publish.staging.prx.tech]
       RemixHostname: !If [IsProduction, www.prx.mx, remix.staging.prx.tech]
       TheCastleHostname: !If [IsProduction, thecastle.prx.org, thecastle.staging.prx.tech]
-      TheCountHostname: !If [IsProduction, count.prx.org, thecount.staging.prx.tech] # TODO Update prod to thecount.prx.org
+      TheCountHostname: !If [IsProduction, thecount.prx.org, thecount.staging.prx.tech]
       TheWorldSearchHostname: !If [IsProduction, search.theworld.org, search.staging.theworld.org]
       # Internal application hostname
       FeederAuthProxyInternalHostname: !If [IsProduction, p.u.prx.tech, p.staging.u.prx.tech]


### PR DESCRIPTION
- Updates shared hostname value to new domain, which is used in `COUNT_HOST` envar
- Removes `COUNT_HOST_NEW` envar