### PR TITLE
Auth Proxy fixes

### DIFF
--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -1226,6 +1226,8 @@ Resources:
             return text(403, 'nope, no feed for you!', 300);
           }
 
+          console.log('requesting', `http://${process.env.PUBLIC_FEED_DOMAIN}${event.path}`);
+
           const resp = await new Promise((resolve) => {
             http.get(`http://${process.env.PUBLIC_FEED_DOMAIN}${event.path}`, resolve);
           });
@@ -1254,7 +1256,7 @@ Resources:
           };
           return { statusCode: 200, body, headers };
         };
-      MemorySize: 192
+      MemorySize: 400
       Runtime: nodejs18.x
       Tags:
         prx:meta:tagging-version: "2021-04-07"


### PR DESCRIPTION
Saw a couple requests this morning that exceeded the 192mb memory this lambda had.  No idea which, as we don't log that.

Bumping the memory a bit and logging the feed urls for future debugging.