### PR TITLE
Router scaling

### DIFF
--- a/spire/templates/apps/dovetail-router.yml
+++ b/spire/templates/apps/dovetail-router.yml
@@ -932,17 +932,17 @@ Resources:
               source:
                 - aws.s3
       Handler: index.handler
-      InlineCode: |
+      InlineCode: !Sub |
         const AWS = require('aws-sdk');
         const s3 = new AWS.S3();
-        const ddb = new AWS.DynamoDB({ region: 'us-east-1' });
-        const ecs = new AWS.ECS({ region: 'us-east-1' });
+        const ddb = new AWS.DynamoDB({ region: '${AWS::Region}' });
+        const ecs = new AWS.ECS({ region: '${AWS::Region}' });
 
         const TABLE_NAME = process.env.DYNAMODB_TABLE_NAME;
         const CLUSTER_NAME = process.env.ECS_CLUSTER_NAME;
         const SERVICE_NAME = process.env.ECS_SERVICE_NAME;
         const SCALE_TO = {
-          '284/feed-rss.xml': 8,
+          '815/feed-rss.xml': 4,
           '70/feed-rss.xml': 20,
           'themoth/feed-rss.xml': 20,
         };
@@ -961,7 +961,7 @@ Resources:
           for (const match of matches) {
             guids.push(match[1]);
           }
-          console.info(`Read ${guids.length} guids from s3://${Bucket}/${Key}`);
+          console.info(`Read ${!guids.length} guids from s3://${!Bucket}/${!Key}`);
 
           // break into chunks of 100
           const allKeys = guids.map((g) => ({ guid: { S: g } }));
@@ -978,7 +978,7 @@ Resources:
             data.Responses[TABLE_NAME].forEach((r) => (found[r.guid.S] = true));
           }
           const newGuids = guids.filter((g) => !found[g]);
-          console.info(`Found ${newGuids.length} new guids not in DDB`);
+          console.info(`Found ${!newGuids.length} new guids not in DDB`);
 
           // scale ECS service
           if (newGuids.length > 0) {
@@ -987,7 +987,7 @@ Resources:
             const count = res.services[0].desiredCount;
             const desiredCount = SCALE_TO[Key];
             if (count < desiredCount) {
-              console.info(`Scaling from ${count} to ${desiredCount}`);
+              console.info(`Scaling from ${!count} to ${!desiredCount}`);
               const updateParams = {
                 cluster: CLUSTER_NAME,
                 service: SERVICE_NAME,
@@ -995,7 +995,7 @@ Resources:
               };
               await ecs.updateService(updateParams).promise();
             } else {
-              console.info(`Already at ${count}`);
+              console.info(`Already at ${!count}`);
             }
           }
 

--- a/spire/templates/apps/dovetail-router.yml
+++ b/spire/templates/apps/dovetail-router.yml
@@ -922,15 +922,10 @@ Resources:
           Properties:
             Pattern:
               detail:
-                bucket:
-                  name:
-                    - !Select [5, !Split [":", !Ref FeedsS3BucketArn]]
                 object:
                   key:
-                    - 815/feed-rss.xml
                     - 284/feed-rss.xml
                     - 70/feed-rss.xml
-                    - criminal/feed-rss.xml
                     - themoth/feed-rss.xml
               detail-type:
                 - Object Created
@@ -947,9 +942,8 @@ Resources:
         const CLUSTER_NAME = process.env.ECS_CLUSTER_NAME;
         const SERVICE_NAME = process.env.ECS_SERVICE_NAME;
         const SCALE_TO = {
-          '815/feed-rss.xml': 4,
+          '284/feed-rss.xml': 8,
           '70/feed-rss.xml': 20,
-          'criminal/feed-rss.xml': 16,
           'themoth/feed-rss.xml': 20,
         };
 

--- a/spire/templates/apps/dovetail-router.yml
+++ b/spire/templates/apps/dovetail-router.yml
@@ -924,7 +924,7 @@ Resources:
               detail:
                 object:
                   key:
-                    - 284/feed-rss.xml
+                    - 815/feed-rss.xml
                     - 70/feed-rss.xml
                     - themoth/feed-rss.xml
               detail-type:

--- a/storage/multi-region-replication/feeds.yml
+++ b/storage/multi-region-replication/feeds.yml
@@ -119,6 +119,9 @@ Resources:
         Rules:
           - NoncurrentVersionExpirationInDays: 1 # Permanently delete non-current versions
             Status: Enabled
+      NotificationConfiguration:
+        EventBridgeConfiguration:
+          EventBridgeEnabled: true
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
Closes #698

- Updates S3 bucket config (already deployed)
- Removes the bucket name from the EventBridge rule for triggering the scaler Lambda. This will now match on `Object Created` from any bucket, but we have EventBridge notifications turned on for very few buckets, and the likelihood of objects with these names being created in another bucket are pretty low. And even if we do get those false positives, we just scale up unnecessarily for a bit, which isn't really a problem.