### PR TITLE
Use policy variable for organization access

### DIFF
--- a/spire/templates/apps/dovetail-cdn-arranger.yml
+++ b/spire/templates/apps/dovetail-cdn-arranger.yml
@@ -96,7 +96,7 @@ Resources:
           - Action: s3:GetObject
             Condition:
               StringEquals:
-                aws:PrincipalOrgID: !Ref AwsOrganizationId
+                aws:ResourceOrgID: ${aws:PrincipalOrgID}
             Effect: Allow
             Principal:
               AWS: "*"

--- a/spire/templates/root.yml
+++ b/spire/templates/root.yml
@@ -227,7 +227,6 @@ Resources:
         RootStackName: !Ref AWS::StackName
         RootStackId: !Ref AWS::StackId
         EnvironmentType: !Ref EnvironmentType
-        AwsOrganizationId: !Ref AwsOrganizationId
         NestedChangeSetScrubbingResourcesState: !Ref NestedChangeSetScrubbingResourcesState
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/shared-dovetail-kinesis.yml
+++ b/spire/templates/shared-dovetail-kinesis.yml
@@ -9,7 +9,6 @@ Parameters:
   EnvironmentType: { Type: String }
   RootStackName: { Type: String }
   RootStackId: { Type: String }
-  AwsOrganizationId: { Type: String }
   NestedChangeSetScrubbingResourcesState: { Type: String }
 
 Conditions:

--- a/spire/templates/shared-dovetail-kinesis.yml
+++ b/spire/templates/shared-dovetail-kinesis.yml
@@ -51,7 +51,7 @@ Resources:
           - Action: sts:AssumeRole
             Condition:
               StringEquals:
-                aws:PrincipalOrgID: !Ref AwsOrganizationId
+                aws:ResourceOrgID: ${aws:PrincipalOrgID}
             Effect: Allow
             Principal:
               AWS: "*"


### PR DESCRIPTION
This is a more modern method of granting access to resources based on organization membership.

Rather than comparing the organization ID of the principal making a request to a static value, it compares the policy's own organization ID (represented by `aws:ResourceOrgID`) to a dynamic value coming from the policy evaluation (`${aws:PrincipalOrgID}`). When they're the same, the resource associated with the policy and the requesting principal are in the same organization, so access should be granted.

This achieves the same thing without having to pass the organization ID around every time this pattern is used.