### PR TITLE
Clean up DNS for The Count

### DIFF
--- a/dns/prx.org-hosted_zone.yml
+++ b/dns/prx.org-hosted_zone.yml
@@ -432,12 +432,6 @@ Resources:
             - cms.prx.tech.
           TTL: "300"
           Type: CNAME
-        # count.prx.org
-        - Name: !Sub count.${Domain}
-          ResourceRecords:
-            - "199.119.122.229"
-          TTL: "300"
-          Type: A
         # exchange.prx.org
         - Name: !Sub exchange.${Domain}
           ResourceRecords:

--- a/stacks/apps/the-count.yml
+++ b/stacks/apps/the-count.yml
@@ -47,8 +47,7 @@ Resources:
   Certificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
-      # TODO DomainName: !Ref CountHostname
-      DomainName: !If [IsProduction, thecount.prx.org, !Ref TheCountHostname]
+      DomainName: !Ref TheCountHostname
       Tags:
         - { Key: Name, Value: !Sub "${RootStackName}_the-count" }
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -76,8 +75,7 @@ Resources:
   DomainName:
     Type: AWS::ApiGatewayV2::DomainName
     Properties:
-      # TODO DomainName: !Ref CountHostname
-      DomainName: !If [IsProduction, thecount.prx.org, !Ref TheCountHostname]
+      DomainName: !Ref TheCountHostname
       DomainNameConfigurations:
         - CertificateArn: !Ref Certificate
       Tags:


### PR DESCRIPTION
- Removes legacy `count.prx.org` Contegix DNS record
- Replaces hard-coded `thecount.prx.org` value with the hostname parameter, which is now also `thecount.prx.org`