### PR TITLE
Truncate shipped IPv6s

### DIFF
--- a/etc/cdn-log-shipper/log-shipper.yml
+++ b/etc/cdn-log-shipper/log-shipper.yml
@@ -92,7 +92,6 @@ Resources:
         const crypto = require('crypto');
 
         const IPV4_MASK = /\.[0-9]{1,3}$/;
-        const IPV6_MASK = /:[0-9a-fA-F]{0,4}$/;
         const maskIp = (ip, field) => {
           if (ip.match(IPV4_MASK)) {
             return ip.replace(IPV4_MASK, '.0');

--- a/etc/cdn-log-shipper/log-shipper.yml
+++ b/etc/cdn-log-shipper/log-shipper.yml
@@ -100,7 +100,7 @@ Resources:
             // take up to 4 chunks - drop the rest
             const chunks = ip.split(':').slice(0, 4);
 
-            # remove all trailing ':', then add '::' (zeroes)
+            // remove all trailing ':', then add '::' (zeroes)
             return chunks.join(':').replace(/:+$/, '') + '::'
           } else if (ip === '-') {
             // that's ok
@@ -151,20 +151,19 @@ Resources:
             fields.push('prx-podcast-id');
             fields.push('prx-episode-guid');
 
-            // mask IP addresses
-            datas.forEach(data => {
-              data['c-ip'] = maskIp(data['c-ip'], 'c-ip');
-              const xffParts = (data['x-forwarded-for'] || '').split(',').map(s => s.trim()).filter(s => s);
-              data['x-forwarded-for'] = xffParts.map(ip => maskIp(ip, 'x-forwarded-for')).join(', ');
-            });
-
             // calculate listener_ids
             datas.forEach(data => {
-              // use leftmost XFF or IP in listener_id
-              const ip = data['x-forwarded-for'].split(', ')[0] || data['c-ip'] || '';
+              // use leftmost XFF or IP
+              const xffParts = (data['x-forwarded-for'] || '').split(',').map(s => s.trim()).filter(s => s);
+              const leftMostIp = xffParts[0] || data['c-ip'];
+
+              // truncate ipv6 but not ipv4
+              const truncatedIp = leftMostIp.includes(':') ? maskIp(leftMostIp, 'listener-id') : leftMostIp;
+
+              // combine with UA string
               const userAgent = data['cs(User-Agent)'] || '';
               const hmac = crypto.createHmac('sha256', process.env.SECRET_KEY || '');
-              hmac.update(ip + userAgent);
+              hmac.update(truncatedIp + userAgent);
               data['prx-listener-id'] = hmac.digest('base64').replace(/\+|\/|=/g, m => {
                 if (m === '+') { return '-'; }
                 if (m === '/') { return '_'; }
@@ -172,6 +171,13 @@ Resources:
               });
             });
             fields.push('prx-listener-id');
+
+            // mask IP addresses
+            datas.forEach(data => {
+              data['c-ip'] = maskIp(data['c-ip'], 'c-ip');
+              const xffParts = (data['x-forwarded-for'] || '').split(',').map(s => s.trim()).filter(s => s);
+              data['x-forwarded-for'] = xffParts.map(ip => maskIp(ip, 'x-forwarded-for')).join(', ');
+            });
 
             // write to tsv and gzip
             const tsv = fields.join('\t') + '\n' + datas.map(data => {

--- a/etc/cdn-log-shipper/log-shipper.yml
+++ b/etc/cdn-log-shipper/log-shipper.yml
@@ -96,10 +96,12 @@ Resources:
         const maskIp = (ip, field) => {
           if (ip.match(IPV4_MASK)) {
             return ip.replace(IPV4_MASK, '.0');
-          } else if (ip.endsWith(':')) {
-            return ip;
-          } else if (ip.match(IPV6_MASK)) {
-            return ip.replace(IPV6_MASK, ':0');
+          } else if (ip.includes(':')) {
+            // take up to 4 chunks - drop the rest
+            const chunks = ip.split(':').slice(0, 4);
+
+            # remove all trailing ':', then add '::' (zeroes)
+            return chunks.join(':').replace(/:+$/, '') + '::'
           } else if (ip === '-') {
             // that's ok
           } else {
@@ -149,12 +151,20 @@ Resources:
             fields.push('prx-podcast-id');
             fields.push('prx-episode-guid');
 
+            // mask IP addresses
+            datas.forEach(data => {
+              data['c-ip'] = maskIp(data['c-ip'], 'c-ip');
+              const xffParts = (data['x-forwarded-for'] || '').split(',').map(s => s.trim()).filter(s => s);
+              data['x-forwarded-for'] = xffParts.map(ip => maskIp(ip, 'x-forwarded-for')).join(', ');
+            });
+
             // calculate listener_ids
             datas.forEach(data => {
-              const literalIp = data['x-forwarded-for'] || data['c-ip'] || '';
+              // use leftmost XFF or IP in listener_id
+              const ip = data['x-forwarded-for'].split(', ')[0] || data['c-ip'] || '';
               const userAgent = data['cs(User-Agent)'] || '';
               const hmac = crypto.createHmac('sha256', process.env.SECRET_KEY || '');
-              hmac.update(literalIp + userAgent);
+              hmac.update(ip + userAgent);
               data['prx-listener-id'] = hmac.digest('base64').replace(/\+|\/|=/g, m => {
                 if (m === '+') { return '-'; }
                 if (m === '/') { return '_'; }
@@ -162,13 +172,6 @@ Resources:
               });
             });
             fields.push('prx-listener-id');
-
-            // mask IP addresses
-            datas.forEach(data => {
-              data['c-ip'] = maskIp(data['c-ip'], 'c-ip');
-              const xffParts = (data['x-forwarded-for'] || '').split(',').map(s => s.trim()).filter(s => s);
-              data['x-forwarded-for'] = xffParts.map(ip => maskIp(ip, 'x-forwarded-for')).join(', ');
-            });
 
             // write to tsv and gzip
             const tsv = fields.join('\t') + '\n' + datas.map(data => {


### PR DESCRIPTION
Per some IAB2.1...

We should only use half of IPv6 when calculating listener_ids.  But continue using all of IPv4.

While I was at it - also truncated the shipped IPv6 IPs / XFFs the same way.

Should probably test this out carefully before actually deploying.