### PR TITLE
Switch all deliveries to go to Porter

### DIFF
--- a/stacks/apps/exchange.yml
+++ b/stacks/apps/exchange.yml
@@ -449,7 +449,7 @@ Resources:
             - Name: PORTER_AUDIO_PROCESSING
               Value: "true"
             - Name: PORTER_DELIVERIES
-              Value: "false"
+              Value: "true"
             - Name: PORTER_DELIVERY_BUCKET
               Value: !If [IsProduction, production.prxtransfer.org, testing.prxtransfer.org]
             - Name: PULL_DELIVERY_BUCKET
@@ -680,7 +680,7 @@ Resources:
             - Name: PORTER_AUDIO_PROCESSING
               Value: "true"
             - Name: PORTER_DELIVERIES
-              Value: "false"
+              Value: "true"
             - Name: PORTER_DELIVERY_BUCKET
               Value: !If [IsProduction, production.prxtransfer.org, testing.prxtransfer.org]
             - Name: PULL_DELIVERY_BUCKET


### PR DESCRIPTION
On top of the per series use_porter flag, this switches all deliveries to Porter, even those not in a series, or in a series not flagged to use Porter.
