### PR TITLE
Service capacity providers

### DIFF
--- a/spire/templates/apps-100A.yml
+++ b/spire/templates/apps-100A.yml
@@ -48,6 +48,8 @@ Parameters:
   PorterJobExecutionSnsTopicArn: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailCdnLogsKinesisStreamArn: { Type: String }
   DovetailCountedKinesisStreamArn: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
+  Aarch64AsgCapacityProviderName: { Type: String }
 
   CmsSharedAlbListenerRulePriorityPrefix: { Type: String }
 
@@ -103,6 +105,7 @@ Resources:
         MetaHostname: !Ref MetaHostname
         NewRelicApiKeyPrxLite: !Ref NewRelicApiKeyPrxLite
         BetaHostname: !Ref BetaHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -294,6 +297,7 @@ Resources:
         SharedAuroraMysqlEndpoint: !Ref SharedAuroraMysqlEndpoint
         SharedAuroraMysqlPort: !Ref SharedAuroraMysqlPort
         TurnstileID: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/ID/turnstile-id
+        Aarch64AsgCapacityProviderName: !Ref Aarch64AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -322,6 +326,7 @@ Resources:
         EnvironmentTypeAbbreviation: !Ref EnvironmentTypeAbbreviation
         RootStackName: !Ref RootStackName
         RootStackId: !Ref RootStackId
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -352,6 +357,7 @@ Resources:
         RootStackName: !Ref RootStackName
         RootStackId: !Ref RootStackId
         PlayHostname: !Ref PlayHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -409,6 +415,7 @@ Resources:
         EnvironmentTypeAbbreviation: !Ref EnvironmentTypeAbbreviation
         RootStackName: !Ref RootStackName
         RootStackId: !Ref RootStackId
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -437,6 +444,7 @@ Resources:
         EnvironmentTypeAbbreviation: !Ref EnvironmentTypeAbbreviation
         RootStackName: !Ref RootStackName
         RootStackId: !Ref RootStackId
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/spire/templates/apps-200A.yml
+++ b/spire/templates/apps-200A.yml
@@ -78,6 +78,8 @@ Parameters:
   AnnounceResourcePrefix: { Type: String }
   PorterJobExecutionSnsTopicArn: { Type: AWS::SSM::Parameter::Value<String> }
   ClickhouseLegacyClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
+  X8664AsgCapacityProviderName: { Type: String }
+  Aarch64AsgCapacityProviderName: { Type: String }
 
   CastleSharedAlbListenerRulePriorityPrefix: { Type: String }
 
@@ -156,6 +158,7 @@ Resources:
         FeederHostname: !Ref FeederHostname
         IdHostname: !Ref IdHostname
         ClickhouseLegacyClientSecurityGroupId: !Ref ClickhouseLegacyClientSecurityGroupId
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -221,6 +224,7 @@ Resources:
         BetaHostname: !Ref BetaHostname
         TheCountHostname: !Ref TheCountHostname
         TheCastleHostname: !Ref TheCastleHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -283,6 +287,7 @@ Resources:
         DovetailAppleApiBridgeEndpointUrl: !Ref DovetailAppleApiBridgeEndpointUrl
         EchoServiceToken: !Ref EchoServiceToken
         SlackMessageRelaySnsTopicArn: !Ref SlackMessageRelaySnsTopicArn
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -316,6 +321,7 @@ Resources:
         RootStackName: !Ref RootStackName
         RootStackId: !Ref RootStackId
         IdHostname: !Ref IdHostname
+        Aarch64AsgCapacityProviderName: !Ref Aarch64AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -370,6 +376,7 @@ Resources:
         ExchangeHostname: !Ref ExchangeHostname
         ExchangeApiHostname: !Ref ExchangeApiHostname
         IdHostname: !Ref IdHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -409,6 +416,7 @@ Resources:
         TransferS3BucketArn: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Exchange/${AWS::Region}/ftp/s3-bucket-arn
         RemixHostname: !Ref RemixHostname
         ExchangeHostname: !Ref ExchangeHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/spire/templates/apps-300A.yml
+++ b/spire/templates/apps-300A.yml
@@ -60,6 +60,7 @@ Parameters:
   DovetailCountedKinesisStreamName: { Type: String }
   DovetailVerifiedMetricsKinesisStreamArn: { Type: String }
   DovetailVerifiedMetricsKinesisStreamName: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
   AugurySharedAlbListenerRulePriorityPrefix: { Type: String }
 
@@ -120,6 +121,7 @@ Resources:
         AdFilesS3BucketArn: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Augury/${AWS::Region}/ad-files-s3-bucket-arn
         SlackMessageRelaySnsTopicArn: !Ref SlackMessageRelaySnsTopicArn
         ClickhouseLegacyClientSecurityGroupId: !Ref ClickhouseLegacyClientSecurityGroupId
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -199,6 +201,7 @@ Resources:
         DovetailCdnRedirectPrefix: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Router/${AWS::Region}/redirect-prefix
         FrequencyDynamodbTableName: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Analytics/FREQUENCY_DDB_TABLE
         FrequencyDynamodbAccessRoleArn: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Analytics/FREQUENCY_DDB_ACCESS_ROLE
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -231,6 +234,7 @@ Resources:
         CastleHostname: !Ref CastleHostname
         IdHostname: !Ref IdHostname
         MetricsHostname: !Ref MetricsHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/spire/templates/apps-400A.yml
+++ b/spire/templates/apps-400A.yml
@@ -32,6 +32,7 @@ Parameters:
   S3SigningEndpointUrl: { Type: String }
   S3SigningAccessKeyId: { Type: String }
   AmazonSesSmtpCredentialsGeneratorServiceToken: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
   ExchangeHostname: { Type: String }
 
@@ -72,6 +73,7 @@ Resources:
         SharedAuroraMysqlEndpoint: !Ref SharedAuroraMysqlEndpoint
         SharedAuroraMysqlPort: !Ref SharedAuroraMysqlPort
         ExchangeHostname: !Ref ExchangeHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
@@ -181,6 +183,7 @@ Resources:
         AnnounceResourcePrefix: !Ref AnnounceResourcePrefix
         PorterJobExecutionSnsTopicArn: !Ref PorterJobExecutionSnsTopicArn
         ExchangeHostname: !Ref ExchangeHostname
+        X8664AsgCapacityProviderName: !Ref X8664AsgCapacityProviderName
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/spire/templates/apps/augury.yml
+++ b/spire/templates/apps/augury.yml
@@ -1180,13 +1180,6 @@ Resources:
         // ECS runTask parameters
         const runParams = (name) => {
           return {
-            capacityProviderStrategy: [
-              {
-                capacityProvider: process.env.X86_64_ASG_CAPACITY_PROVIDER_NAME,
-                base: 0,
-                weight: 1
-              }
-            ],
             cluster: process.env.ECS_CLUSTER_ARN,
             launchType: 'FARGATE',
             networkConfiguration: {

--- a/spire/templates/apps/augury.yml
+++ b/spire/templates/apps/augury.yml
@@ -68,6 +68,7 @@ Parameters:
   DovetailRouterHostname: { Type: String }
   AdFilesS3BucketArn: { Type: AWS::SSM::Parameter::Value<String> }
   SlackMessageRelaySnsTopicArn: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -260,6 +261,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -291,6 +296,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: EnableWorkers # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -1144,6 +1153,7 @@ Resources:
           ROOT_STACK_NAME: !Ref RootStackName
           STACK_ID: !Ref AWS::StackName
           STACK_NAME: !Ref AWS::StackId
+          X86_64_ASG_CAPACITY_PROVIDER_NAME: !Ref X8664AsgCapacityProviderName
       Events:
         SqsMessages:
           Type: SQS
@@ -1170,6 +1180,13 @@ Resources:
         // ECS runTask parameters
         const runParams = (name) => {
           return {
+            capacityProviderStrategy: [
+              {
+                capacityProvider: process.env.X86_64_ASG_CAPACITY_PROVIDER_NAME,
+                base: 0,
+                weight: 1
+              }
+            ],
             cluster: process.env.ECS_CLUSTER_ARN,
             launchType: 'FARGATE',
             networkConfiguration: {

--- a/spire/templates/apps/castle.yml
+++ b/spire/templates/apps/castle.yml
@@ -37,6 +37,7 @@ Parameters:
   SharedEcsAsgInstanceSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   FeederHostname: { Type: String }
   IdHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
   ClickhouseLegacyClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
 
 Conditions:
@@ -120,6 +121,10 @@ Resources:
   EcsService:
     Type: AWS::ECS::Service
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/cms.yml
+++ b/spire/templates/apps/cms.yml
@@ -56,6 +56,7 @@ Parameters:
   MetaHostname: { Type: String }
   NewRelicApiKeyPrxLite: { Type: String }
   BetaHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -333,6 +334,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -360,6 +365,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: EnableWorkers # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/dovetail-insights.yml
+++ b/spire/templates/apps/dovetail-insights.yml
@@ -36,6 +36,7 @@ Parameters:
   EcrImageTag: { Type: AWS::SSM::Parameter::Value<String> }
   AlbListenerRulePriorityPrefix: { Type: String }
   IdHostname: { Type: String }
+  Aarch64AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -177,6 +178,10 @@ Resources:
     Type: AWS::ECS::Service
     # Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref Aarch64AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/dovetail-router.yml
+++ b/spire/templates/apps/dovetail-router.yml
@@ -93,6 +93,7 @@ Parameters:
   FeederHostname: { Type: String }
   DovetailCdnHostname: { Type: String }
   DovetailRouterHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
   DovetailCdnRedirectPrefix: { Type: AWS::SSM::Parameter::Value<String> }
   FrequencyDynamodbTableName: { Type: AWS::SSM::Parameter::Value<String> }
   FrequencyDynamodbAccessRoleArn: { Type: AWS::SSM::Parameter::Value<String> }
@@ -661,6 +662,10 @@ Resources:
       - HttpListener
       - HttpsListener
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/exchange.yml
+++ b/spire/templates/apps/exchange.yml
@@ -73,6 +73,7 @@ Parameters:
   BetaHostname: { Type: String }
   TheCountHostname: { Type: String }
   TheCastleHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -345,6 +346,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -586,6 +591,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: EnableWorkers # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -962,6 +971,10 @@ Resources:
       Targets:
         - Arn: !Ref EcsClusterArn
           EcsParameters:
+            CapacityProviderStrategy:
+              - Base: 0
+                CapacityProvider: !Ref X8664AsgCapacityProviderName
+                Weight: 1
             TaskCount: 1
             TaskDefinitionArn: !Ref WorkerTaskDefinition
           Id: SayWhenRuleTarget

--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -72,6 +72,7 @@ Parameters:
   PublicFeedsHostname: { Type: String }
   DovetailAppleApiBridgeEndpointUrl: { Type: String }
   SlackMessageRelaySnsTopicArn: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -736,6 +737,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -910,6 +915,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: EnableWorkers # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/id.yml
+++ b/spire/templates/apps/id.yml
@@ -39,6 +39,7 @@ Parameters:
   PorterJobExecutionSnsTopicArn: { Type: String }
   SharedAuroraMysqlEndpoint: { Type: String }
   SharedAuroraMysqlPort: { Type: String }
+  Aarch64AsgCapacityProviderName: { Type: String }
   TurnstileID: { Type: AWS::SSM::Parameter::Value<String> }
 
 Conditions:
@@ -122,6 +123,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref Aarch64AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/iframely.yml
+++ b/spire/templates/apps/iframely.yml
@@ -24,6 +24,7 @@ Parameters:
   VpcId: { Type: AWS::EC2::VPC::Id }
   EcrImageTag: { Type: AWS::SSM::Parameter::Value<String> }
   AlbListenerRulePriorityPrefix: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -128,6 +129,10 @@ Resources:
   EcsService:
     Type: AWS::ECS::Service
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/metrics.yml
+++ b/spire/templates/apps/metrics.yml
@@ -28,6 +28,7 @@ Parameters:
   CastleHostname: { Type: String }
   IdHostname: { Type: String }
   MetricsHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -148,6 +149,10 @@ Resources:
   EcsService:
     Type: AWS::ECS::Service
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/networks.yml
+++ b/spire/templates/apps/networks.yml
@@ -60,6 +60,7 @@ Parameters:
   ExchangeHostname: { Type: String }
   ExchangeApiHostname: { Type: String }
   IdHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -239,6 +240,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -629,6 +634,10 @@ Resources:
       - SphinxServerSearchdNlbListener
       - SphinxServerWebNlbListener
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/play.yml
+++ b/spire/templates/apps/play.yml
@@ -28,6 +28,7 @@ Parameters:
   EcrImageTag: { Type: AWS::SSM::Parameter::Value<String> }
   AlbListenerRulePriorityPrefix: { Type: String }
   PlayHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -159,6 +160,10 @@ Resources:
   WebEcsService:
     Type: AWS::ECS::Service
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/remix.yml
+++ b/spire/templates/apps/remix.yml
@@ -40,6 +40,7 @@ Parameters:
   TransferS3BucketArn: { Type: AWS::SSM::Parameter::Value<String> }
   RemixHostname: { Type: String }
   ExchangeHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -227,6 +228,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -514,6 +519,10 @@ Resources:
       Targets:
         - Arn: !Ref EcsClusterArn
           EcsParameters:
+            CapacityProviderStrategy:
+              - Base: 0
+                CapacityProvider: !Ref X8664AsgCapacityProviderName
+                Weight: 1
             TaskCount: 1
             TaskDefinitionArn: !Ref WorkerTaskDefinition
           Id: RemixWorkerRuleTarget

--- a/spire/templates/apps/styleguide.yml
+++ b/spire/templates/apps/styleguide.yml
@@ -25,6 +25,8 @@ Parameters:
   VpcId: { Type: AWS::EC2::VPC::Id }
   EcrImageTag: { Type: AWS::SSM::Parameter::Value<String> }
   AlbListenerRulePriorityPrefix: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
+
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -103,6 +105,10 @@ Resources:
   EcsService:
     Type: AWS::ECS::Service
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/styleguide.yml
+++ b/spire/templates/apps/styleguide.yml
@@ -27,7 +27,6 @@ Parameters:
   AlbListenerRulePriorityPrefix: { Type: String }
   X8664AsgCapacityProviderName: { Type: String }
 
-
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
   EnableNestedChangeSetScrubbingResources: !Equals [!Ref NestedChangeSetScrubbingResourcesState, Enabled]

--- a/spire/templates/apps/the-castle.yml
+++ b/spire/templates/apps/the-castle.yml
@@ -40,6 +40,7 @@ Parameters:
   SharedAuroraMysqlEndpoint: { Type: String }
   SharedAuroraMysqlPort: { Type: String }
   ExchangeHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -206,6 +207,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: HasAuroraEndpoint # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -466,6 +471,10 @@ Resources:
       Targets:
         - Arn: !Ref EcsClusterArn
           EcsParameters:
+            CapacityProviderStrategy:
+              - Base: 0
+                CapacityProvider: !Ref X8664AsgCapacityProviderName
+                Weight: 1
             TaskCount: 1
             TaskDefinitionArn: !Ref WorkerTaskDefinition
           Id: TheCastleWorkerRuleTarget

--- a/spire/templates/apps/theworld-website.yml
+++ b/spire/templates/apps/theworld-website.yml
@@ -25,6 +25,7 @@ Parameters:
   VpcId: { Type: AWS::EC2::VPC::Id }
   EcrImageTag: { Type: AWS::SSM::Parameter::Value<String> }
   AlbListenerRulePriorityPrefix: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -106,6 +107,10 @@ Resources:
   EcsService:
     Type: AWS::ECS::Service
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/apps/wfmt.yml
+++ b/spire/templates/apps/wfmt.yml
@@ -44,6 +44,7 @@ Parameters:
   AnnounceResourcePrefix: { Type: String }
   PorterJobExecutionSnsTopicArn: { Type: String }
   ExchangeHostname: { Type: String }
+  X8664AsgCapacityProviderName: { Type: String }
 
 Conditions:
   IsProduction: !Equals [!Ref EnvironmentType, Production]
@@ -411,6 +412,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: EnableWeb
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -569,6 +574,10 @@ Resources:
     Type: AWS::ECS::Service
     Condition: EnableWorkers # See README
     Properties:
+      CapacityProviderStrategy:
+        - Base: 0
+          CapacityProvider: !Ref X8664AsgCapacityProviderName
+          Weight: 1
       Cluster: !Ref EcsClusterArn
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/spire/templates/root.yml
+++ b/spire/templates/root.yml
@@ -710,6 +710,8 @@ Resources:
         PorterJobExecutionSnsTopicArn: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/${AWS::Region}/porter-job-execution-topic-arn
         DovetailCdnLogsKinesisStreamArn: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailCdnLogsKinesisStreamArn
         DovetailCountedKinesisStreamArn: !GetAtt SharedDovetailKinesisStack.Outputs.DovetailCountedKinesisStreamArn
+        X8664AsgCapacityProviderName: !GetAtt SharedEcsAsgStack.Outputs.CapacityProviderName
+        Aarch64AsgCapacityProviderName: !GetAtt SharedEcsAsgAarch64Stack.Outputs.CapacityProviderName
 
         # App-specific parameters
 
@@ -814,6 +816,8 @@ Resources:
         PorterJobExecutionSnsTopicArn: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/${AWS::Region}/porter-job-execution-topic-arn
         DovetailAppleApiBridgeEndpointUrl: !GetAtt Apps100AStack.Outputs.DovetailAppleApiBridgeEndpointUrl
         ClickhouseLegacyClientSecurityGroupId: !GetAtt SharedClickhouseSecurityGroupStack.Outputs.LegacyClientSecurityGroupId
+        X8664AsgCapacityProviderName: !GetAtt SharedEcsAsgStack.Outputs.CapacityProviderName
+        Aarch64AsgCapacityProviderName: !GetAtt SharedEcsAsgAarch64Stack.Outputs.CapacityProviderName
 
         # App-specific parameters
 
@@ -898,6 +902,7 @@ Resources:
         SharedClickhouseEndpoint: !GetAtt SharedClickhouseStack.Outputs.PrivateDnsName
         SharedClickhousePort: !GetAtt SharedClickhouseStack.Outputs.HttpPort
         ClickhouseLegacyClientSecurityGroupId: !GetAtt SharedClickhouseSecurityGroupStack.Outputs.LegacyClientSecurityGroupId
+        X8664AsgCapacityProviderName: !GetAtt SharedEcsAsgStack.Outputs.CapacityProviderName
 
         # App-specific parameters
 
@@ -947,6 +952,7 @@ Resources:
         S3SigningEndpointUrl: !GetAtt Apps100AStack.Outputs.S3SigningEndpointUrl
         S3SigningAccessKeyId: !GetAtt Apps100AStack.Outputs.S3SigningAccessKeyId
         AmazonSesSmtpCredentialsGeneratorServiceToken: !GetAtt CustomResourcesStack.Outputs.AmazonSesSmtpCredentialsGeneratorServiceToken
+        X8664AsgCapacityProviderName: !GetAtt SharedEcsAsgStack.Outputs.CapacityProviderName
 
         # App-specific parameters
 

--- a/spire/templates/shared-ecs/asg-aarch64.yml
+++ b/spire/templates/shared-ecs/asg-aarch64.yml
@@ -403,6 +403,14 @@ Resources:
   # The capacity provider is associated with the ECS cluster in the x86-64
   # template, for that's where the association resource was originally created
   # and it's a pain to move.
+  #
+  # > [!NOTE]
+  # > This is poorly named. As of 2025, we have multiple capacity providers,
+  # and this one may or may not be part of the cluster's default capacity
+  # provider strategy. Even when it was, it was improper to name the logical ID
+  # of this resource as the "default". It is (or isn't) the default because of
+  # the way it's used, not inherently. It would be better named something like
+  # `BasicCapactiyProvider` or even just `CapacityProvider`.
   DefaultCapacityProvider:
     Type: AWS::ECS::CapacityProvider
     Properties:

--- a/spire/templates/shared-ecs/asg-x86-64.yml
+++ b/spire/templates/shared-ecs/asg-x86-64.yml
@@ -452,9 +452,6 @@ Resources:
         - Base: 0
           Weight: 1
           CapacityProvider: !Ref DefaultCapacityProvider
-        - Base: 0
-          Weight: 1
-          CapacityProvider: !Ref Aarch64AsgCapacityProviderName
 
 Outputs:
   AsgName:

--- a/spire/templates/shared-ecs/asg-x86-64.yml
+++ b/spire/templates/shared-ecs/asg-x86-64.yml
@@ -410,6 +410,13 @@ Resources:
         - !Ref VpcPublicSubnet2Id
         - !Ref VpcPublicSubnet3Id
 
+  # > [!NOTE]
+  # > This is poorly named. As of 2025, we have multiple capacity providers,
+  # and this one may or may not be part of the cluster's default capacity
+  # provider strategy. Even when it was, it was improper to name the logical ID
+  # of this resource as the "default". It is (or isn't) the default because of
+  # the way it's used, not inherently. It would be better named something like
+  # `BasicCapactiyProvider` or even just `CapacityProvider`.
   DefaultCapacityProvider:
     Type: AWS::ECS::CapacityProvider
     Properties:

--- a/spire/templates/shared-ecs/asg-x86-64.yml
+++ b/spire/templates/shared-ecs/asg-x86-64.yml
@@ -463,3 +463,5 @@ Resources:
 Outputs:
   AsgName:
     Value: !Ref Asg
+  CapacityProviderName:
+    Value: !Ref DefaultCapacityProvider


### PR DESCRIPTION
- Reverts the default capacity provider strategy for the ECS cluster to use only the x86 capacity provider (this only affects ECS services (not tasks) that are created from this point forward, it's essentially a no-op)
- Intended to explicitly set the capacity provider strategy on every ECS service and non-service task (things that use `runTask`, like cron workers and Augury slow worker Lambda function).

If this PR misses any services/tasks, that's not really a big deal (at this point), since they will continue to work as they have been.

The bigger deal would be if this gets the provider strategy _wrong_ (aarch64 when it should be x86, a malformed definition, etc) for any of the resources that it is affecting. This is redefining the capacity strategy for all ECS services, some which haven't been touched in years. The intention, though, is that the new explicit definition is identical to the existing configuration. CloudFormation will actually touch all of them, though, since it's new config in the CFN resources.

Key things to look for:
- That the `!GetAtt`s in `root.yml` are getting the correct value from the correct ASG template (no crossed wires where an aarch64 name ends up in an x64 parameter)
- That each service/task is using the correct provider for the desire platform (everything except Insights and ID should use x86)

This is probably not a Friday deploy.