### PR TITLE
Treat missing data for some alarms as missing

### DIFF
--- a/spire/templates/apps/castle.yml
+++ b/spire/templates/apps/castle.yml
@@ -473,7 +473,7 @@ Resources:
       Statistic: Average
       Threshold: 50000000000
       Unit: Bytes
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
 
   # Resources that need access to the Castle DB (clients) belong to this
   # security group. It allows traffic to the cluster security group.

--- a/spire/templates/apps/cms.yml
+++ b/spire/templates/apps/cms.yml
@@ -638,7 +638,7 @@ Resources:
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:application, Value: CMS }
       Threshold: 60
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   AudioCallbackQueueVerySlowAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProduction
@@ -667,7 +667,7 @@ Resources:
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:application, Value: CMS }
       Threshold: 300
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   AudioCallbackDeadletterQueue:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete
@@ -765,7 +765,7 @@ Resources:
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:application, Value: CMS }
       Threshold: 60
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   ImageCallbackQueueVerySlowAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProduction
@@ -794,7 +794,7 @@ Resources:
         - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
         - { Key: prx:dev:application, Value: CMS }
       Threshold: 300
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   ImageCallbackDeadletterQueue:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete

--- a/spire/templates/apps/dovetail-analytics.yml
+++ b/spire/templates/apps/dovetail-analytics.yml
@@ -161,7 +161,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Analytics }
       Threshold: 900000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
       Unit: Milliseconds
 
   AnalyticsBigqueryFunctionKinesisIteratorStalledAlarm:
@@ -191,7 +191,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Analytics }
       Threshold: 3600000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
       Unit: Milliseconds
 
   AnalyticsBigqueryFunctionDownloadsMetricFilter:
@@ -620,7 +620,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Analytics }
       Threshold: 900000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
       Unit: Milliseconds
   AnalyticsDynamoDbFunctionKinesisIteratorStalledAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -649,7 +649,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Analytics }
       Threshold: 3600000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
       Unit: Milliseconds
 
   AnalyticsDynamoDbFunctionErrorLevelLogMetricFilter:
@@ -833,7 +833,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Analytics }
       Threshold: 900000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
       Unit: Milliseconds
   AnalyticsPingbacksFunctionKinesisIteratorStalledAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -862,7 +862,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Analytics }
       Threshold: 3600000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
       Unit: Milliseconds
 
   AnalyticsPingbacksFunctionErrorLevelLogMetricFilter:

--- a/spire/templates/apps/dovetail-counts.yml
+++ b/spire/templates/apps/dovetail-counts.yml
@@ -208,7 +208,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Counts }
       Threshold: 900000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   CountsFunctionKinesisIteratorStalledAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -236,7 +236,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Counts }
       Threshold: 3600000 # milliseconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
 
   CountsFunctionWarnLevelLogMetricFilter:
     Type: AWS::Logs::MetricFilter

--- a/spire/templates/apps/exchange.yml
+++ b/spire/templates/apps/exchange.yml
@@ -1008,7 +1008,7 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Exchange }
       Threshold: 50
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
 
   DeliveryUpdateQueueAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -1036,7 +1036,7 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Exchange }
       Threshold: 100
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
 
   FixerAudioQueue:
     Type: AWS::SQS::Queue

--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -226,7 +226,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
       Threshold: 900 # 15 minutes; ApproximateAgeOfOldestMessage is reported in seconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   DefaultJobDeadletterQueue:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete
@@ -330,7 +330,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
       Threshold: 3960 # 66 minutes; ApproximateAgeOfOldestMessage is reported in seconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   PublishingJobDeadletterQueue:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete
@@ -434,7 +434,7 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Feeder }
       Threshold: 900 # 15 minutes; ApproximateAgeOfOldestMessage is reported in seconds
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
   FixerCallbackDeadletterQueue:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete

--- a/spire/templates/apps/s3-signing.yml
+++ b/spire/templates/apps/s3-signing.yml
@@ -242,7 +242,6 @@ Resources:
         - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: S3 Signing Service }
-
       Threshold: 500
       TreatMissingData: notBreaching
 

--- a/spire/templates/shared-memcached.yml
+++ b/spire/templates/shared-memcached.yml
@@ -119,7 +119,7 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
       Threshold: 33000000
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
 
   SharedMemcachedHighSwapUsageAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -147,7 +147,7 @@ Resources:
         - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
         - { Key: prx:dev:application, Value: Common }
       Threshold: 50000000
-      TreatMissingData: notBreaching
+      TreatMissingData: missing
 
 Outputs:
   CacheName:


### PR DESCRIPTION
Closes https://github.com/PRX/internal/issues/1131

To be seen how often these don't have data. I'm assuming only during fairly major AWS issues. But we can dial things back if it's noisy. I went with `missing` rather than `breaching` so at least make it obvious when we see alarms because of this change.