### PR TITLE
Use Node.js 16 for Dovetail Lambdas

### DIFF
--- a/stacks/apps/dovetail-cdn-arranger.yml
+++ b/stacks/apps/dovetail-cdn-arranger.yml
@@ -83,6 +83,7 @@ Resources:
       CompatibleRuntimes:
         - nodejs14.x
         - nodejs16.x
+        - nodejs18.x
       Content:
         S3Bucket: !Ref CodeS3Bucket
         S3Key: !Ref FfmpegLambdaLayerS3ObjectKey
@@ -116,7 +117,7 @@ Resources:
           - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:14
           - !Ref AWS::NoValue
       MemorySize: 8000
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Policies:
         - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
         - Statement:

--- a/stacks/apps/dovetail-counts.yml
+++ b/stacks/apps/dovetail-counts.yml
@@ -93,10 +93,10 @@ Resources:
       Layers:
         - Fn::If:
             - IsProduction
-            - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:14
+            - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:38
             - !Ref AWS::NoValue
       MemorySize: 2000
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Policies:
         - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
         - arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole

--- a/stacks/apps/dovetail-traffic.yml
+++ b/stacks/apps/dovetail-traffic.yml
@@ -74,7 +74,7 @@ Resources:
           Type: Schedule
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Policies:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole
         - Statement:


### PR DESCRIPTION
Could find anything that looked problematic in the app
https://github.com/PRX/dovetail-traffic-lambda
