### PR TITLE
Fix feeder auth proxy atom link

### DIFF
--- a/stacks/apps/feeder.yml
+++ b/stacks/apps/feeder.yml
@@ -995,7 +995,7 @@ Resources:
           const body = data.replace(
             /<enclosure url="([^"]+)"/g,
             `<enclosure url="$1?auth=${auth}"`,
-          );
+          ).replace(/{\?auth}"/g, `?auth=${auth}"`);
           const headers = {
             'Content-Type': resp.headers['content-type'],
             'Cache-Control': `public, max-age=300`,


### PR DESCRIPTION
Need to also replace the auth in the RSS atom link:

```xml
<atom:link href="https://p.prxu.org/4647/subscriber/feed-rss.xml{?auth}" rel="self" type="application/rss+xml"/>
```

This auth proxy code feels kind of brittle?  But since we (Feeder) controls the RSS generation, I think this is pretty safe for now.  Until we want to rewrite this lambda as something better than an API Gateway (which has some known file size limitations) - that feels like the time to improve this code.