### PR TITLE
Remove dupe alarm

### DIFF
--- a/spire/templates/apps/augury.yml
+++ b/spire/templates/apps/augury.yml
@@ -85,8 +85,6 @@ Resources:
     Properties:
       ServiceToken: !Ref EchoServiceToken
       ActualsIngestJobInvocationCountMetricName: !Sub ActualsIngestJobInvocationCountNewCluster${EnvironmentType}
-      JobErrorsCountMetricName: !Sub JobErrorsCountNewCluster${EnvironmentType}
-      SlowJobErrorsCountMetricName: !Sub SlowJobErrorsCountNewCluster${EnvironmentType}
       TargetingRecordCacheSizeMetricsName: !Sub TargetingRecordCacheSize${EnvironmentType}
       AdFilesS3BucketName: !Select [5, !Split [":", !Ref AdFilesS3BucketArn]]
       WorkerLoggedErrorsMetricName: !Sub WorkerLoggedErrors${EnvironmentType}
@@ -672,26 +670,6 @@ Resources:
         - MetricName: !Sub InventoryUpdateJobElapsed${EnvironmentType}
           MetricNamespace: !Ref kMetricFilterNamespace
           MetricValue: $.elapsed
-  WorkerJobsProducedErrorsMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      FilterPattern: |-
-        { $.msg = "*Error performing*" }
-      LogGroupName: !Ref WorkerTaskLogGroup
-      MetricTransformations:
-        - MetricName: !GetAtt Constants.JobErrorsCountMetricName
-          MetricNamespace: !Ref kMetricFilterNamespace
-          MetricValue: "1"
-  WorkerSlowJobsProducedErrorsMetricFilter:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      FilterPattern: |-
-        { $.msg = "*Error performing*" }
-      LogGroupName: !Ref SlowWorkerTaskLogGroup
-      MetricTransformations:
-        - MetricName: !GetAtt Constants.SlowJobErrorsCountMetricName
-          MetricNamespace: !Ref kMetricFilterNamespace
-          MetricValue: "1"
   WebLoggedErrorsMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -855,54 +833,6 @@ Resources:
         - { Key: prx:dev:family, Value: Dovetail }
         - { Key: prx:dev:application, Value: Augury }
       Threshold: 1000
-      TreatMissingData: notBreaching
-  AugurySlowJobsProducedErrorsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ERROR [Augury] Slow Worker <${EnvironmentTypeAbbreviation}> IS THROWING THE ERRORS (${RootStackName})
-      AlarmDescription: !Sub >-
-        ${EnvironmentType} Augury's slow worker task has raised an error. Check the logs!
-      ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
-      MetricName: !GetAtt Constants.SlowJobErrorsCountMetricName
-      Namespace: !Ref kMetricFilterNamespace
-      Period: 300
-      Statistic: Sum
-      Tags:
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Augury }
-      Threshold: 0
-      TreatMissingData: notBreaching
-  AuguryJobsProducedErrorsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ERROR [Augury] Worker <${EnvironmentTypeAbbreviation}> IS THROWING THE ERRORS (${RootStackName})
-      AlarmDescription: !Sub >-
-        ${EnvironmentType} Augury's worker task has raised an error. Check the logs!
-      ComparisonOperator: GreaterThanThreshold
-      EvaluationPeriods: 1
-      MetricName: !GetAtt Constants.JobErrorsCountMetricName
-      Namespace: !Ref kMetricFilterNamespace
-      Period: 300
-      Statistic: Sum
-      Tags:
-        - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
-        - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }
-        - { Key: prx:cloudformation:stack-id, Value: !Ref AWS::StackId }
-        - { Key: prx:cloudformation:root-stack-name, Value: !Ref RootStackName }
-        - { Key: prx:cloudformation:root-stack-id, Value: !Ref RootStackId }
-        - { Key: prx:ops:environment, Value: !Ref EnvironmentType }
-        - { Key: prx:ops:cloudwatch-log-group-name, Value: !Ref WorkerTaskLogGroup }
-        - { Key: prx:dev:family, Value: Dovetail }
-        - { Key: prx:dev:application, Value: Augury }
-      Threshold: 0
       TreatMissingData: notBreaching
   AuguryForecastsAreBehindAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
This is already handled by e.g. `WebLoggedErrorsAlarm` alarm using [the metrics filter on the log level](https://github.com/PRX/Infrastructure/blob/fbfd72cb3dc76f8cadf68d5731efd0689a169d0c/spire/templates/apps/augury.yml#L673-L682)