### PR TITLE
Use CloudFront Function JavaScript runtime 2.0 for Dovetail CDN

### DIFF
--- a/cdn/dovetail-cdn/cloudfront.yml
+++ b/cdn/dovetail-cdn/cloudfront.yml
@@ -177,7 +177,7 @@ Resources:
       FunctionCode: !GetAtt GithubCodeFetcher.ViewerRequestFunctionCode
       FunctionConfig:
         Comment: Handle viewer-requests for Dovetail 3 CDN
-        Runtime: cloudfront-js-1.0
+        Runtime: cloudfront-js-2.0
       Name: !Sub ${AWS::StackName}-viewer-request
   ViewerRequestCloudFrontFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
This shouldn't have any real impact for us, but 2.0 does include some newer JavaScript features we may want to use in the future.