### PR TITLE
Spread out augury web tasks

### DIFF
--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -288,12 +288,15 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
-      DesiredCount: !If [IsPrimaryRegion, !If [IsProduction, 12, 2], 0]
+      DesiredCount: !If [IsPrimaryRegion, !If [IsProduction, 10, 2], 0]
       EnableECSManagedTags: true
       LoadBalancers:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementStrategies:
+        - Field: "instanceId"
+          Type: "spread"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/stacks/apps/augury.yml
+++ b/stacks/apps/augury.yml
@@ -295,8 +295,8 @@ Resources:
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
       PlacementStrategies:
-        - Field: "instanceId"
-          Type: "spread"
+        - Field: instanceId
+          Type: spread
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }


### PR DESCRIPTION
Augury webs should be as spread out as possible.  Ideally only 1 per EC2 instance.