### PR TITLE
Add redirect prefix to non-primary regions

### DIFF
--- a/stacks/apps-300A.yml
+++ b/stacks/apps-300A.yml
@@ -169,6 +169,7 @@ Resources:
         AuguryHostname: !Ref AuguryHostname
         FeederHostname: !Ref FeederHostname
         DovetailCdnHostname: !Ref DovetailCdnHostname
+        DovetailCdnRedirectPrefix: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Router/${AWS::Region}/redirect-prefix
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/apps/dovetail-router.yml
+++ b/stacks/apps/dovetail-router.yml
@@ -93,6 +93,7 @@ Parameters:
   AuguryHostname: { Type: String }
   FeederHostname: { Type: String }
   DovetailCdnHostname: { Type: String }
+  DovetailCdnRedirectPrefix: { Type: AWS::SSM::Parameter::Value<String> }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -795,6 +796,8 @@ Resources:
               Value: !Ref kApplicationPort
             - Name: REDIRECT_HOST
               Value: !Ref DovetailCdnHostname
+            - Name: REDIRECT_PREFIX
+              Value: !If [IsPrimaryRegion, !Ref "AWS::NoValue", !Ref DovetailCdnRedirectPrefix]
             - Name: REDIRECT_TTL
               Value: "86400"
             - Name: AUGURY_HOST


### PR DESCRIPTION
Leaving us-east-1 without a `REDIRECT_PREFIX` for now.  CloudFront knows that us-east-1 is the "default" region to send a realtime log to, when a request has no `/use1/` or `/usw2/` prefix/behavior.