### PR TITLE
Dovetail to valkey

### DIFF
--- a/spire/templates/apps-100A.yml
+++ b/spire/templates/apps-100A.yml
@@ -45,6 +45,8 @@ Parameters:
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
+  DovetailRedisReplicationGroupEndpointAddress: { Type: String }
+  DovetailRedisReplicationGroupEndpointPort: { Type: String }
   AnnounceResourcePrefix: { Type: String }
   PorterJobExecutionSnsTopicArn: { Type: AWS::SSM::Parameter::Value<String> }
   DovetailCdnLogsKinesisStreamArn: { Type: String }
@@ -204,6 +206,8 @@ Resources:
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
         SharedRedisClientSecurityGroupId: !Ref SharedRedisClientSecurityGroupId
+        DovetailRedisReplicationGroupEndpointAddress: !Ref DovetailRedisReplicationGroupEndpointAddress
+        DovetailRedisReplicationGroupEndpointPort: !Ref DovetailRedisReplicationGroupEndpointPort
       Tags:
         - { Key: prx:meta:tagging-version, Value: "2021-04-07" }
         - { Key: prx:cloudformation:stack-name, Value: !Ref AWS::StackName }

--- a/spire/templates/apps-200A.yml
+++ b/spire/templates/apps-200A.yml
@@ -36,6 +36,8 @@ Parameters:
   SharedMemcachedEndpointPort: { Type: String }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
+  DovetailRedisReplicationGroupEndpointAddress: { Type: String }
+  DovetailRedisReplicationGroupEndpointPort: { Type: String }
   AmazonSesSmtpCredentialsGeneratorServiceToken: { Type: String }
   EchoServiceToken: { Type: String }
   TransferServerIpFinderServiceToken: { Type: String }
@@ -154,6 +156,8 @@ Resources:
         CastlePostgresUserPassword: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Castle/database-root-password
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
+        DovetailRedisReplicationGroupEndpointAddress: !Ref DovetailRedisReplicationGroupEndpointAddress
+        DovetailRedisReplicationGroupEndpointPort: !Ref DovetailRedisReplicationGroupEndpointPort
         SharedEcsAsgInstanceSecurityGroupId: !Ref SharedEcsAsgInstanceSecurityGroupId
         FeederHostname: !Ref FeederHostname
         IdHostname: !Ref IdHostname

--- a/spire/templates/apps-300A.yml
+++ b/spire/templates/apps-300A.yml
@@ -32,6 +32,8 @@ Parameters:
   SharedEcsAsgInstanceSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
+  DovetailRedisReplicationGroupEndpointAddress: { Type: String }
+  DovetailRedisReplicationGroupEndpointPort: { Type: String }
   SharedAppRedisEndpointAddress: { Type: String }
   SharedAppRedisEndpointPort: { Type: String }
   SharedAuroraPostgresqlEndpoint: { Type: String }
@@ -193,6 +195,8 @@ Resources:
         DovetailCountedKinesisStreamArn: !Ref DovetailCountedKinesisStreamArn
         SharedRedisReplicationGroupEndpointAddress: !Ref SharedRedisReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !Ref SharedRedisReplicationGroupEndpointPort
+        DovetailRedisReplicationGroupEndpointAddress: !Ref DovetailRedisReplicationGroupEndpointAddress
+        DovetailRedisReplicationGroupEndpointPort: !Ref DovetailRedisReplicationGroupEndpointPort
         SharedGlueDatabaseName: !Ref SharedGlueDatabaseName
         FeedsS3BucketArn: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/Dovetail-Feeder/${AWS::Region}/s3-bucket-arn
         AuguryHostname: !Ref AuguryHostname

--- a/spire/templates/apps/castle.yml
+++ b/spire/templates/apps/castle.yml
@@ -232,9 +232,9 @@ Resources:
             - Name: AWS_DEFAULT_REGION
               Value: !Ref AWS::Region
             - Name: REDIS_HOST
-              Value: !Ref SharedRedisReplicationGroupEndpointAddress
+              Value: !If [IsProduction, !Ref SharedRedisReplicationGroupEndpointAddress, !Ref DovetailRedisReplicationGroupEndpointAddress]
             - Name: REDIS_PORT
-              Value: !Ref SharedRedisReplicationGroupEndpointPort
+              Value: !If [IsProduction, !Ref SharedRedisReplicationGroupEndpointPort, !Ref DovetailRedisReplicationGroupEndpointPort]
             - Name: REDIS_NAMESPACE
               Value: castle
             - Name: REDIS_POOL_SIZE

--- a/spire/templates/apps/castle.yml
+++ b/spire/templates/apps/castle.yml
@@ -34,6 +34,8 @@ Parameters:
   CastlePostgresUserPassword: { Type: AWS::SSM::Parameter::Value<String>, NoEcho: true }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
+  DovetailRedisReplicationGroupEndpointAddress: { Type: String }
+  DovetailRedisReplicationGroupEndpointPort: { Type: String }
   SharedEcsAsgInstanceSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   FeederHostname: { Type: String }
   IdHostname: { Type: String }

--- a/spire/templates/apps/dovetail-counts.yml
+++ b/spire/templates/apps/dovetail-counts.yml
@@ -84,6 +84,11 @@ Resources:
           ARRANGEMENTS_DDB_TABLE: !Ref ArrangementsDynamodbTableName
           KINESIS_IMPRESSION_STREAM: !Ref DovetailCountedKinesisStreamArn
           REDIS_URL: !Sub cluster://${SharedRedisReplicationGroupEndpointAddress}:${SharedRedisReplicationGroupEndpointPort}
+          REDIS_BACKUP_URL:
+            - Fn::If:
+                - IsProduction
+                - !Ref AWS::NoValue
+                - !Sub cluster://${DovetailRedisReplicationGroupEndpointAddress}:${DovetailRedisReplicationGroupEndpointPort}
       Events:
         CountsBytesKinesisTrigger:
           Properties:

--- a/spire/templates/apps/dovetail-counts.yml
+++ b/spire/templates/apps/dovetail-counts.yml
@@ -34,6 +34,8 @@ Parameters:
   DovetailCountedKinesisStreamArn: { Type: String }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
+  DovetailRedisReplicationGroupEndpointAddress: { Type: String }
+  DovetailRedisReplicationGroupEndpointPort: { Type: String }
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
 
 Conditions:

--- a/spire/templates/apps/dovetail-router.yml
+++ b/spire/templates/apps/dovetail-router.yml
@@ -811,6 +811,14 @@ Resources:
               Value: "2000"
             - Name: REDIS_REQUEST_TIMEOUT
               Value: "1000"
+            - Name: REDIS_CLONE_HOST
+              Value: !If [IsProduction, !Ref "AWS::NoValue", !Ref DovetailRedisReplicationGroupEndpointAddress]
+            - Name: REDIS_CLONE_PORT
+              Value: !If [IsProduction, !Ref "AWS::NoValue", !Ref DovetailRedisReplicationGroupEndpointPort]
+            - Name: REDIS_CLONE_NAMESPACE
+              Value: dovetail
+            - Name: REDIS_CLONE_POOL_SIZE
+              Value: "20"
             - Name: FINCH_POOL_COUNT
               Value: "2"
             - Name: FINCH_POOL_SIZE

--- a/spire/templates/apps/dovetail-router.yml
+++ b/spire/templates/apps/dovetail-router.yml
@@ -87,6 +87,8 @@ Parameters:
   DovetailCountedKinesisStreamArn: { Type: String }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
+  DovetailRedisReplicationGroupEndpointAddress: { Type: String }
+  DovetailRedisReplicationGroupEndpointPort: { Type: String }
   SharedGlueDatabaseName: { Type: String }
   FeedsS3BucketArn: { Type: AWS::SSM::Parameter::Value<String> }
   AuguryHostname: { Type: String }

--- a/spire/templates/jump-server.yml
+++ b/spire/templates/jump-server.yml
@@ -32,6 +32,8 @@ Parameters:
   SharedRedisClientSecurityGroupId: { Type: AWS::EC2::SecurityGroup::Id }
   SharedRedisReplicationGroupEndpointAddress: { Type: String }
   SharedRedisReplicationGroupEndpointPort: { Type: String }
+  DovetailRedisReplicationGroupEndpointAddress: { Type: String }
+  DovetailRedisReplicationGroupEndpointPort: { Type: String }
   VpcId: { Type: AWS::EC2::VPC::Id }
   VpcPublicSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   Temp: { Type: AWS::SSM::Parameter::Value<String> }
@@ -158,6 +160,8 @@ Resources:
                 export PRX_SHARED_APP_REDIS_PORT=${SharedAppRedisEndpointPort}
                 export PRX_SHARED_REDIS_HOST=${SharedRedisReplicationGroupEndpointAddress}
                 export PRX_SHARED_REDIS_PORT=${SharedRedisReplicationGroupEndpointPort}
+                export PRX_DOVETAIL_REDIS_HOST=${DovetailRedisReplicationGroupEndpointAddress}
+                export PRX_DOVETAIL_REDIS_PORT=${DovetailRedisReplicationGroupEndpointPort}
                 export PRX_CASTLE_POSTGRES_HOST=${CastlePostgresInstanceEndpointAddress}
                 export PRX_CASTLE_POSTGRES_PORT=${CastlePostgresInstanceEndpointPort}
           packages:

--- a/spire/templates/root.yml
+++ b/spire/templates/root.yml
@@ -694,6 +694,8 @@ Resources:
         SharedRedisClientSecurityGroupId: !GetAtt SharedRedisSecurityGroupStack.Outputs.ClientSecurityGroupId
         SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
+        DovetailRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointAddress
+        DovetailRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointPort
         AmazonSesSmtpCredentialsGeneratorServiceToken: !GetAtt CustomResourcesStack.Outputs.AmazonSesSmtpCredentialsGeneratorServiceToken
         SharedEcsAsgInstanceSecurityGroupId: !GetAtt SharedEcsAsgSecurityGroupStack.Outputs.InstanceSecurityGroupId
         DeploymentPackageBucketName: !GetAtt Constants2.Outputs.DeploymentPackageBucketName
@@ -776,6 +778,8 @@ Resources:
         SharedMemcachedEndpointPort: !GetAtt SharedMemcachedStack.Outputs.CacheEndpointPort
         SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
+        DovetailRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointAddress
+        DovetailRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointPort
         AmazonSesSmtpCredentialsGeneratorServiceToken: !GetAtt CustomResourcesStack.Outputs.AmazonSesSmtpCredentialsGeneratorServiceToken
         EchoServiceToken: !GetAtt CustomResourcesStack.Outputs.EchoServiceToken
         TransferServerIpFinderServiceToken: !GetAtt CustomResourcesStack.Outputs.TransferServerIpFinderServiceToken
@@ -877,6 +881,8 @@ Resources:
         SharedEcsAsgInstanceSecurityGroupId: !GetAtt SharedEcsAsgSecurityGroupStack.Outputs.InstanceSecurityGroupId
         SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
+        DovetailRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointAddress
+        DovetailRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointPort
         SharedAppRedisEndpointAddress: !GetAtt SharedAppRedisStack.Outputs.CacheEndpointAddress
         SharedAppRedisEndpointPort: !GetAtt SharedAppRedisStack.Outputs.CacheEndpointPort
         SharedAuroraPostgresqlEndpoint: !Ref SharedAuroraPostgresqlEndpoint
@@ -1015,6 +1021,8 @@ Resources:
         SharedRedisClientSecurityGroupId: !GetAtt SharedRedisSecurityGroupStack.Outputs.ClientSecurityGroupId
         SharedRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointAddress
         SharedRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ReplicationGroupEndpointPort
+        DovetailRedisReplicationGroupEndpointAddress: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointAddress
+        DovetailRedisReplicationGroupEndpointPort: !GetAtt SharedRedisStack.Outputs.ValkeyReplicationGroupEndpointPort
         VpcId: !GetAtt SharedVpcStack.Outputs.VpcId
         VpcPublicSubnet1Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet1Id
         Temp: !Sub /prx/${EnvironmentTypeAbbreviation}/Spire/${AWS::Region}/porter-state-machine-arn


### PR DESCRIPTION
Moving dovetail to a new valkey cluster.

This PR just clones writes in staging, for DTR and the counts-lambda.  Castle just uses redis more like a traditional cache these days, but moving that to the new valkey as well.