### PR TITLE
Set up feeder alarms on error log levels

### DIFF
--- a/stacks/apps-200A.yml
+++ b/stacks/apps-200A.yml
@@ -284,6 +284,7 @@ Resources:
         BetaHostname: !Ref BetaHostname
         PublicFeedsHostname: !Ref PublicFeedsHostname
         DovetailAppleApiBridgeEndpointUrl: !Ref DovetailAppleApiBridgeEndpointUrl
+        EchoServiceToken: { Type: String }
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/apps-200A.yml
+++ b/stacks/apps-200A.yml
@@ -284,7 +284,7 @@ Resources:
         BetaHostname: !Ref BetaHostname
         PublicFeedsHostname: !Ref PublicFeedsHostname
         DovetailAppleApiBridgeEndpointUrl: !Ref DovetailAppleApiBridgeEndpointUrl
-        EchoServiceToken: { Type: String }
+        EchoServiceToken: !Ref EchoServiceToken
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -66,6 +66,12 @@ Conditions:
   EnableWorkers: !And [!Condition HasAuroraEndpoint, !Condition IsPrimaryRegion]
 
 Resources:
+  Constants:
+    Type: Custom::Echo
+    Properties:
+      WorkerLoggedErrorsMetricName: !Sub WorkerLoggedErrors${EnvironmentType}
+      WebLoggedErrorsMetricName: !Sub WebLoggedErrors${EnvironmentType}
+
   HostHeaderListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -74,7 +74,7 @@ Resources:
     Type: Custom::Echo
     Properties:
       ServiceToken: !Ref EchoServiceToken
-      WorkerLoggedtrrorsMetricName: !Sub WorkerLoggedErrors${EnvironmentType}
+      WorkerLoggedErrorsMetricName: !Sub WorkerLoggedErrors${EnvironmentType}
       WebLoggedErrorsMetricName: !Sub WebLoggedErrors${EnvironmentType}
 
   HostHeaderListenerRule:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -392,6 +392,7 @@ Resources:
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
+
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -368,7 +368,7 @@ Resources:
     Properties:
       AlarmName: !Sub ERROR [Feeder] Worker <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName} 2)
       AlarmDescription: !Sub >-
-        ${EnvironmentType} Augury's worker task has logged an error. Check the logs!
+        ${EnvironmentType} Feeder's worker task has logged an error. Check the logs!
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -314,7 +314,84 @@ Resources:
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
-
+  WebLoggedErrorsMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: |-
+        { ($.level >= 50) && ($.level < 60) }
+      LogGroupName: !Ref WebTaskLogGroup
+      MetricTransformations:
+        - MetricName: !GetAtt Constants.WebLoggedErrorsMetricName
+          MetricNamespace: !Ref kMetricFilterNamespace
+          MetricValue: "1"
+  WebLoggedErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ERROR [Feeder] Web <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName} 2)
+      AlarmDescription: !Sub >-
+        ${EnvironmentType} Feeder's web task has logged an error. Check the logs!
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: !GetAtt Constants.WebLoggedErrorsMetricName
+      Namespace: !Ref kMetricFilterNamespace
+      Period: 300
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+  WebLoggedErrorsAlarmTags:
+    Type: Custom::CloudWatchAlarmTags
+    Properties:
+      ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
+      AlarmArn: !GetAtt WebLoggedErrorsAlarm.Arn
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WebTaskLogGroup }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Feeder }
+  WorkersLoggedErrorsMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: |-
+        { ($.level >= 50) && ($.level < 60) }
+      LogGroupName: !Ref WorkerTaskLogGroup
+      MetricTransformations:
+        - MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName
+          MetricNamespace: !Ref kMetricFilterNamespace
+          MetricValue: "1"
+  WorkerLoggedErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ERROR [Feeder] Worker <${EnvironmentTypeAbbreviation}> IS LOGGING ERRORS (${RootStackName} 2)
+      AlarmDescription: !Sub >-
+        ${EnvironmentType} Augury's worker task has logged an error. Check the logs!
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: !GetAtt Constants.WorkerLoggedErrorsMetricName
+      Namespace: !Ref kMetricFilterNamespace
+      Period: 300
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+  WorkerLoggedErrorsAlarmTags:
+    Type: Custom::CloudWatchAlarmTags
+    Properties:
+      ServiceToken: !Ref CloudWatchAlarmTaggerServiceToken
+      AlarmArn: !GetAtt WorkerLoggedErrorsAlarm.Arn
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
+        - { Key: prx:dev:family, Value: Dovetail }
+        - { Key: prx:dev:application, Value: Feeder }
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -23,6 +23,9 @@ Parameters:
   kWebApplicationPort:
     Type: Number
     Default: 3000
+  kMetricFilterNamespace:
+    Type: String
+    Default: PRX/Feeder
   #######
   AlbFullName: { Type: String }
   AlbHttpsListenerArn: { Type: String }

--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -38,6 +38,7 @@ Parameters:
   RootStackId: { Type: String }
   CloudWatchAlarmTaggerServiceToken: { Type: String }
   CloudWatchLogGroupTaggerServiceToken: { Type: String }
+  EchoServiceToken: { Type: String }
   S3SigningUserName: { Type: String }
   S3SigningEndpointUrl: { Type: String }
   S3SigningAccessKeyId: { Type: String }
@@ -72,7 +73,8 @@ Resources:
   Constants:
     Type: Custom::Echo
     Properties:
-      WorkerLoggedErrorsMetricName: !Sub WorkerLoggedErrors${EnvironmentType}
+      ServiceToken: !Ref EchoServiceToken
+      WorkerLoggedtrrorsMetricName: !Sub WorkerLoggedErrors${EnvironmentType}
       WebLoggedErrorsMetricName: !Sub WebLoggedErrors${EnvironmentType}
 
   HostHeaderListenerRule:


### PR DESCRIPTION
Sets up alarms that are triggered on error log levels, similar to Augury.  A way to send messages to the team about errors, without relying on exceptions bubbling up, for things like https://github.com/PRX/feeder.prx.org/issues/714 