### PR TITLE
Update theworld.org-hosted-zone.yml

### DIFF
--- a/dns/theworld.org-hosted-zone.yml
+++ b/dns/theworld.org-hosted-zone.yml
@@ -53,6 +53,7 @@ Resources:
         - Name: !Sub o365.${Domain}
           ResourceRecords:
             - '"MS=ms31071817"'
+            - '"v=spf1 include:spf.protection.outlook.com -all"'
           TTL: "3600"
           Type: TXT
 
@@ -85,7 +86,7 @@ Resources:
         # O365 Side of Mail Migration
         - Name: !Sub o365.${Domain}
           ResourceRecords:
-            - 10 wgbh-org.mail.protection.outlook.com.
+            - 10 o365-theworld-org.mail.protection.outlook.com.
           TTL: "3600"
           Type: MX
         # DMARC
@@ -148,6 +149,13 @@ Resources:
           ResourceRecords:
             - alias.zeit.co.
           TTL: "300"
+          Type: CNAME
+          
+        # o365
+        - Name: !Sub autodiscover.o365.${Domain}
+          ResourceRecords:
+            - autodiscover.outlook.com.
+          TTL: "3600"
           Type: CNAME
 
   Search:


### PR DESCRIPTION
3 updates for o365.theworld.org:

MX slight tweak
CNAME for autodiscover.o365.theworld.org > autodiscover.outlook.com. SPF TXT for o365.theworld.org

Please publish when approved, thanks!