### PR TITLE
Shared ALB WAF

### DIFF
--- a/spire/templates/shared-alb.yml
+++ b/spire/templates/shared-alb.yml
@@ -442,6 +442,20 @@ Resources:
         Allow: {}
       Description: !Sub WAF for Spire ${EnvironmentType} shared ALB
       Scope: REGIONAL
+      Rules:
+        - Action:
+            Challenge: {}
+          Name: reject-exchange-geo
+          Priority: 20
+          Statement:
+            GeoMatchStatement:
+              CountryCodes:
+                - CN
+                - HK
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: reject-exchange-geo
+            SampledRequestsEnabled: true
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/spire/templates/shared-alb.yml
+++ b/spire/templates/shared-alb.yml
@@ -435,30 +435,30 @@ Resources:
           SetIdentifier: !Ref AWS::StackName
           Type: A
 
-  # Waf:
-  #   Type: AWS::WAFv2::WebACL
-  #   Properties:
-  #     DefaultAction:
-  #       Allow: {}
-  #     Description: !Sub WAF for Spire ${EnvironmentType} shared ALB
-  #     Scope: REGIONAL
-  #     Tags:
-  #       - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-  #       - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-  #       - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-  #       - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-  #       - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-  #       - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-  #       - { Key: prx:dev:application, Value: Common }
-  #     VisibilityConfig:
-  #       CloudWatchMetricsEnabled: false
-  #       MetricName: !Sub ${Alb.LoadBalancerName}-WAF
-  #       SampledRequestsEnabled: false
-  # WafAssociation:
-  #   Type: AWS::WAFv2::WebACLAssociation
-  #   Properties:
-  #     ResourceArn: !Ref Alb
-  #     WebACLArn: !GetAtt Waf.Arn
+  Waf:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      DefaultAction:
+        Allow: {}
+      Description: !Sub WAF for Spire ${EnvironmentType} shared ALB
+      Scope: REGIONAL
+      Tags:
+        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
+        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
+        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
+        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
+        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
+        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
+        - { Key: prx:dev:application, Value: Common }
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: false
+        MetricName: !Sub ${Alb.LoadBalancerName}-WAF
+        SampledRequestsEnabled: false
+  WafAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref Alb
+      WebACLArn: !GetAtt Waf.Arn
 
 Outputs:
   AlbArn:


### PR DESCRIPTION
Adds a WAF to the shared ALB. Does not change the Dovetail Router ALB.

Meant to mimic the setup/rule that we currently have deployed.

This shouldn't be deployed until the existing WAF is torn down.