### PR TITLE
Change to standard postgres env var names, like augury

### DIFF
--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -52,11 +52,7 @@ Parameters:
   FeederAuthProxyHostname: { Type: String }
   FeederAuthProxyInternalHostname: { Type: String }
   PublicFeedsHostname: { Type: String }
-  HoneycombApiKey:
-    {
-      Type: AWS::SSM::Parameter::Value<String>,
-      Default: /prx/global/Spire/honeycomb-api-key,
-    }
+  HoneycombApiKey: { Type: AWS::SSM::Parameter::Value<String>, Default: /prx/global/Spire/honeycomb-api-key }
   DovetailAppleApiBridgeEndpointUrl: { Type: String }
 
 Conditions:
@@ -153,10 +149,7 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - {
-            Key: prx:ops:cloudwatch-log-group-name,
-            Value: !Ref WorkerTaskLogGroup,
-          }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
 

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -230,10 +230,7 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - {
-            Key: prx:ops:cloudwatch-log-group-name,
-            Value: !Ref WorkerTaskLogGroup,
-          }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
 
@@ -406,10 +403,7 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - {
-            Key: prx:ops:cloudwatch-log-group-name,
-            Value: !Ref WebTaskLogGroup,
-          }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WebTaskLogGroup }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
 

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -52,7 +52,11 @@ Parameters:
   FeederAuthProxyHostname: { Type: String }
   FeederAuthProxyInternalHostname: { Type: String }
   PublicFeedsHostname: { Type: String }
-  HoneycombApiKey: { Type: AWS::SSM::Parameter::Value<String>, Default: /prx/global/Spire/honeycomb-api-key }
+  HoneycombApiKey:
+    {
+      Type: AWS::SSM::Parameter::Value<String>,
+      Default: /prx/global/Spire/honeycomb-api-key,
+    }
   DovetailAppleApiBridgeEndpointUrl: { Type: String }
 
 Conditions:
@@ -149,7 +153,10 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
+        - {
+            Key: prx:ops:cloudwatch-log-group-name,
+            Value: !Ref WorkerTaskLogGroup,
+          }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
 
@@ -230,7 +237,10 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
+        - {
+            Key: prx:ops:cloudwatch-log-group-name,
+            Value: !Ref WorkerTaskLogGroup,
+          }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
 
@@ -403,7 +413,10 @@ Resources:
         - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WebTaskLogGroup }
+        - {
+            Key: prx:ops:cloudwatch-log-group-name,
+            Value: !Ref WebTaskLogGroup,
+          }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
 
@@ -537,6 +550,12 @@ Resources:
             - ContainerPort: !Ref kWebApplicationPort
               HostPort: 0
           Secrets:
+            - Name: POSTGRES_DATABASE
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
+            - Name: POSTGRES_PASSWORD
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
+            - Name: POSTGRES_USER
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
             - Name: DB_ENV_POSTGRES_DATABASE
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
             - Name: DB_ENV_POSTGRES_PASSWORD
@@ -687,6 +706,12 @@ Resources:
           MemoryReservation: !If [IsProduction, 1000, 500]
           Name: !Ref kWorkerContainerName
           Secrets:
+            - Name: POSTGRES_DATABASE
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
+            - Name: POSTGRES_PASSWORD
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
+            - Name: POSTGRES_USER
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
             - Name: DB_ENV_POSTGRES_DATABASE
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
             - Name: DB_ENV_POSTGRES_PASSWORD


### PR DESCRIPTION
- part of the feeder rails 7 upgrade PR https://github.com/PRX/feeder.prx.org/pull/469
- adds now standard naming for postgres env var connection info
- once deployed, the old variable names `DB_ENV_*` can be removed