### PR TITLE
Switch from round_robin to least_outstanding_requests

### DIFF
--- a/spire/templates/apps/augury.yml
+++ b/spire/templates/apps/augury.yml
@@ -124,6 +124,8 @@ Resources:
       Port: 80
       Protocol: HTTP
       TargetGroupAttributes:
+        - Key: load_balancing.algorithm.type
+          Value: "least_outstanding_requests"
         - Key: deregistration_delay.timeout_seconds
           Value: "30"
       Tags:


### PR DESCRIPTION
Try switching from round-robin to least_outstanding requests to alleviate pressure on tasks with running requests.