### PR TITLE
Modernize ALB logs bucket policy

### DIFF
--- a/spire/templates/shared-alb.yml
+++ b/spire/templates/shared-alb.yml
@@ -10,52 +10,6 @@ Description: >-
   Creates application load balancers that can be reused for multiple
   applications, using host- and path-based routing rules.
 
-Mappings:
-  ElbService:
-    # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
-    us-east-1:
-      AccountId: "127311923021"
-    us-east-2:
-      AccountId: "033677994240"
-    us-west-1:
-      AccountId: "027434742980"
-    us-west-2:
-      AccountId: "797873946194"
-    af-south-1:
-      AccountId: "098369216593"
-    ca-central-1:
-      AccountId: "985666609251"
-    eu-central-1:
-      AccountId: "054676820928"
-    eu-west-1:
-      AccountId: "156460612806"
-    eu-west-2:
-      AccountId: "652711504416"
-    eu-south-1:
-      AccountId: "635631232127"
-    eu-west-3:
-      AccountId: "009996457667"
-    eu-north-1:
-      AccountId: "897822967062"
-    ap-east-1:
-      AccountId: "754344448648"
-    ap-northeast-1:
-      AccountId: "582318560864"
-    ap-northeast-2:
-      AccountId: "600734575887"
-    ap-northeast-3:
-      AccountId: "383597477331"
-    ap-southeast-1:
-      AccountId: "114774131450"
-    ap-southeast-2:
-      AccountId: "783225319266"
-    ap-south-1:
-      AccountId: "718504428378"
-    me-south-1:
-      AccountId: "076674570225"
-    sa-east-1:
-      AccountId: "507241528517"
-
 Parameters:
   EnvironmentType: { Type: String }
   EnvironmentTypeAbbreviation: { Type: String }
@@ -181,9 +135,7 @@ Resources:
           - Action: s3:PutObject
             Effect: Allow
             Principal:
-              AWS: !Sub
-                - arn:aws:iam::${ElbAccountId}:root
-                - ElbAccountId: !FindInMap [ElbService, !Ref "AWS::Region", AccountId]
+              Service: logdelivery.elasticloadbalancing.amazonaws.com
             Resource: !Sub ${AccessLogsBucket.Arn}/AWSLogs/${AWS::AccountId}/*
         Version: "2012-10-17"
   AccessLogsGlueTable:


### PR DESCRIPTION
When setting up some similar infrastructure for The World, I learned that AWS came up with a better way to handle bucket policies for log deliveries, which doesn't require per-region account IDs. Seems to be working with The World's ALB, so backporting it here.