### PR TITLE
Add NEW_RELIC_NAME to Exchange envars

### DIFF
--- a/stacks/apps/exchange.yml
+++ b/stacks/apps/exchange.yml
@@ -478,6 +478,8 @@ Resources:
               Value: "5"
             - Name: NEW_RELIC_LICENSE_KEY
               Value: !Ref NewRelicApiKeyPrxLite
+            - Name: NEW_RELIC_NAME
+              Value: !If [IsProduction, Exchange Production, Exchange Staging]
             - Name: CMS_API_VERSION
               Value: v1
             - Name: DATABASE_SOCKET
@@ -713,6 +715,8 @@ Resources:
               Value: "5"
             - Name: NEW_RELIC_LICENSE_KEY
               Value: !Ref NewRelicApiKeyPrxLite
+            - Name: NEW_RELIC_NAME
+              Value: !If [IsProduction, Exchange Production, Exchange Staging]
             - Name: CMS_API_VERSION
               Value: v1
             - Name: DATABASE_SOCKET


### PR DESCRIPTION
I don't know if this is why Exchange stopped reporting to NR, but it's the only app that didn't have this name configured as an envar. Maybe that's required now? I doubt it, but seems good to have here anyway.