### PR TITLE
Enable replication time control for the prxtransfer prod s3 bucket

### DIFF
--- a/storage/multi-region-replication/ftp-transfer.yml
+++ b/storage/multi-region-replication/ftp-transfer.yml
@@ -119,6 +119,10 @@ Resources:
           Rules:
             - Destination:
                 Bucket: !Ref DestinationBucketArn
+                ReplicationTime:
+                  Status: Enabled
+                  Time:
+                    Minutes: 15
               Status: Enabled
         - !Ref AWS::NoValue
       Tags:


### PR DESCRIPTION
activated manually for the bucket via the console