### PR TITLE
Update theworld.org DNS

### DIFF
--- a/dns/theworld.org-hosted-zone.yml
+++ b/dns/theworld.org-hosted-zone.yml
@@ -154,17 +154,17 @@ Resources:
           Name: !Sub api.${Domain}
 
         # Projects
-        - ResourceRecords:
-            - "23.185.0.4"
-          TTL: "3600"
-          Type: A
-          Name: !Sub projects.${Domain}
-        - ResourceRecords:
-            - 2620:12a:8000::4
-            - 2620:12a:8001::4
-          TTL: "3600"
-          Type: AAAA
-          Name: !Sub projects.${Domain}
+        # - ResourceRecords:
+        #     - "23.185.0.4"
+        #   TTL: "3600"
+        #   Type: A
+        #   Name: !Sub projects.${Domain}
+        # - ResourceRecords:
+        #     - 2620:12a:8000::4
+        #     - 2620:12a:8001::4
+        #   TTL: "3600"
+        #   Type: AAAA
+        #   Name: !Sub projects.${Domain}
 
   Search:
     Type: AWS::Route53::RecordSetGroup

--- a/dns/theworld.org-hosted-zone.yml
+++ b/dns/theworld.org-hosted-zone.yml
@@ -129,23 +129,42 @@ Resources:
       RecordSets:
         # Admin
         - ResourceRecords:
-            - "23.185.0.3"
+            - "23.185.0.4"
           TTL: "3600"
           Type: A
           Name: !Sub admin.${Domain}
         - ResourceRecords:
-            - 2620:12a:8000::3
-            - 2620:12a:8001::3
+            - 2620:12a:8000::4
+            - 2620:12a:8001::4
           TTL: "3600"
           Type: AAAA
           Name: !Sub admin.${Domain}
 
+        # API
+        - ResourceRecords:
+            - "23.185.0.4"
+          TTL: "3600"
+          Type: A
+          Name: !Sub api.${Domain}
+        - ResourceRecords:
+            - 2620:12a:8000::4
+            - 2620:12a:8001::4
+          TTL: "3600"
+          Type: AAAA
+          Name: !Sub api.${Domain}
+
         # Projects
-        - Name: !Sub projects.${Domain}
-          ResourceRecords:
-            - alias.zeit.co.
-          TTL: "300"
-          Type: CNAME
+        - ResourceRecords:
+            - "23.185.0.4"
+          TTL: "3600"
+          Type: A
+          Name: !Sub projects.${Domain}
+        - ResourceRecords:
+            - 2620:12a:8000::4
+            - 2620:12a:8001::4
+          TTL: "3600"
+          Type: AAAA
+          Name: !Sub projects.${Domain}
 
   Search:
     Type: AWS::Route53::RecordSetGroup
@@ -172,7 +191,12 @@ Resources:
       RecordSets:
         - Name: !Sub _acme-challenge.admin.${Domain}
           ResourceRecords:
-            - '"KMh9zENybgfkDH9qJ2mLJ_bOhlWItDy8uR0t_rJ-Ae8"'
+            - '"CcRIm8RSIdU6DhNGald4B3UkZ8aK2OrxXGMsyDE8n0E"'
+          TTL: "3600"
+          Type: TXT
+        - Name: !Sub _acme-challenge.api.${Domain}
+          ResourceRecords:
+            - '"l7wEmKbu4YmK-Qd8BG40HpGt18mcC9aGmjSaZSxZTmA"'
           TTL: "3600"
           Type: TXT
         - Name: !Sub _acme-challenge.feeds.${Domain}
@@ -183,6 +207,11 @@ Resources:
         - Name: !Sub _acme-challenge.files.${Domain}
           ResourceRecords:
             - '"x5VSDL-trt717dO4NeoA14OUehY4iJ2Njm8qVTsarEk"'
+          TTL: "3600"
+          Type: TXT
+        - Name: !Sub _acme-challenge.projects.${Domain}
+          ResourceRecords:
+            - '"gV2qmHfaqilCO_Q7a4tyKPSg4aa0CPcXY4U5o8e8qtU"'
           TTL: "3600"
           Type: TXT
         - Name: !Sub _acme-challenge.sitemap.${Domain}
@@ -215,20 +244,33 @@ Resources:
       Comment: Feeds
       HostedZoneId: !Ref HostedZone
       RecordSets:
-        # TNITN feed
+        # Numbers in the News feed
         - Name: !Sub feed.${Domain}
           ResourceRecords:
             - pf78e6d33db02b.publicfeeds.net.
           TTL: "3600"
           Type: CNAME
+        # Latest Edition feed
+        - Name: !Sub latest-edition.feed.${Domain}
+          ResourceRecords:
+            - pf0940laed.publicfeeds.net.
+          TTL: "3600"
+          Type: CNAME
+        # Latest Stories feed
+        - Name: !Sub latest-stories.feed.${Domain}
+          ResourceRecords:
+            - pf0938last.publicfeeds.net.
+          TTL: "3600"
+          Type: CNAME
+        # CMS feeds
         - ResourceRecords:
-            - "23.185.0.3"
+            - "23.185.0.4"
           TTL: "300"
           Type: A
           Name: !Sub feeds.${Domain}
         - ResourceRecords:
-            - 2620:12a:8000::3
-            - 2620:12a:8001::3
+            - 2620:12a:8000::4
+            - 2620:12a:8001::4
           TTL: "300"
           Type: AAAA
           Name: !Sub feeds.${Domain}
@@ -388,6 +430,18 @@ Resources:
         - Name: !Sub _69e3012e6d990b8b21c001001e70b2a0.feed.${Domain}
           ResourceRecords:
             - _1fcc43a42474af1ec05a29f236ca68a3.olprtlswtu.acm-validations.aws.
+          TTL: "3600"
+          Type: CNAME
+        #  latest-edition.feed.theworld.org
+        - Name: !Sub _5ca687f20932a70a7b7e0fbebc9e99a6.latest-edition.feed.${Domain}
+          ResourceRecords:
+            - _474298821bb6ea58215acc2162f2f4a2.djqtsrsxkq.acm-validations.aws.
+          TTL: "3600"
+          Type: CNAME
+        #  latest-stories.feed.theworld.org
+        - Name: !Sub _75db653e6e2656332b214816b114c90e.latest-stories.feed.${Domain}
+          ResourceRecords:
+            - _2124f019a520adb3d048435a4d00cac8.sdgjtdhdhz.acm-validations.aws.
           TTL: "3600"
           Type: CNAME
   AwsAcmLegacyUsEast1:

--- a/dns/theworld.org-hosted-zone.yml
+++ b/dns/theworld.org-hosted-zone.yml
@@ -154,17 +154,17 @@ Resources:
           Name: !Sub api.${Domain}
 
         # Projects
-        # - ResourceRecords:
-        #     - "23.185.0.4"
-        #   TTL: "3600"
-        #   Type: A
-        #   Name: !Sub projects.${Domain}
-        # - ResourceRecords:
-        #     - 2620:12a:8000::4
-        #     - 2620:12a:8001::4
-        #   TTL: "3600"
-        #   Type: AAAA
-        #   Name: !Sub projects.${Domain}
+        - ResourceRecords:
+            - "23.185.0.4"
+          TTL: "3600"
+          Type: A
+          Name: !Sub projects.${Domain}
+        - ResourceRecords:
+            - 2620:12a:8000::4
+            - 2620:12a:8001::4
+          TTL: "3600"
+          Type: AAAA
+          Name: !Sub projects.${Domain}
 
   Search:
     Type: AWS::Route53::RecordSetGroup


### PR DESCRIPTION
Update DNS to add records needed to get The World podcast feeds off Feedburner, and get YML file in sync with DNS changes made via Route 53 admin.

> __DO NOT MERGE/DEPLOY UNTIL ROUTTE 53 HAS BEEN UPDATE TO REVERT CHANGES TO MATCH YML DEFINITIONS PRIOR TO THIS PR.__

New feed records (provided via [Google doc](https://docs.google.com/spreadsheets/d/1BOCZlwOfa0RxGFf8pVwHLeyjxdvuVM57CFmDLgWzTw4/edit?gid=0#gid=0))

- add latest-edition.feed acm validation record
- add latest-edition.feed publicfeeds CNAME record
- add latest-stories.feed acm validation record
- add latest-stories.feed publicfeeds CNAME record

The following changes were made to get YML in sync with Route 53 (records changes tracked [here](https://prx.slack.com/lists/T0256R4CK/F07GT1P2203)):

- update admin records to point to WP host
- update admin acm challenge record value
- add api records to point to WP host
- add api acme challenge record
- updates feeds records to point to WP host
- remove projects CNAME to zeit host
- add projects records to point to WP host
- add projects acme challenge record