### PR TITLE
gsuite subdomain for The World email migration

### DIFF
--- a/dns/theworld.org-hosted-zone.yml
+++ b/dns/theworld.org-hosted-zone.yml
@@ -66,6 +66,16 @@ Resources:
             - 10 ASPMX3.GOOGLEMAIL.COM.
           TTL: "3600"
           Type: MX
+        # Gsuite Side of Mail Migration
+        - Name: !Sub gsuite.${Domain}
+          ResourceRecords:
+            - 1 ASPMX.L.GOOGLE.COM.
+            - 5 ALT1.ASPMX.L.GOOGLE.COM.
+            - 5 ALT2.ASPMX.L.GOOGLE.COM.
+            - 10 ASPMX2.GOOGLEMAIL.COM.
+            - 10 ASPMX3.GOOGLEMAIL.COM.
+          TTL: "3600"
+          Type: MX
         # DMARC
         - Name: !Sub _dmarc.${Domain}
           ResourceRecords:


### PR DESCRIPTION
gsuite.theworld.org pointed to PRX Gmail

(done correct this time)