### PR TITLE
Office 365 side email migration changes

### DIFF
--- a/dns/theworld.org-hosted-zone.yml
+++ b/dns/theworld.org-hosted-zone.yml
@@ -42,6 +42,7 @@ Resources:
             - '"google-site-verification=AmP3tjFXQJg12mB6BkeWWipzwEOl1ZYlyjVSxTmzKbw"'
             - '"google-site-verification=muTtOe9lHpw4cK1h206kClidRJPqLVgJdKIwOkGTeZo"'
             - '"google-site-verification=_IB_vOu2XghTIYg_z50bsa94KgNh0TSZeqI2CVlmcfs"'
+            - '"MS=ms74236638"'
           TTL: "300"
           Type: TXT
         - Name: !Sub _now.${Domain}
@@ -74,6 +75,12 @@ Resources:
             - 5 ALT2.ASPMX.L.GOOGLE.COM.
             - 10 ASPMX2.GOOGLEMAIL.COM.
             - 10 ASPMX3.GOOGLEMAIL.COM.
+          TTL: "3600"
+          Type: MX
+        # O365 Side of Mail Migration
+        - Name: !Sub o365.${Domain}
+          ResourceRecords:
+            - 10 wgbh-org.mail.protection.outlook.com.
           TTL: "3600"
           Type: MX
         # DMARC


### PR DESCRIPTION
added two lines - MX record for o365.theworld.org pointing at GBH, and an MS verification TXT for theworld.org

Once you approve this one, go ahead and push it live, thanks!