### PR TITLE
Drop http api in favor of lambda url

### DIFF
--- a/stacks/apps-100A.yml
+++ b/stacks/apps-100A.yml
@@ -476,9 +476,9 @@ Outputs:
     Value: !GetAtt CmsStack.Outputs.TargetGroupFullName
 
   DovetailAppleApiBridgeEndpointUrl:
-    Value: !GetAtt DovetailAppleApiBridgeStack.Outputs.ApiUrl
-  DovetailAppleApiBridgeApiId:
-    Value: !GetAtt DovetailAppleApiBridgeStack.Outputs.ApiId
+    Value: !GetAtt DovetailAppleApiBridgeStack.Outputs.FunctionUrl
+  DovetailAppleApiBridgeFunctionId:
+    Value: !GetAtt DovetailAppleApiBridgeStack.Outputs.FunctionId
 
   DovetailCdnArrangerFunctionArn:
     Value: !GetAtt DovetailCdnArrangerStack.Outputs.ArrangerFunctionArn

--- a/stacks/apps/dovetail-apple-api-bridge.yml
+++ b/stacks/apps/dovetail-apple-api-bridge.yml
@@ -19,21 +19,6 @@ Parameters:
   CodeS3ObjectKey: { Type: AWS::SSM::Parameter::Value<String> }
 
 Resources:
-  HttpApi:
-    Type: AWS::Serverless::HttpApi
-    Properties:
-      Description: !Sub >-
-        ${EnvironmentType} Apple Api Bridge API
-      Tags:
-        prx:meta:tagging-version: "2021-04-07"
-        prx:cloudformation:stack-name: !Ref AWS::StackName
-        prx:cloudformation:stack-id: !Ref AWS::StackId
-        prx:cloudformation:root-stack-name: !Ref RootStackName
-        prx:cloudformation:root-stack-id: !Ref RootStackId
-        prx:ops:environment: !Ref EnvironmentType
-        prx:dev:family: Dovetail
-        prx:dev:application: Apple Api Bridge
-
   AppleApiBridgeFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -46,13 +31,6 @@ Resources:
       MemorySize: 128
       Architectures:
         - arm64
-      Events:
-        ApiRequest:
-          Properties:
-            ApiId: !Ref HttpApi
-            Method: post
-            Path: /bridge
-          Type: HttpApi
       Tags:
         prx:meta:tagging-version: "2021-04-07"
         prx:cloudformation:stack-name: !Ref AWS::StackName

--- a/stacks/apps/dovetail-apple-api-bridge.yml
+++ b/stacks/apps/dovetail-apple-api-bridge.yml
@@ -200,8 +200,7 @@ Resources:
 Outputs:
   FunctionUrl:
     Description: URL of the Apple API Bridge API
-    Value:
-      !GetAtt AppleApiBridgeFunctionUrl.FunctionUrl
+    Value: !GetAtt AppleApiBridgeFunctionUrl.FunctionUrl
   FunctionId:
     Description: Id of the Apple Api Bridge AWS Lambda
     Value: !Ref AppleApiBridgeFunction

--- a/stacks/apps/dovetail-apple-api-bridge.yml
+++ b/stacks/apps/dovetail-apple-api-bridge.yml
@@ -63,6 +63,11 @@ Resources:
         prx:dev:family: Dovetail
         prx:dev:application: Apple Api Bridge
       Timeout: 900
+  AppleApiBridgeFunctionUrl:
+    Type: AWS::Lambda::Url
+    Properties:
+      AuthType: NONE
+      TargetFunctionArn: !GetAtt AppleApiBridgeFunction.Arn
   AppleApiBridgeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     DeletionPolicy: Delete
@@ -193,10 +198,10 @@ Resources:
         - { Key: prx:dev:application, Value: Apple Api Bridge }
 
 Outputs:
-  ApiUrl:
+  FunctionUrl:
     Description: URL of the Apple API Bridge API
     Value:
-      Fn::Sub: "https://${HttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
-  ApiId:
-    Description: Api id of HttpApi for Apple Api Bridge
-    Value: !Ref HttpApi
+      !GetAtt AppleApiBridgeFunctionUrl.FunctionUrl
+  FunctionId:
+    Description: Id of the Apple Api Bridge AWS Lambda
+    Value: !Ref AppleApiBridgeFunction

--- a/stacks/dashboards.yml
+++ b/stacks/dashboards.yml
@@ -160,7 +160,7 @@ Resources:
                           [ "AWS/ApplicationELB", "RequestCount", "TargetGroup", "${CastleTargetGroupFullName}", "LoadBalancer", "${SharedAlbFullName}", { "label": "Castle" } ],
                           [ "AWS/ApplicationELB", "RequestCount", "TargetGroup", "${CmsTargetGroupFullName}", "LoadBalancer", "${SharedAlbFullName}", { "label": "CMS" } ],
                           [ "AWS/ApplicationELB", "RequestCount", "TargetGroup", "${DovetailTargetGroupFullName}", "LoadBalancer", "${DovetailAlbFullName}", { "label": "Dovetail-Router" } ],
-                          [ "AWS/ApiGateway", "Count", "ApiId", "${DovetailAppleApiBridgeApiId}", { "label": "Dovetail-Apple API Bridge" } ],
+                          [ "AWS/Lambda", "RequestCount", "UrlRequestCount", "FunctionName", ${DovetailAppleApiBridgeFunctionId}", { "label": "Dovetail-Apple API Bridge" } ],
                           [ "AWS/ApplicationELB", "RequestCount", "TargetGroup", "${ExchangeWebTargetGroupFullName}", "LoadBalancer", "${SharedAlbFullName}", { "label": "Exchange" } ],
                           [ "AWS/ApplicationELB", "RequestCount", "TargetGroup", "${FeederWebTargetGroupFullName}", "LoadBalancer", "${SharedAlbFullName}", { "label": "Feeder" } ],
                           [ "AWS/ApiGateway", "Count", "ApiId", "${FeederAuthProxyApiId}", { "label": "Feeder Auth Proxy" } ],

--- a/stacks/dashboards.yml
+++ b/stacks/dashboards.yml
@@ -41,7 +41,7 @@ Parameters:
   CmsElasticsearchDomainName: { Type: String }
   CmsTargetGroupFullName: { Type: String }
 
-  DovetailAppleApiBridgeApiId: { Type: String }
+  DovetailAppleApiBridgeFunctionId: { Type: String }
 
   DovetailAlbName: { Type: String }
   DovetailAlbFullName: { Type: String }

--- a/stacks/root.yml
+++ b/stacks/root.yml
@@ -874,7 +874,7 @@ Resources:
         CmsElasticsearchDomainName: !GetAtt Apps100AStack.Outputs.CmsElasticsearchDomainName
         CmsTargetGroupFullName: !GetAtt Apps100AStack.Outputs.CmsTargetGroupFullName
 
-        DovetailAppleApiBridgeApiId: !GetAtt Apps100AStack.Outputs.DovetailAppleApiBridgeApiId
+        DovetailAppleApiBridgeFunctionId: !GetAtt Apps100AStack.Outputs.DovetailAppleApiBridgeFunctionId
 
         DovetailAlbName: !GetAtt Apps300AStack.Outputs.DovetailAlbName
         DovetailAlbFullName: !GetAtt Apps300AStack.Outputs.DovetailAlbFullName


### PR DESCRIPTION
Looking at the upload functionality in feeder, I noticed that the http api gateway trigger has a fixed timeout and does not reflect the underlying lambda's timeout.

Digging a bit deeper, it looks like the lambda url resource on the lambda itself can be used to invoke the lambda directly and will honor the underlying timeout.

This PR:

- sets up a new lambda url resource on the lambda
- removes the api gateway trigger
- patches that new url through the stacks in place of the api gateway url