### PR TITLE
Disable TED data export

### DIFF
--- a/spire/templates/apps/dovetail-metrics-export.yml
+++ b/spire/templates/apps/dovetail-metrics-export.yml
@@ -189,7 +189,7 @@ Resources:
       Description: TED network data export
       RoleArn: !GetAtt RulesRole.Arn
       ScheduleExpression: cron(15 0 * * ? *) # 00:15 UTC every day
-      State: ENABLED
+      State: DISABLED
       Targets:
         - Arn: !GetAtt ExportFunction.Arn
           Id: !Sub "${RootStackName}.Export.TEDNetwork"


### PR DESCRIPTION
TED shows have been offboarded - let's just disable them for awhile, before deleting entirely.  We can always backfill if we need to.