### PR TITLE
Update hostnames for Augury and Feeder

### DIFF
--- a/spire/templates/apps-300A.yml
+++ b/spire/templates/apps-300A.yml
@@ -97,6 +97,7 @@ Resources:
         CastlePostgresInstanceEndpointPort: !Ref CastlePostgresInstanceEndpointPort
         CastlePostgresClientSecurityGroupId: !Ref CastlePostgresClientSecurityGroupId
         AdFilesHostname: !Ref AdFilesHostname
+        AuguryHostname: !Ref AuguryHostname
         FeederHostname: !Ref FeederHostname
         IdHostname: !Ref IdHostname
         CastleHostname: !Ref CastleHostname

--- a/spire/templates/apps/augury.yml
+++ b/spire/templates/apps/augury.yml
@@ -54,6 +54,7 @@ Parameters:
   CastlePostgresInstanceEndpointPort: { Type: String }
   CastlePostgresClientSecurityGroupId: { Type: String }
   AdFilesHostname: { Type: String }
+  AuguryHostname: { Type: String }
   FeederHostname: { Type: String }
   IdHostname: { Type: String }
   CastleHostname: { Type: String }
@@ -94,18 +95,24 @@ Resources:
             - inventory.dovetail.*
       ListenerArn: !Ref AlbHttpsListenerArn
       Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "01"]]
-  AltHostHeaderListenerRule:
+  RedirectHostHeaderListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       Actions:
-        - TargetGroupArn: !Ref TargetGroup
-          Type: forward
+        - RedirectConfig:
+            Host: !Ref AuguryHostname
+            Path: "/#{path}"
+            Port: "#{port}"
+            Protocol: "#{protocol}"
+            Query: "#{query}"
+            StatusCode: "HTTP_301"
+          Type: redirect
       Conditions:
         - Field: host-header
           Values:
             - augury.*
       ListenerArn: !Ref AlbHttpsListenerArn
-      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "02"]]
+      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "03"]]
 
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup

--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -68,7 +68,6 @@ Parameters:
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
-  IsStaging: !Equals [!Ref EnvironmentType, Staging]
   IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
   HasAuroraEndpoint: !Not [!Equals [!Ref SharedAuroraPostgresqlEndpoint, ""]]
   EnableWorkers: !And [!Condition HasAuroraEndpoint, !Condition IsPrimaryRegion]

--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -82,6 +82,10 @@ Resources:
       WebLoggedErrorsMetricName: !Sub WebLoggedErrors${EnvironmentType}
       PublicFeedsUrlPrefix: !Sub https://${PublicFeedsHostname}/f
 
+  # The canonical address for this app is podcasts.dovetail.prx.org.
+  # API traffic to the old feeder.prx.org domain should continue to be handled
+  # directly.
+  # All other traffic to feeder.prx.org should redirect to the new domain.
   HostHeaderListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
@@ -94,21 +98,7 @@ Resources:
             - podcasts.dovetail.*
       ListenerArn: !Ref AlbHttpsListenerArn
       Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "01"]]
-  AltHostHeaderListenerRule:
-    Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Condition: IsProduction
-    Properties:
-      Actions:
-        - TargetGroupArn: !Ref WebTargetGroup2
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - feeder.*
-      ListenerArn: !Ref AlbHttpsListenerArn
-      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "02"]]
-
-  Temp1ListenerRule:
+  LegacyApiWildcardListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Condition: IsStaging
     Properties:
@@ -123,8 +113,8 @@ Resources:
           Values:
             - /api/*
       ListenerArn: !Ref AlbHttpsListenerArn
-      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "07"]]
-  Temp3ListenerRule:
+      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "20"]]
+  LegacyApiRootListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Condition: IsStaging
     Properties:
@@ -139,8 +129,8 @@ Resources:
           Values:
             - /api
       ListenerArn: !Ref AlbHttpsListenerArn
-      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "08"]]
-  Temp2ListenerRule:
+      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "21"]]
+  LegacyRedirectListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Condition: IsStaging
     Properties:
@@ -158,7 +148,7 @@ Resources:
           Values:
             - feeder.*
       ListenerArn: !Ref AlbHttpsListenerArn
-      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "11"]]
+      Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "99"]]
 
   DefaultJobQueue:
     Type: AWS::SQS::Queue

--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -100,7 +100,6 @@ Resources:
       Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "01"]]
   LegacyApiWildcardListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Condition: IsStaging
     Properties:
       Actions:
         - TargetGroupArn: !Ref WebTargetGroup2
@@ -116,7 +115,6 @@ Resources:
       Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "20"]]
   LegacyApiRootListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Condition: IsStaging
     Properties:
       Actions:
         - TargetGroupArn: !Ref WebTargetGroup2
@@ -132,7 +130,6 @@ Resources:
       Priority: !Join ["", [!Ref AlbListenerRulePriorityPrefix, "21"]]
   LegacyRedirectListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Condition: IsStaging
     Properties:
       Actions:
         - RedirectConfig:

--- a/spire/templates/constants.yml
+++ b/spire/templates/constants.yml
@@ -47,7 +47,7 @@ Mappings:
     Production:
       EnvironmentTypeAbbreviation: prod
       EnvironmentTypeLowercase: production
-      AuguryHostname: augury.prx.org
+      AuguryHostname: inventory.dovetail.prx.org
       BetaHostname: beta.prx.org
       CastleHostname: castle.prx.org
       CmsHostname: cms.prx.org
@@ -57,7 +57,7 @@ Mappings:
       ExchangeHostname: exchange.prx.org
       ExchangeApiHostname: api.prx.org
       ExchangeTransferHostname: prxtransfer.org
-      FeederHostname: feeder.prx.org
+      FeederHostname: podcasts.dovetail.prx.org
       FeederAssetsHostname: assets.feeder.prx.org
       FeederAuthProxyHostname: p.prxu.org
       FixerHostname: fixer.prx.org


### PR DESCRIPTION
- Change `augury.` to a redirect
- Unify staging and prod rules for Feeder
- Send `/api` and `/api/*` Feeder traffic directly to target group
- Redirect all other traffic to `feeder.` to `podcasts.dovetail`