### PR TITLE
Use cache.m6g.large everywhere

### DIFF
--- a/spire/templates/root.yml
+++ b/spire/templates/root.yml
@@ -545,7 +545,6 @@ Resources:
         RootStackId: !Ref AWS::StackId
         EnvironmentType: !Ref EnvironmentType
         EnvironmentTypeAbbreviation: !Ref EnvironmentTypeAbbreviation
-        RegionMode: !FindInMap [RegionModeMap, !Ref "AWS::Region", !Ref EnvironmentType]
         NestedChangeSetScrubbingResourcesState: !Ref NestedChangeSetScrubbingResourcesState
         VpcPrivateSubnet1Id: !GetAtt SharedVpcStack.Outputs.PrivateSubnet1Id
         VpcPrivateSubnet2Id: !GetAtt SharedVpcStack.Outputs.PrivateSubnet2Id

--- a/spire/templates/shared-redis/cluster.yml
+++ b/spire/templates/shared-redis/cluster.yml
@@ -11,7 +11,6 @@ Parameters:
   RootStackId: { Type: String }
   EnvironmentType: { Type: String }
   EnvironmentTypeAbbreviation: { Type: String }
-  RegionMode: { Type: String }
   NestedChangeSetScrubbingResourcesState: { Type: String }
   VpcPrivateSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   VpcPrivateSubnet2Id: { Type: AWS::EC2::Subnet::Id }
@@ -20,7 +19,6 @@ Parameters:
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
-  IsPrimaryRegion: !Equals [!Ref RegionMode, Primary]
   EnableNestedChangeSetScrubbingResources: !Equals [!Ref NestedChangeSetScrubbingResourcesState, Enabled]
 
 Resources:
@@ -51,7 +49,7 @@ Resources:
       AtRestEncryptionEnabled: false
       AutomaticFailoverEnabled: true
       AutoMinorVersionUpgrade: false
-      CacheNodeType: !If [IsProduction, !If [IsPrimaryRegion, cache.m6g.large, cache.t4g.medium], cache.t4g.small]
+      CacheNodeType: !If [IsProduction, cache.m6g.large, cache.t4g.small]
       CacheParameterGroupName: default.redis7.cluster.on
       CacheSubnetGroupName: !Ref RedisSubnetGroup
       Engine: Redis


### PR DESCRIPTION
We've hit some high memory alarms in us-west-2.  Revert to cache.m6g.large for now.