### PR TITLE
Add hashed ip for Triton

### DIFF
--- a/etc/cdn-log-shipper/log-shipper.yml
+++ b/etc/cdn-log-shipper/log-shipper.yml
@@ -171,6 +171,15 @@ Resources:
             });
             fields.push('prx-listener-id');
 
+            datas.forEach(data => {
+              if (data['sc-range-start'].match(/^[0-9]+$/)) {
+                data['byte-range'] = `${data['sc-range-start']}-${data['sc-range-end']}`;
+              } else {
+                data['byte-range'] = '-';
+              }
+            });
+            fields.push('byte-range');
+
             // mask IP addresses
             datas.forEach(data => {
               data['c-ip'] = maskIp(data['c-ip'], 'c-ip');

--- a/etc/cdn-log-shipper/log-shipper.yml
+++ b/etc/cdn-log-shipper/log-shipper.yml
@@ -109,6 +109,16 @@ Resources:
           }
         };
 
+        const hashValue = (val) => {
+          const hmac = crypto.createHmac('sha256', process.env.SECRET_KEY || '');
+          hmac.update(val);
+          return hmac.digest('base64').replace(/\+|\/|=/g, m => {
+            if (m === '+') { return '-'; }
+            if (m === '/') { return '_'; }
+            return '';
+          });
+        };
+
         const PODCAST_IDS = process.env.PODCAST_IDS.split(',').map(s => s.trim()).filter(s => s);
 
         const IGNORE_PATHS = ['/', '/favicon.ico', '/robots.txt'];
@@ -161,24 +171,13 @@ Resources:
 
               // combine with UA string
               const userAgent = data['cs(User-Agent)'] || '';
-              const hmac = crypto.createHmac('sha256', process.env.SECRET_KEY || '');
-              hmac.update(truncatedIp + userAgent);
-              data['prx-listener-id'] = hmac.digest('base64').replace(/\+|\/|=/g, m => {
-                if (m === '+') { return '-'; }
-                if (m === '/') { return '_'; }
-                return '';
-              });
+              data['prx-listener-id'] = hashValue(truncatedIp + userAgent);
+
+              // also provide just the hashed IP, use truncated ipv6
+              data['prx-hashed-ip'] = hashValue(truncatedIp);
             });
             fields.push('prx-listener-id');
-
-            datas.forEach(data => {
-              if (data['sc-range-start'].match(/^[0-9]+$/)) {
-                data['byte-range'] = `${data['sc-range-start']}-${data['sc-range-end']}`;
-              } else {
-                data['byte-range'] = '-';
-              }
-            });
-            fields.push('byte-range');
+            fields.push('prx-hashed-ip');
 
             // mask IP addresses
             datas.forEach(data => {


### PR DESCRIPTION
For #684 
Not totally sure how to test this, but using a local script this seems to work ~, adding a single column for `byte-range`~
actually, they are fine with the separate start and end columns, they did ask for a hashed ip, so adding that instead.

*Don't merge until we get confirmation they want the truncated ipv6 used for the hashed ip*