### PR TITLE
More cdn-arranger tmp storage

### DIFF
--- a/spire/templates/apps/dovetail-cdn-arranger.yml
+++ b/spire/templates/apps/dovetail-cdn-arranger.yml
@@ -147,7 +147,8 @@ Resources:
           DOVETAIL_TOKEN: !Ref DovetailRouterToken
           TMP_DISK_LIMIT: 500000000
           WORKSPACE_S3_BUCKET: !Ref DtCdnArrangerWorkspaceBucket
-      EphemeralStorage: 4096
+      EphemeralStorage:
+        Size: 4096
       Handler: index.handler
       Layers:
         - !Ref FfmpegBinaryLayer

--- a/spire/templates/apps/dovetail-cdn-arranger.yml
+++ b/spire/templates/apps/dovetail-cdn-arranger.yml
@@ -147,6 +147,7 @@ Resources:
           DOVETAIL_TOKEN: !Ref DovetailRouterToken
           TMP_DISK_LIMIT: 500000000
           WORKSPACE_S3_BUCKET: !Ref DtCdnArrangerWorkspaceBucket
+      EphemeralStorage: 4096
       Handler: index.handler
       Layers:
         - !Ref FfmpegBinaryLayer


### PR DESCRIPTION
Hit an issue where a flac transcode needed more than 512mb.