### PR TITLE
Add instance-type placement constraint to ECS tasks

### DIFF
--- a/spire/templates/apps/augury.yml
+++ b/spire/templates/apps/augury.yml
@@ -271,6 +271,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PlacementStrategies:
         - Field: instanceId
           Type: spread
@@ -295,6 +298,9 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: !If [IsProduction, 2, 1]
       EnableECSManagedTags: true
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/castle.yml
+++ b/spire/templates/apps/castle.yml
@@ -130,6 +130,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/cms.yml
+++ b/spire/templates/apps/cms.yml
@@ -343,6 +343,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -363,6 +366,9 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: 1
       EnableECSManagedTags: true
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/dovetail-router.yml
+++ b/spire/templates/apps/dovetail-router.yml
@@ -671,6 +671,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/exchange.yml
+++ b/spire/templates/apps/exchange.yml
@@ -355,6 +355,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kWebApplicationPort
           TargetGroupArn: !Ref WebTargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -595,6 +598,9 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: !If [IsProduction, 6, 1]
       EnableECSManagedTags: true
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -747,6 +747,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kWebApplicationPort
           TargetGroupArn: !Ref WebTargetGroup2
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -922,6 +925,9 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: 1
       EnableECSManagedTags: true
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/id.yml
+++ b/spire/templates/apps/id.yml
@@ -132,6 +132,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/iframely.yml
+++ b/spire/templates/apps/iframely.yml
@@ -138,6 +138,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/metrics.yml
+++ b/spire/templates/apps/metrics.yml
@@ -158,6 +158,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/networks.yml
+++ b/spire/templates/apps/networks.yml
@@ -249,6 +249,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kWebApplicationPort
           TargetGroupArn: !Ref PublicWebTargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -651,6 +654,9 @@ Resources:
             - !Ref VpcPrivateSubnet1Id
             - !Ref VpcPrivateSubnet2Id
             - !Ref VpcPrivateSubnet3Id
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/play.yml
+++ b/spire/templates/apps/play.yml
@@ -169,6 +169,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref WebTargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/remix.yml
+++ b/spire/templates/apps/remix.yml
@@ -237,6 +237,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/styleguide.yml
+++ b/spire/templates/apps/styleguide.yml
@@ -113,6 +113,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/the-castle.yml
+++ b/spire/templates/apps/the-castle.yml
@@ -216,6 +216,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kWebApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/theworld-website.yml
+++ b/spire/templates/apps/theworld-website.yml
@@ -116,6 +116,9 @@ Resources:
         - ContainerName: !Ref kContainerName
           ContainerPort: !Ref kApplicationPort
           TargetGroupArn: !Ref TargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }

--- a/spire/templates/apps/wfmt.yml
+++ b/spire/templates/apps/wfmt.yml
@@ -421,6 +421,9 @@ Resources:
         - ContainerName: !Ref kWebContainerName
           ContainerPort: !Ref kWebApplicationPort
           TargetGroupArn: !Ref WebTargetGroup
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
@@ -572,6 +575,9 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: 1
       EnableECSManagedTags: true
+      PlacementConstraints:
+        - Type: memberOf
+          Expression: attribute:ecs.instance-type == "x86_64"
       PropagateTags: TASK_DEFINITION
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }


### PR DESCRIPTION
This adds `PlacementConstraints` to each existing ECS service, ensuring that associated tasks are only placed on `x86_64` instances.

This shouldn't make any functional change to existing deployments, since all instances are `x86_64`.