### PR TITLE
Remove Spire instance SG SSH rule

### DIFF
--- a/spire/templates/root.yml
+++ b/spire/templates/root.yml
@@ -398,7 +398,6 @@ Resources:
         RootStackName: !Ref AWS::StackName
         RootStackId: !Ref AWS::StackName
         NestedChangeSetScrubbingResourcesState: !Ref NestedChangeSetScrubbingResourcesState
-        AuthorizedKeys: !Join [",", !Ref AuthorizedKeys]
         VpcPublicSubnet1Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet1Id
         VpcPublicSubnet2Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet2Id
         VpcPublicSubnet3Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet3Id
@@ -433,7 +432,6 @@ Resources:
         RootStackName: !Ref AWS::StackName
         RootStackId: !Ref AWS::StackName
         NestedChangeSetScrubbingResourcesState: !Ref NestedChangeSetScrubbingResourcesState
-        AuthorizedKeys: !Join [",", !Ref AuthorizedKeys]
         VpcPublicSubnet1Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet1Id
         VpcPublicSubnet2Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet2Id
         VpcPublicSubnet3Id: !GetAtt SharedVpcStack.Outputs.PublicSubnet3Id

--- a/spire/templates/shared-ecs/asg-aarch64.yml
+++ b/spire/templates/shared-ecs/asg-aarch64.yml
@@ -22,7 +22,6 @@ Parameters:
   RootStackName: { Type: String }
   RootStackId: { Type: String }
   NestedChangeSetScrubbingResourcesState: { Type: String }
-  AuthorizedKeys: { Type: CommaDelimitedList }
   VpcPublicSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   VpcPublicSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPublicSubnet3Id: { Type: AWS::EC2::Subnet::Id }
@@ -279,16 +278,6 @@ Resources:
                   text: !Sub >-
                     EC2 instance `'"$INSTANCE_ID"'` could not connect to `${DovetailRedisReplicationGroupEndpointAddress}`
                     at `'"$IP"'`. It will be marked as *unhealthy* in its auto scaling group and get replaced.
-            02_add_authorized_keys:
-              # For more information, see:
-              # https://github.com/PRX/internal/wiki/AWS:-Developer-Access
-              command: !Sub
-                - |-
-                  #!/bin/bash
-                  echo "Adding developer public keys to authorized_keys"
-                  truncate -s 0 /home/ec2-user/.ssh/authorized_keys
-                  echo "${developer_keys}" >> /home/ec2-user/.ssh/authorized_keys
-                - developer_keys: !Join ["\n", !Ref AuthorizedKeys]
           services:
             sysvinit:
               cfn-hup:

--- a/spire/templates/shared-ecs/asg-sg.yml
+++ b/spire/templates/shared-ecs/asg-sg.yml
@@ -47,26 +47,6 @@ Resources:
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref LoadBalancerSecurityGroupId
       ToPort: 60999
-  InstanceSecurityGroupSshIpv4Ingress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      CidrIp: 0.0.0.0/0
-      Description: !Sub >-
-        Allows inbound SSH traffic to ${EnvironmentType} ASG instances
-      FromPort: 22
-      GroupId: !GetAtt InstanceSecurityGroup.GroupId
-      IpProtocol: tcp
-      ToPort: 22
-  InstanceSecurityGroupSshIpv6Ingress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      CidrIpv6: ::/0
-      Description: !Sub >-
-        Allows inbound SSH traffic to ${EnvironmentType} ASG instances
-      FromPort: 22
-      GroupId: !GetAtt InstanceSecurityGroup.GroupId
-      IpProtocol: tcp
-      ToPort: 22
   InstanceSecurityGroupAllIpv4Egress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:

--- a/spire/templates/shared-ecs/asg-x86-64.yml
+++ b/spire/templates/shared-ecs/asg-x86-64.yml
@@ -30,7 +30,6 @@ Parameters:
   RootStackName: { Type: String }
   RootStackId: { Type: String }
   NestedChangeSetScrubbingResourcesState: { Type: String }
-  AuthorizedKeys: { Type: CommaDelimitedList }
   VpcPublicSubnet1Id: { Type: AWS::EC2::Subnet::Id }
   VpcPublicSubnet2Id: { Type: AWS::EC2::Subnet::Id }
   VpcPublicSubnet3Id: { Type: AWS::EC2::Subnet::Id }
@@ -289,16 +288,6 @@ Resources:
                   text: !Sub >-
                     EC2 instance `'"$INSTANCE_ID"'` could not connect to `${DovetailRedisReplicationGroupEndpointAddress}`
                     at `'"$IP"'`. It will be marked as *unhealthy* in its auto scaling group and get replaced.
-            02_add_authorized_keys:
-              # For more information, see:
-              # https://github.com/PRX/internal/wiki/AWS:-Developer-Access
-              command: !Sub
-                - |-
-                  #!/bin/bash
-                  echo "Adding developer public keys to authorized_keys"
-                  truncate -s 0 /home/ec2-user/.ssh/authorized_keys
-                  echo "${developer_keys}" >> /home/ec2-user/.ssh/authorized_keys
-                - developer_keys: !Join ["\n", !Ref AuthorizedKeys]
           services:
             sysvinit:
               cfn-hup:


### PR DESCRIPTION
We may want to make sure we aren't forgetting about any non-human SSH connections we might be making to these instances