### PR TITLE
Dovetail traffic lambda secret

### DIFF
--- a/stacks/apps/dovetail-router.yml
+++ b/stacks/apps/dovetail-router.yml
@@ -843,6 +843,8 @@ Resources:
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Router/augury-token
             - Name: FEEDER_TOKEN
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Router/feeder-token
+            - Name: TRAFFIC_SECRET
+              ValueFrom: /prx/global/Spire/Dovetail-Router/traffic-secret
             - Name: MAXMIND_LICENSE_KEY
               ValueFrom: /prx/global/Spire/maxmind/license-key
           Ulimits:

--- a/stacks/apps/dovetail-traffic.yml
+++ b/stacks/apps/dovetail-traffic.yml
@@ -26,6 +26,7 @@ Parameters:
   CloudWatchLogGroupTaggerServiceToken: { Type: String }
   CodeS3Bucket: { Type: String }
   CodeS3ObjectKey: { Type: AWS::SSM::Parameter::Value<String> }
+  DovetailRouterTrafficSecret: { Type: AWS::SSM::Parameter::Value<String>, Default: /prx/global/Spire/Dovetail-Router/traffic-secret }
 
 Resources:
   TrafficSqsQueue:
@@ -58,6 +59,7 @@ Resources:
           SCHEDULE_INTERVAL_MINUTES: !Ref kScheduleIntervalMinutes
           SQS_QUEUE_URL: !Ref TrafficSqsQueue
           SQS_QUEUE_REGION: !Ref AWS::Region
+          PRX_DT_TRAFFIC_SECRET: !Ref DovetailRouterTrafficSecret
       Events:
         SqsTrigger:
           Properties:


### PR DESCRIPTION
Upcoming changes will cut off the traffic lambda from generating fake downloads on our staging/demo podcasts.

This wires up a shared secret to continue allowing it for our demo/test podcasts.