### PR TITLE
Force FlowLog resource replacement

### DIFF
--- a/spire/templates/shared-vpc/flow-logs.yml
+++ b/spire/templates/shared-vpc/flow-logs.yml
@@ -63,12 +63,12 @@ Resources:
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
-  FlowLog:
+  FlowLogV7:
     Type: AWS::EC2::FlowLog
     Properties:
       DeliverLogsPermissionArn: !GetAtt DeliverLogsRole.Arn
-      # LogDestinationType: cloud-watch-logs
-      LogGroupName: !Ref FlowLogGroup
+      LogDestination: !GetAtt FlowLogGroup.Arn
+      LogDestinationType: cloud-watch-logs
       ResourceId: !Ref VpcId
       ResourceType: VPC
       Tags:


### PR DESCRIPTION
To support [the newest](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-vpc-flow-logs-for-elastic-container-services/) version of flow log format that include ECS data, I think we need to create a new flow log.

This replaces the existing flow log with a new one by changing the resource name, and also update some of the resource definition to the more modern format.