### PR TITLE
Give feeder tasks access to the uploads bucket

### DIFF
--- a/spire/templates/apps/feeder.yml
+++ b/spire/templates/apps/feeder.yml
@@ -671,6 +671,26 @@ Resources:
                 Sid: AllowObjectActions
             Version: "2012-10-17"
           PolicyName: FeedsBucket
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                Effect: Allow
+                Resource: !GetAtt FeederUploadsBucket.Arn
+              - Action:
+                  - s3:AbortMultipartUpload
+                  - s3:GetObject
+                  - s3:GetObjectAcl
+                  - s3:ListMultipartUploadParts
+                  - s3:PutObject
+                  - s3:PutObjectAcl
+                Effect: Allow
+                Resource: !Sub ${FeederUploadsBucket.Arn}/*
+            Version: "2012-10-17"
+          PolicyName: UploadsBucket
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }


### PR DESCRIPTION
The worker for Megaphone imports "simulates" uploading the audio to the uploads bucket, so the task needs access to wrote to this bucket.