### PR TITLE
Add a new publishing queue for the feeder app

### DIFF
--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -230,7 +230,7 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Feeder } 
+        - { Key: prx:dev:application, Value: Feeder }
 
   FixerCallbackQueue:
     Type: AWS::SQS::Queue

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -155,6 +155,83 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
 
+  PublishingJobQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      DelaySeconds: 0
+      MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_feeder_publishing
+      ReceiveMessageWaitTimeSeconds: 0
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt PublishingJobDeadletterQueue.Arn
+        maxReceiveCount: 10
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Feeder }
+      VisibilityTimeout: 3600 # 1 hour
+  PublishingJobDeadletterQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      DelaySeconds: 0
+      MessageRetentionPeriod: 604800 # 7 days
+      QueueName: !Sub ${AnnounceResourcePrefix}_feeder_publishing_failures
+      ReceiveMessageWaitTimeSeconds: 0
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Feeder }
+      VisibilityTimeout: 3600 # 1 hour
+  PublishingJobDeadletterQueueMessageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProduction
+    Properties:
+      AlarmName: !Sub ERROR [Feeder] Publishing dead-letter queue <${EnvironmentTypeAbbreviation}> NOT EMPTY (${RootStackName})
+      AlarmDescription: !Sub >-
+        ${EnvironmentType} Feeder's dead-letter queue for the publishing
+        queue is not empty, which means some publishing jobs are not being processed.
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt PublishingJobDeadletterQueue.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Average
+      Threshold: 0
+      TreatMissingData: notBreaching
+  PublishingJobDeadletterQueueMessageAlarmTags:
+    Type: Custom::CloudWatchAlarmTags
+    Condition: IsProduction
+    Properties:
+      ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
+      AlarmArn: !GetAtt PublishingJobDeadletterQueueMessageAlarm.Arn
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Feeder } 
+
   FixerCallbackQueue:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete


### PR DESCRIPTION
Sets up a new `feeder_publishing`  queue for feeder jobs to work on publishing artifacts (RSS/Apple/etc).

Copies the default queue baseline CFN params for the SQS resource.