### PR TITLE
Fix/augury logged error alarms

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -716,13 +716,13 @@ Resources:
       AlarmName: !Sub ERROR [Augury] Web <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName})
       AlarmDescription: !Sub >-
         ${EnvironmentType} Augury's web task has logged an error. Check the logs!
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 3
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
       MetricName: !GetAtt Constants.WebLoggedErrorsMetricName
       Namespace: !Ref kMetricFilterNamespace
       Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 0
       TreatMissingData: notBreaching
   AuguryWorkerLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -730,13 +730,13 @@ Resources:
       AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName})
       AlarmDescription: !Sub >-
         ${EnvironmentType} Augury's worker task has logged an error. Check the logs!
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 3
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
       MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName
       Namespace: !Ref kMetricFilterNamespace
       Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 0
       TreatMissingData: notBreaching
   AugurySlowWorkerLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -744,13 +744,13 @@ Resources:
       AlarmName: !Sub ERROR [Augury] Slow Worker <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName})
       AlarmDescription: !Sub >-
         ${EnvironmentType} Augury's slow worker task has logged an error. Check the logs!
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 3
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
       MetricName: !GetAtt Constants.SlowWorkerLoggedErrorsMetricName
       Namespace: !Ref kMetricFilterNamespace
       Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 0
       TreatMissingData: notBreaching
   TargetingRecordCacheSizeMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -831,13 +831,13 @@ Resources:
       AlarmName: !Sub ERROR [Augury] Slow Worker <${EnvironmentTypeAbbreviation}> IS THROWING THE ERRORS (${RootStackName})
       AlarmDescription: !Sub >-
         ${EnvironmentType} Augury's slow worker task has raised an error. Check the logs!
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 3
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
       MetricName: !GetAtt Constants.SlowJobErrorsCountMetricName
       Namespace: !Ref kMetricFilterNamespace
       Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 0
       TreatMissingData: notBreaching
   AuguryJobsProducedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -845,13 +845,13 @@ Resources:
       AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> IS THROWING THE ERRORS (${RootStackName})
       AlarmDescription: !Sub >-
         ${EnvironmentType} Augury's worker task has raised an error. Check the logs!
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 3
+      ComparisonOperator: GreaterToThreshold
+      EvaluationPeriods: 1
       MetricName: !GetAtt Constants.JobErrorsCountMetricName
       Namespace: !Ref kMetricFilterNamespace
       Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 0
       TreatMissingData: notBreaching
   AuguryJobsProducedErrorsAlarmTags:
     Type: Custom::CloudWatchAlarmTags

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -687,7 +687,7 @@ Resources:
         { ($.level >= 50) && ($.level < 60) }
       LogGroupName: !Ref WebTaskLogGroup
       MetricTransformations:
-        - MetricName: !GettAtt Constants.WebLoggedErrorsMetricName
+        - MetricName: !GetAtt Constants.WebLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
   WorkersLoggedErrorsMetricFilter:

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -687,7 +687,7 @@ Resources:
         { ($.level >= 50) && ($.level < 60) }
       LogGroupName: !Ref WebTaskLogGroup
       MetricTransformations:
-        - MetricName: !Sub Constants.WebLoggedErrorsMetricName
+        - MetricName: !GettAtt Constants.WebLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
   WorkersLoggedErrorsMetricFilter:
@@ -697,7 +697,7 @@ Resources:
         { ($.level >= 50) && ($.level < 60) }
       LogGroupName: !Ref WorkerTaskLogGroup
       MetricTransformations:
-        - MetricName: !Sub Constants.WorkerLoggedErrorsMetricName
+        - MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
   WorkersSlowLoggedErrorsMetricFilter:
@@ -707,7 +707,7 @@ Resources:
         { ($.level >= 50) && ($.level < 60) }
       LogGroupName: !Ref SlowWorkerTaskLogGroup
       MetricTransformations:
-        - MetricName: !Sub Constants.SlowWorkerLoggedErrorsMetricName
+        - MetricName: !GetAtt Constants.SlowWorkerLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
   AuguryWebLoggedErrorsAlarm:
@@ -759,7 +759,7 @@ Resources:
         { $.type = "inventory.allocation_caching_states" }
       LogGroupName: !Ref WorkerTaskLogGroup
       MetricTransformations:
-        - MetricName: !Sub Constants.TargetingRecordCacheSizeMetricsName
+        - MetricName: !GetAtt Constants.TargetingRecordCacheSizeMetricsName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: $.max_flight_allocation_cache_entries.acs_entry_count
   AuguryActualsAreBehindAlarm:
@@ -804,7 +804,7 @@ Resources:
         flight(s). Check the logs and the TruncateExpiredDataJob job.
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 3
-      MetricName: !Sub Constants.TargetingRecordCacheSizeMetricsName
+      MetricName: !GetAtt Constants.TargetingRecordCacheSizeMetricsName
       Namespace: !Ref kMetricFilterNamespace
       Period: 300
       Statistic: Maximum

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -845,7 +845,7 @@ Resources:
       AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> IS THROWING THE ERRORS (${RootStackName})
       AlarmDescription: !Sub >-
         ${EnvironmentType} Augury's worker task has raised an error. Check the logs!
-      ComparisonOperator: GreaterToThreshold
+      ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       MetricName: !GetAtt Constants.JobErrorsCountMetricName
       Namespace: !Ref kMetricFilterNamespace


### PR DESCRIPTION
Fixes a set of alarms that don't work for a couple reasons:

- Too many evaluation periods to likely ever satisfy
- Incorrectly access the `Constants` resource attributes

This PR fixes the above, and switches the style to match the 500's alarm:

- Use a single evaluation period
- Use `GreaterThanThreshold`

In the modified alarms here, the alarm is considered existential: if the error occurs, then set off the alarm.  Re: Multiple evaluation periods, I think only in a self-healing scenario (like the actuals falling behind or forecasts slow down a bit) would we want to ignore the error metrics for a single evaluation period.  These alarms imply something has gone wrong that needs outside intervention.