### PR TITLE
Feat/tag augury logged error alarms

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -704,6 +704,22 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
+  AuguryWebLoggedAlarmTags:
+    Type: Custom::CloudWatchAlarmTags
+    Condition: EnableWorkers # See README
+    Properties:
+      ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
+      AlarmArn: !GetAtt AuguryWebLoggedErrorsAlarm.Arn
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WebTaskLogGroup }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Augury }
   WorkersLoggedErrorsMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -728,6 +744,22 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
+  AuguryWorkerLoggedAlarmTags:
+    Type: Custom::CloudWatchAlarmTags
+    Condition: EnableWorkers # See README
+    Properties:
+      ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
+      AlarmArn: !GetAtt AuguryWorkerLoggedErrorsAlarm.Arn
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Augury }
   WorkersSlowLoggedErrorsMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -752,6 +784,22 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
+  AugurySlowWorkerLoggedAlarmTags:
+    Type: Custom::CloudWatchAlarmTags
+    Condition: EnableWorkers # See README
+    Properties:
+      ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
+      AlarmArn: !GetAtt AugurySlowWorkerLoggedErrorsAlarm.Arn
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref SlowWorkerTaskLogGroup }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Augury }
   TargetingRecordCacheSizeMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -758,7 +758,7 @@ Resources:
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Augury }
-  WorkersSlowLoggedErrorsMetricFilter:
+  SlowWorkerLoggedErrorsMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       FilterPattern: |-

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -706,7 +706,6 @@ Resources:
       TreatMissingData: notBreaching
   WebLoggedErrorsAlarmTags:
     Type: Custom::CloudWatchAlarmTags
-    Condition: EnableWorkers # See README
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
       AlarmArn: !GetAtt WebLoggedErrorsAlarm.Arn
@@ -746,7 +745,6 @@ Resources:
       TreatMissingData: notBreaching
   WorkerLoggedErrorsAlarmTags:
     Type: Custom::CloudWatchAlarmTags
-    Condition: EnableWorkers # See README
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
       AlarmArn: !GetAtt WorkerLoggedErrorsAlarm.Arn
@@ -786,7 +784,6 @@ Resources:
       TreatMissingData: notBreaching
   SlowWorkerLoggedAlarmTags:
     Type: Custom::CloudWatchAlarmTags
-    Condition: EnableWorkers # See README
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
       AlarmArn: !GetAtt SlowWorkerLoggedErrorsAlarm.Arn

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -782,7 +782,7 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
-  SlowWorkerLoggedAlarmTags:
+  SlowWorkerLoggedErrorsAlarmTags:
     Type: Custom::CloudWatchAlarmTags
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -690,7 +690,7 @@ Resources:
         - MetricName: !GetAtt Constants.WebLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
-  AuguryWebLoggedErrorsAlarm:
+  WebLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ERROR [Augury] Web <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName})
@@ -704,12 +704,12 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
-  AuguryWebLoggedAlarmTags:
+  WebLoggedErrorsAlarmTags:
     Type: Custom::CloudWatchAlarmTags
     Condition: EnableWorkers # See README
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
-      AlarmArn: !GetAtt AuguryWebLoggedErrorsAlarm.Arn
+      AlarmArn: !GetAtt WebLoggedErrorsAlarm.Arn
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -730,7 +730,7 @@ Resources:
         - MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
-  AuguryWorkerLoggedErrorsAlarm:
+  WorkerLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName})
@@ -744,12 +744,12 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
-  AuguryWorkerLoggedAlarmTags:
+  WorkerLoggedErrorsAlarmTags:
     Type: Custom::CloudWatchAlarmTags
     Condition: EnableWorkers # See README
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
-      AlarmArn: !GetAtt AuguryWorkerLoggedErrorsAlarm.Arn
+      AlarmArn: !GetAtt WorkerLoggedErrorsAlarm.Arn
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -770,7 +770,7 @@ Resources:
         - MetricName: !GetAtt Constants.SlowWorkerLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
-  AugurySlowWorkerLoggedErrorsAlarm:
+  SlowWorkerLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ERROR [Augury] Slow Worker <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName})
@@ -784,12 +784,12 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
-  AugurySlowWorkerLoggedAlarmTags:
+  SlowWorkerLoggedAlarmTags:
     Type: Custom::CloudWatchAlarmTags
     Condition: EnableWorkers # See README
     Properties:
       ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
-      AlarmArn: !GetAtt AugurySlowWorkerLoggedErrorsAlarm.Arn
+      AlarmArn: !GetAtt SlowWorkerLoggedErrorsAlarm.Arn
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -690,26 +690,6 @@ Resources:
         - MetricName: !GetAtt Constants.WebLoggedErrorsMetricName
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: "1"
-  WorkersLoggedErrorsMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      FilterPattern: |-
-        { ($.level >= 50) && ($.level < 60) }
-      LogGroupName: !Ref WorkerTaskLogGroup
-      MetricTransformations:
-        - MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName
-          MetricNamespace: !Ref kMetricFilterNamespace
-          MetricValue: "1"
-  WorkersSlowLoggedErrorsMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      FilterPattern: |-
-        { ($.level >= 50) && ($.level < 60) }
-      LogGroupName: !Ref SlowWorkerTaskLogGroup
-      MetricTransformations:
-        - MetricName: !GetAtt Constants.SlowWorkerLoggedErrorsMetricName
-          MetricNamespace: !Ref kMetricFilterNamespace
-          MetricValue: "1"
   AuguryWebLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -724,6 +704,16 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
+  WorkersLoggedErrorsMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: |-
+        { ($.level >= 50) && ($.level < 60) }
+      LogGroupName: !Ref WorkerTaskLogGroup
+      MetricTransformations:
+        - MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName
+          MetricNamespace: !Ref kMetricFilterNamespace
+          MetricValue: "1"
   AuguryWorkerLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -738,6 +728,16 @@ Resources:
       Statistic: Sum
       Threshold: 0
       TreatMissingData: notBreaching
+  WorkersSlowLoggedErrorsMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: |-
+        { ($.level >= 50) && ($.level < 60) }
+      LogGroupName: !Ref SlowWorkerTaskLogGroup
+      MetricTransformations:
+        - MetricName: !GetAtt Constants.SlowWorkerLoggedErrorsMetricName
+          MetricNamespace: !Ref kMetricFilterNamespace
+          MetricValue: "1"
   AugurySlowWorkerLoggedErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
Fixes up the previous #669 

This:

- adds the tags to the "logged errors" alarms
- reformats so the metric filters, alarms and tags are cuddled together