### PR TITLE
Cleanup Feeder ENVs

### DIFF
--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -460,22 +460,16 @@ Resources:
             - web
           Cpu: !If [IsProduction, 200, 128]
           Environment:
-            - Name: RAILS_ENV
-              Value: !Ref EnvironmentTypeLowercase
+            - Name: ANNOUNCE_RESOURCE_PREFIX
+              Value: !Ref AnnounceResourcePrefix
             - Name: APPLE_API_BRIDGE_URL
               Value: !Ref DovetailAppleApiBridgeEndpointUrl
+            - Name: AWS_ACCOUNT_ID
+              Value: !Ref AWS::AccountId
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
             - Name: AWS_REGION
               Value: !Ref AWS::Region
-            - Name: AWS_ACCOUNT_ID
-              Value: !Ref AWS::AccountId
-            - Name: POSTGRES_HOST
-              Value: !Ref SharedAuroraPostgresqlEndpoint
-            - Name: POSTGRES_PORT
-              Value: !Ref SharedAuroraPostgresqlPort
-            - Name: ANNOUNCE_RESOURCE_PREFIX
-              Value: !Ref AnnounceResourcePrefix
             - Name: CMS_HOST
               Value: !Ref CmsHostname
             - Name: DATABASE_POOL_SIZE
@@ -486,6 +480,8 @@ Resources:
               Value: !Ref PublicFeedsHostname
             - Name: FEEDER_CDN_PRIVATE_HOST
               Value: !Ref FeederAuthProxyHostname
+            - Name: FEEDER_HOST
+              Value: !Ref FeederHostname
             - Name: ID_HOST
               Value: !Ref IdHostname
             - Name: NEW_RELIC_KEY
@@ -496,10 +492,14 @@ Resources:
               Value: !Ref kWebApplicationPort
             - Name: PORTER_SNS_TOPIC
               Value: !Ref PorterJobExecutionSnsTopicArn
+            - Name: POSTGRES_HOST
+              Value: !Ref SharedAuroraPostgresqlEndpoint
+            - Name: POSTGRES_PORT
+              Value: !Ref SharedAuroraPostgresqlPort
+            - Name: RAILS_ENV
+              Value: !Ref EnvironmentTypeLowercase
             - Name: PRX_HOST
               Value: !Ref BetaHostname
-            - Name: FEEDER_HOST
-              Value: !Ref FeederHostname
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrImageTag}
           LinuxParameters:
@@ -517,14 +517,14 @@ Resources:
             - ContainerPort: !Ref kWebApplicationPort
               HostPort: 0
           Secrets:
+            - Name: FEEDS_TOKEN
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/feeds-token
             - Name: POSTGRES_DATABASE
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
             - Name: POSTGRES_PASSWORD
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
             - Name: POSTGRES_USER
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
-            - Name: FEEDS_TOKEN
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/feeds-token
             - Name: PRX_CLIENT_ID
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/id-auth-client-id
             - Name: PRX_SECRET
@@ -593,22 +593,16 @@ Resources:
             - worker
           Cpu: !If [IsProduction, 200, 128]
           Environment:
+            - Name: ANNOUNCE_RESOURCE_PREFIX
+              Value: !Ref AnnounceResourcePrefix
             - Name: APPLE_API_BRIDGE_URL
               Value: !Ref DovetailAppleApiBridgeEndpointUrl
-            - Name: RAILS_ENV
-              Value: !Ref EnvironmentTypeLowercase
+            - Name: AWS_ACCOUNT_ID
+              Value: !Ref AWS::AccountId
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
             - Name: AWS_REGION
               Value: !Ref AWS::Region
-            - Name: AWS_ACCOUNT_ID
-              Value: !Ref AWS::AccountId
-            - Name: POSTGRES_HOST
-              Value: !Ref SharedAuroraPostgresqlEndpoint
-            - Name: POSTGRES_PORT
-              Value: !Ref SharedAuroraPostgresqlPort
-            - Name: ANNOUNCE_RESOURCE_PREFIX
-              Value: !Ref AnnounceResourcePrefix
             - Name: CMS_HOST
               Value: !Ref CmsHostname
             - Name: DATABASE_POOL_SIZE
@@ -619,6 +613,8 @@ Resources:
               Value: !Ref PublicFeedsHostname
             - Name: FEEDER_CDN_PRIVATE_HOST
               Value: !Ref FeederAuthProxyHostname
+            - Name: FEEDER_HOST
+              Value: !Ref FeederHostname
             - Name: ID_HOST
               Value: !Ref IdHostname
             - Name: NEW_RELIC_KEY
@@ -627,14 +623,18 @@ Resources:
               Value: !If [IsProduction, Feeder Production, Feeder Staging]
             - Name: PORTER_SNS_TOPIC
               Value: !Ref PorterJobExecutionSnsTopicArn
+            - Name: POSTGRES_HOST
+              Value: !Ref SharedAuroraPostgresqlEndpoint
+            - Name: POSTGRES_PORT
+              Value: !Ref SharedAuroraPostgresqlPort
             - Name: PRX_HOST
               Value: !Ref BetaHostname
+            - Name: RAILS_ENV
+              Value: !Ref EnvironmentTypeLowercase
             - Name: START_SAY_WHEN
               Value: true
             - Name: WORKER_COUNT
               Value: !If [IsProduction, 8, 5]
-            - Name: FEEDER_HOST
-              Value: !Ref FeederHostname
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrImageTag}
           LinuxParameters:
@@ -649,14 +649,14 @@ Resources:
           MemoryReservation: !If [IsProduction, 1000, 500]
           Name: !Ref kWorkerContainerName
           Secrets:
+            - Name: FEEDS_TOKEN
+              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/feeds-token
             - Name: POSTGRES_DATABASE
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
             - Name: POSTGRES_PASSWORD
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
             - Name: POSTGRES_USER
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
-            - Name: FEEDS_TOKEN
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/feeds-token
             - Name: PRX_CLIENT_ID
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/id-auth-client-id
             - Name: PRX_SECRET

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -464,8 +464,6 @@ Resources:
               Value: feeder
             - Name: RAILS_ENV
               Value: !Ref EnvironmentTypeLowercase
-            - Name: APP_ENV
-              Value: !Ref EnvironmentTypeAbbreviation
             - Name: APPLE_API_BRIDGE_URL
               Value: !Ref DovetailAppleApiBridgeEndpointUrl
             - Name: AWS_DEFAULT_REGION
@@ -478,12 +476,6 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: POSTGRES_PORT
               Value: !Ref SharedAuroraPostgresqlPort
-            - Name: DB_PORT_5432_TCP_ADDR
-              Value: !Ref SharedAuroraPostgresqlEndpoint
-            - Name: DB_PORT_5432_TCP_PORT
-              Value: !Ref SharedAuroraPostgresqlPort
-            - Name: FIXER_CALLBACK_QUEUE_NAME
-              Value: !GetAtt FixerCallbackQueue.QueueName
             - Name: ANNOUNCE_RESOURCE_PREFIX
               Value: !Ref AnnounceResourcePrefix
             - Name: CMS_HOST
@@ -498,8 +490,6 @@ Resources:
               Value: !Ref FeederAuthProxyHostname
             - Name: ID_HOST
               Value: !Ref IdHostname
-            - Name: LANG
-              Value: en_US.UTF-8
             - Name: NEW_RELIC_KEY
               Value: !Ref NewRelicApiKeyPrxLite
             - Name: NEW_RELIC_NAME
@@ -510,22 +500,12 @@ Resources:
               Value: !Ref PorterJobExecutionSnsTopicArn
             - Name: PRX_HOST
               Value: !Ref BetaHostname
-            - Name: RAILS_SERVE_STATIC_FILES
-              Value: enabled
-            - Name: WORKER_PAUSE
-              Value: "30"
             - Name: WORKER_DATABASE_POOL_SIZE
               Value: !If [IsProduction, 16, 5]
             - Name: WORKER_COUNT
               Value: !If [IsProduction, 8, 5]
             - Name: FEEDER_HOST
               Value: !Ref FeederHostname
-            - Name: OTEL_EXPORTER_OTLP_ENDPOINT
-              Value: https://api.honeycomb.io
-            - Name: OTEL_EXPORTER_OTLP_HEADERS
-              Value: !Sub x-honeycomb-team=${HoneycombApiKey}
-            - Name: OTEL_SERVICE_NAME
-              Value: !If [IsProduction, Feeder Production, Feeder Staging]
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrImageTag}
           LinuxParameters:
@@ -631,8 +611,6 @@ Resources:
               Value: !Ref DovetailAppleApiBridgeEndpointUrl
             - Name: RAILS_ENV
               Value: !Ref EnvironmentTypeLowercase
-            - Name: APP_ENV
-              Value: !Ref EnvironmentTypeAbbreviation
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
             - Name: AWS_REGION
@@ -643,12 +621,6 @@ Resources:
               Value: !Ref SharedAuroraPostgresqlEndpoint
             - Name: POSTGRES_PORT
               Value: !Ref SharedAuroraPostgresqlPort
-            - Name: DB_PORT_5432_TCP_ADDR
-              Value: !Ref SharedAuroraPostgresqlEndpoint
-            - Name: DB_PORT_5432_TCP_PORT
-              Value: !Ref SharedAuroraPostgresqlPort
-            - Name: FIXER_CALLBACK_QUEUE_NAME
-              Value: !GetAtt FixerCallbackQueue.QueueName
             - Name: ANNOUNCE_RESOURCE_PREFIX
               Value: !Ref AnnounceResourcePrefix
             - Name: CMS_HOST
@@ -663,8 +635,6 @@ Resources:
               Value: !Ref FeederAuthProxyHostname
             - Name: ID_HOST
               Value: !Ref IdHostname
-            - Name: LANG
-              Value: en_US.UTF-8
             - Name: NEW_RELIC_KEY
               Value: !Ref NewRelicApiKeyPrxLite
             - Name: NEW_RELIC_NAME
@@ -673,24 +643,14 @@ Resources:
               Value: !Ref PorterJobExecutionSnsTopicArn
             - Name: PRX_HOST
               Value: !Ref BetaHostname
-            - Name: RAILS_SERVE_STATIC_FILES
-              Value: enabled
             - Name: START_SAY_WHEN
               Value: "true"
-            - Name: WORKER_PAUSE
-              Value: "30"
             - Name: WORKER_DATABASE_POOL_SIZE
               Value: !If [IsProduction, 16, 5]
             - Name: WORKER_COUNT
               Value: !If [IsProduction, 8, 5]
             - Name: FEEDER_HOST
               Value: !Ref FeederHostname
-            - Name: OTEL_EXPORTER_OTLP_ENDPOINT
-              Value: https://api.honeycomb.io
-            - Name: OTEL_EXPORTER_OTLP_HEADERS
-              Value: !Sub x-honeycomb-team=${HoneycombApiKey}
-            - Name: OTEL_SERVICE_NAME
-              Value: !If [IsProduction, Feeder Production, Feeder Staging]
           Essential: true
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrImageTag}
           LinuxParameters:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -460,8 +460,6 @@ Resources:
             - web
           Cpu: !If [IsProduction, 200, 128]
           Environment:
-            - Name: APP_NAME
-              Value: feeder
             - Name: RAILS_ENV
               Value: !Ref EnvironmentTypeLowercase
             - Name: APPLE_API_BRIDGE_URL
@@ -481,7 +479,7 @@ Resources:
             - Name: CMS_HOST
               Value: !Ref CmsHostname
             - Name: DATABASE_POOL_SIZE
-              Value: "16"
+              Value: 16
             - Name: DOVETAIL_HOST
               Value: !Ref DovetailRouterHostname
             - Name: FEEDER_CDN_HOST
@@ -500,10 +498,6 @@ Resources:
               Value: !Ref PorterJobExecutionSnsTopicArn
             - Name: PRX_HOST
               Value: !Ref BetaHostname
-            - Name: WORKER_DATABASE_POOL_SIZE
-              Value: !If [IsProduction, 16, 5]
-            - Name: WORKER_COUNT
-              Value: !If [IsProduction, 8, 5]
             - Name: FEEDER_HOST
               Value: !Ref FeederHostname
           Essential: true
@@ -528,12 +522,6 @@ Resources:
             - Name: POSTGRES_PASSWORD
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
             - Name: POSTGRES_USER
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
-            - Name: DB_ENV_POSTGRES_DATABASE
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
-            - Name: DB_ENV_POSTGRES_PASSWORD
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
-            - Name: DB_ENV_POSTGRES_USER
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
             - Name: FEEDS_TOKEN
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/feeds-token
@@ -605,8 +593,6 @@ Resources:
             - worker
           Cpu: !If [IsProduction, 200, 128]
           Environment:
-            - Name: APP_NAME
-              Value: feeder
             - Name: APPLE_API_BRIDGE_URL
               Value: !Ref DovetailAppleApiBridgeEndpointUrl
             - Name: RAILS_ENV
@@ -626,7 +612,7 @@ Resources:
             - Name: CMS_HOST
               Value: !Ref CmsHostname
             - Name: DATABASE_POOL_SIZE
-              Value: "16"
+              Value: !If [IsProduction, 16, 5]
             - Name: DOVETAIL_HOST
               Value: !Ref DovetailRouterHostname
             - Name: FEEDER_CDN_HOST
@@ -644,9 +630,7 @@ Resources:
             - Name: PRX_HOST
               Value: !Ref BetaHostname
             - Name: START_SAY_WHEN
-              Value: "true"
-            - Name: WORKER_DATABASE_POOL_SIZE
-              Value: !If [IsProduction, 16, 5]
+              Value: true
             - Name: WORKER_COUNT
               Value: !If [IsProduction, 8, 5]
             - Name: FEEDER_HOST
@@ -670,12 +654,6 @@ Resources:
             - Name: POSTGRES_PASSWORD
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
             - Name: POSTGRES_USER
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
-            - Name: DB_ENV_POSTGRES_DATABASE
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-name
-            - Name: DB_ENV_POSTGRES_PASSWORD
-              ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-password
-            - Name: DB_ENV_POSTGRES_USER
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/database-username
             - Name: FEEDS_TOKEN
               ValueFrom: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/feeds-token

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -52,7 +52,6 @@ Parameters:
   FeederAuthProxyHostname: { Type: String }
   FeederAuthProxyInternalHostname: { Type: String }
   PublicFeedsHostname: { Type: String }
-  HoneycombApiKey: { Type: AWS::SSM::Parameter::Value<String>, Default: /prx/global/Spire/honeycomb-api-key }
   DovetailAppleApiBridgeEndpointUrl: { Type: String }
 
 Conditions:


### PR DESCRIPTION
I also sorted the ENVs, so probably easiest to review commit by commit.

Summary of changes:

- Removed `APP_NAME` ... that was an aws-secrets thing
- Removed `APP_ENV` ... also an aws-secrets thing
- Removed `DB_PORT_` vars - they were deprecated awhile back
- Removed `FIXER_CALLBACK_QUEUE_NAME` - Feeder doesn't use it.  It actually [interpolates it](https://github.com/PRX/feeder.prx.org/blob/main/app/models/task.rb#L58).
- Removed `LANG` - rails defaults to `en_US.UTF-8` anyways
- Removed `RAILS_SERVE_STATIC_FILES` - Feeder always serves static files now
- Removed `WORKER_PAUSE` - it already [defaults to 30](https://github.com/PRX/feeder.prx.org/blob/master/config/shoryuken.yml#L7)
- Removed `OTEL_` honeycomb stuff - unused.
- Removed `WORKER_DATABASE_POOL_SIZE`, and just set `DATABASE_POOL_SIZE` in the worker task def.  (I'm not sure why it had its own ENV?  Maybe for local development?)